### PR TITLE
feat: partner-readiness polish (coverage badge + share checklist)

### DIFF
--- a/apps/web/src/app/(public)/standings/page.tsx
+++ b/apps/web/src/app/(public)/standings/page.tsx
@@ -95,7 +95,7 @@ export default async function StandingsPage({
   const params = await searchParams
   const divisionFilter = params.division ?? null
 
-  const { tournament, standings, divisions } = await getStandings(undefined, divisionFilter)
+  const { tournament, standings, divisions, scoreCoverage } = await getStandings(undefined, divisionFilter)
   const typedStandings = standings as StandingRow[]
 
   const activeDiv = divisionFilter ? getDivision(divisionFilter) : undefined
@@ -120,6 +120,11 @@ export default async function StandingsPage({
           currentFilter={divisionFilter}
           basePath="/standings"
         />
+
+        <div className="mt-3 inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-xs" style={{ borderColor: 'var(--border-subtle)', color: 'var(--neutral-600)' }}>
+          <span className="font-semibold" style={{ color: 'var(--fd-ink)' }}>Data coverage</span>
+          <span>{scoreCoverage.scoredGames}/{scoreCoverage.totalGames} games scored ({scoreCoverage.percent}%)</span>
+        </div>
       </div>
 
       {!tournament || typedStandings.length === 0 ? (

--- a/apps/web/src/lib/services/public-feed.ts
+++ b/apps/web/src/lib/services/public-feed.ts
@@ -150,6 +150,11 @@ type StandingsFeed = {
   tournament: Awaited<ReturnType<typeof db.tournament.findUnique>>
   standings: StandingWithTeam[]
   divisions: string[]
+  scoreCoverage: {
+    scoredGames: number
+    totalGames: number
+    percent: number
+  }
 }
 
 export async function getStandings(
@@ -159,7 +164,12 @@ export async function getStandings(
   const tournament = tournamentId
     ? await db.tournament.findUnique({ where: { id: tournamentId } })
     : await getActiveTournament()
-  if (!tournament) return { tournament: null, standings: [], divisions: [] }
+  if (!tournament) return {
+    tournament: null,
+    standings: [],
+    divisions: [],
+    scoreCoverage: { scoredGames: 0, totalGames: 0, percent: 0 },
+  }
 
   // Get all teams' divisions for the tab list
   const allTeams = await db.team.findMany({
@@ -175,15 +185,32 @@ export async function getStandings(
   const teamWhere: Prisma.TeamWhereInput = { tournamentId: tournament.id }
   if (divisionFilter) teamWhere.division = divisionFilter
 
-  const standings = await db.standing.findMany({
-    where: {
-      tournamentId: tournament.id,
-      team: teamWhere,
-    },
-    include: { team: true },
-    orderBy: [{ wins: 'desc' }, { losses: 'asc' }, { pointsFor: 'desc' }],
-    take: 100,
-  })
+  const [standings, totalGames, scoredGames] = await Promise.all([
+    db.standing.findMany({
+      where: {
+        tournamentId: tournament.id,
+        team: teamWhere,
+      },
+      include: { team: true },
+      orderBy: [{ wins: 'desc' }, { losses: 'asc' }, { pointsFor: 'desc' }],
+      take: 100,
+    }),
+    db.game.count({ where: { tournamentId: tournament.id } }),
+    db.game.count({
+      where: {
+        tournamentId: tournament.id,
+        homeScore: { not: null },
+        awayScore: { not: null },
+      },
+    }),
+  ])
 
-  return { tournament, standings, divisions: Array.from(divSet).sort() }
+  const percent = totalGames ? Math.round((scoredGames / totalGames) * 1000) / 10 : 0
+
+  return {
+    tournament,
+    standings,
+    divisions: Array.from(divSet).sort(),
+    scoreCoverage: { scoredGames, totalGames, percent },
+  }
 }

--- a/docs/PARTNER-SHARE-CHECKLIST.md
+++ b/docs/PARTNER-SHARE-CHECKLIST.md
@@ -1,0 +1,35 @@
+# Partner Share Checklist (Clutch + GuamTime)
+
+Use this before sending the collaboration message.
+
+## Product Readiness
+- [ ] Homepage, schedule, standings, watch, news, sponsors load on production
+- [ ] Mobile nav and filters work on iPhone + Android viewport
+- [ ] No runtime 500s in Netlify logs for public routes
+
+## Data Readiness
+- [ ] 2025 pool + playoff schedule confirmed against official PDFs
+- [ ] Division/phase tags verified (Maroon/Gold/Platinum/Special + Pool/Playoff/FS)
+- [ ] Standings coverage badge reflects current scored-game coverage
+
+## Ticketing Readiness (GuamTime)
+- [ ] Missing ticket links CSV generated (`apps/web/scripts/export-missing-links.ts`)
+- [ ] `/admin/links` used to bulk-fill available ticket URLs
+- [ ] Link health report generated and no critical ticket link failures
+
+## Streaming Readiness (Clutch)
+- [ ] Missing stream links CSV generated (`apps/web/scripts/export-missing-links.ts`)
+- [ ] `/admin/links` used to bulk-fill available stream URLs
+- [ ] Link health report generated and no critical stream link failures
+
+## Partner Package
+- [ ] `docs/PROJECT-STATUS-2026-03-04.md` reviewed and current
+- [ ] `docs/2025-SCORE-COVERAGE-REPORT.md` attached for transparency
+- [ ] Updated outreach draft copied from `docs/OUTREACH-DRAFTS.md`
+- [ ] Point person + turnaround expectation included in message
+
+## Greptile + PR Workflow
+- [ ] Work on feature branch from `main`
+- [ ] Open PR with clear scope and screenshots
+- [ ] Comment `@greptile` on PR
+- [ ] Address review comments before merge

--- a/docs/PROJECT-STATUS-2026-03-04.md
+++ b/docs/PROJECT-STATUS-2026-03-04.md
@@ -173,4 +173,5 @@ The following deliverables were shipped to make the platform legit and ops-ready
 - `docs/DATA-MODEL-V1.md`
 - `docs/BRAND-DESIGN-TOKENS.md`
 - `docs/2025-SCORE-COVERAGE-REPORT.md`
+- `docs/PARTNER-SHARE-CHECKLIST.md`
 - `docs/OUTREACH-DRAFTS.md`


### PR DESCRIPTION
## Summary
This PR tightens partner-share readiness without rushing broad feature churn.

### Included
- Add standings data coverage badge (scored games / total games, %)
- Extend standings service API with coverage metadata
- Add `docs/PARTNER-SHARE-CHECKLIST.md` for Clutch + GuamTime handoff readiness
- Update `docs/PROJECT-STATUS-2026-03-04.md` to include checklist in source-of-truth docs

## Why
Leon asked to move via branch + PR flow and get Greptile review before merge.
This gives a clean, auditable readiness artifact and transparent coverage visibility in the product.

## Validation
- `npm --workspace @fd/web run build` passes locally

## Follow-ups
- Fill ticket/stream links via `/admin/links`
- Run link-health + export scripts for partner package

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a data coverage badge to the standings page and creates a comprehensive partner share checklist for Clutch + GuamTime collaboration. The implementation cleanly extends the standings service to compute and expose scored-game coverage (14/93 scored = 15.1%), displays it in a visually consistent badge, and documents the full handoff workflow. 

**Key improvements:**
- Standings coverage badge shows transparency into data completeness
- Parallel database queries maintain performance
- Coverage calculation properly handles edge cases (zero division)
- Tournament-level coverage metric remains consistent across division filters
- Comprehensive checklist provides clear partner handoff process

<h3>Confidence Score: 5/5</h3>

- Safe to merge with no issues found
- Clean implementation following existing patterns, properly typed, handles edge cases, performance-optimized with parallel queries, and build validation passes
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(public)/standings/page.tsx | Added data coverage badge displaying scored games ratio and percentage - clean UI integration with existing design patterns |
| apps/web/src/lib/services/public-feed.ts | Extended getStandings to include scoreCoverage metadata with parallel database queries - properly typed and handles edge cases |
| docs/PARTNER-SHARE-CHECKLIST.md | New comprehensive checklist for Clutch + GuamTime partner handoff readiness - well-organized and actionable |
| docs/PROJECT-STATUS-2026-03-04.md | Added new checklist to source-of-truth documentation list - minimal update, documentation consistency maintained |

</details>


</details>


<sub>Last reviewed commit: 21f291f</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->