### PR TITLE
docs: partner handoff package baseline (2025 exports + link health)

### DIFF
--- a/docs/LINK-HEALTH-REPORT.md
+++ b/docs/LINK-HEALTH-REPORT.md
@@ -1,0 +1,22 @@
+# Link Health Report
+
+**Tournament:** FD Alumni Basketball Tournament 2025  
+**Generated:** 2026-03-04 (manual baseline run)  
+**Total URLs checked:** 0
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| ✅ Healthy | 0 |
+| ❌ Failed | 0 |
+| ↪️ Redirected | 0 |
+| 🎟️ Missing ticket links | 93 |
+| 📺 Missing stream links | 93 |
+
+## Notes
+- No ticket or stream URLs are populated yet for 2025 games.
+- Run `apps/web/scripts/check-link-health.ts --tournament-id cmmbc92ua0001hx5bijf0unag` again after links are populated.
+- Missing-link CSV exports are available under `docs/exports/`:
+  - `2025-fd-alumni-basketball-tournament-missing-ticket-links.csv`
+  - `2025-fd-alumni-basketball-tournament-missing-stream-links.csv`

--- a/docs/PROJECT-STATUS-2026-03-04.md
+++ b/docs/PROJECT-STATUS-2026-03-04.md
@@ -92,6 +92,13 @@ Current score coverage: **14 / 93 games (15.1%)**
 3. Recompute standings per division
 4. Run final 2025 QA checklist against official docs
 
+## Current Partner Ops Baseline
+- Missing-link exports generated for 2025:
+  - `docs/exports/2025-fd-alumni-basketball-tournament-missing-ticket-links.csv`
+  - `docs/exports/2025-fd-alumni-basketball-tournament-missing-stream-links.csv`
+- Link health baseline report generated:
+  - `docs/LINK-HEALTH-REPORT.md` (0 URLs checked; 93 ticket + 93 stream links still missing)
+
 ## P1 — Operations
 1. Add simple admin "missing score" work queue
 2. Add visible coverage badge on standings (e.g., 14/93 scored)

--- a/docs/exports/2025-fd-alumni-basketball-tournament-missing-stream-links.csv
+++ b/docs/exports/2025-fd-alumni-basketball-tournament-missing-stream-links.csv
@@ -1,0 +1,99 @@
+# FD Alumni Hub — Games Missing Stream Links
+# Tournament: FD Alumni Basketball Tournament 2025
+# Generated: 2026-03-04T04:14:34.408Z
+# Partner: Clutch (streaming)
+# Total: 93 of 93 games
+Game ID,Date,Time,Away Team,Home Team,Division,Phase,Bracket Code,Venue,Status,Missing Fields
+cmmbe40zz0006hxphcs5yw4a5,"Jun 27, 2025",6:00 PM,Class 84/85,Class 79/80,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe422a000chxphf6xwlcwg,"Jun 27, 2025",7:10 PM,Class 2013,Class 02/04,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe42uz000ihxphska5lmdu,"Jun 27, 2025",8:20 PM,Class 2016/17,Class 2025,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe43nh000ohxphzrk8x1p5,"Jun 28, 2025",12:10 PM,Class 2018/19,Class 2015,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe44gr000uhxphksyjzsvs,"Jun 28, 2025",1:20 PM,Class 2014,Class 08/09,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe459p0010hxphah3dzu1f,"Jun 28, 2025",2:30 PM,Class FS3,Class FS1,Special,Father-Son,FS,FD Jungle,scheduled,streamUrl
+cmmbe461i0016hxph7dtm44qt,"Jun 28, 2025",3:40 PM,Class 98,Class 1991,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe46tx001chxphlrsnaabx,"Jun 28, 2025",4:50 PM,Class 1988,Class 82/86/AD7/92,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe47l2001ihxphgfqt990h,"Jun 28, 2025",6:00 PM,Class 05,Class 2007,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe48di001ohxphys6ldalg,"Jun 28, 2025",7:10 PM,Class 2010,Class 12 Pack,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4948001uhxphxlgqudr2,"Jun 28, 2025",8:20 PM,Class 2023,Class 2022,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe49vh0020hxph0ka4co6b,"Jun 29, 2025",12:10 PM,Class 2024,Class 2021,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4amm0026hxphtd8gy9kg,"Jun 29, 2025",1:20 PM,Class 60s,Class 60s,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4bll002chxphnwzvntbz,"Jun 29, 2025",2:30 PM,Class 2023,Class 2020,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4dtp002ihxphmi7f0o2p,"Jun 29, 2025",3:40 PM,Class 1989,Class 75,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4f5h002ohxph3k83lbv8,"Jun 29, 2025",4:50 PM,Class 96/97,Class 430-5,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4fy1002uhxphrrvarsj1,"Jun 29, 2025",6:00 PM,Class 2006,Class 02/04,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4gq50030hxph1rznpvkk,"Jun 29, 2025",7:10 PM,Class 2025,Class 2022,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4hnu0036hxph7icsbjqi,"Jun 29, 2025",8:20 PM,Class 2018/19,Class 2016/17,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4if1003chxph49kawvn4,"Jun 30, 2025",6:00 PM,Class 2021,Class 2020,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe4j5l003ihxphufs6p1i5,"Jun 30, 2025",7:10 PM,Class 12 Pack,Class 2024,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe4k4q003ohxphfqp65dl6,"Jun 30, 2025",8:20 PM,Class 99/01/03,Class 98,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe4kv5003uhxphcizp5rig,"Jul 1, 2025",6:00 PM,Class 96/97,Class 84/85,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe4llu0040hxphnjglph25,"Jul 1, 2025",7:10 PM,Class 2006,Class 2007,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe4mcm0046hxphbzlzfr4f,"Jul 1, 2025",8:20 PM,Class 2025,Class 2023,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe4n9p004chxphjg6mcxf5,"Jul 2, 2025",6:00 PM,Class 1988,Class 79/80,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe4o0h004ihxph365w1vau,"Jul 2, 2025",7:10 PM,Class 1989,Class 1991,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe4oru004ohxph9vxc2rdx,"Jul 2, 2025",8:20 PM,Class 2013,Class 12 Pack,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4pim004uhxphl7yi6y0q,"Jul 3, 2025",6:00 PM,Class 82/86/AD7/92,Class 75,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe4q8t0050hxphj1c7oxpk,"Jul 3, 2025",7:10 PM,Class 430-5,Class 98,Gold,Pool,,FD Jungle,final,streamUrl
+cmmbe4qze0056hxphfp0zc3cr,"Jul 3, 2025",8:20 PM,Class 2018/19,Class 2014,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe4rpi005chxphwm49jk8t,"Jul 4, 2025",6:00 PM,Class 99/01/03,Class 96/97,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4sgg005ihxphon9udsfg,"Jul 4, 2025",7:10 PM,Class 05,Class 02/04,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4t7s005ohxph8i76rizv,"Jul 4, 2025",8:20 PM,Class 2016/17,Class 2013,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4tyx005uhxphiq47xvek,"Jul 5, 2025",12:10 PM,Class 60s,Class 60s,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4us50060hxphvvan2w4r,"Jul 5, 2025",1:20 PM,Class 1989,Class 1988,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4vn40066hxphny8vskcq,"Jul 5, 2025",2:30 PM,Class FS2,Class FS1,Special,Father-Son,FS,FD Jungle,scheduled,streamUrl
+cmmbe4wgh006chxphk6tzzzhb,"Jul 5, 2025",3:40 PM,Class 2015,Class 2014,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4x8l006ihxpha2o273io,"Jul 5, 2025",4:50 PM,Class 82/86/AD7/92,Class 79/80,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4xzl006ohxpht9rhpdrc,"Jul 5, 2025",6:00 PM,Class 2024,Class 2023,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4yq9006uhxph86y7zoqu,"Jul 5, 2025",7:10 PM,Class 08/09,Class 2006,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe4zo50070hxphknsrcguo,"Jul 5, 2025",8:20 PM,Class 2022,Class 2021,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe50fl0076hxph033qp24g,"Jul 6, 2025",1:20 PM,Class 2024,Class 2020,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe516h007chxphugls3ts8,"Jul 6, 2025",2:30 PM,Class 84/85,Class 75,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe51xp007ihxphafjrd3px,"Jul 6, 2025",3:40 PM,Class 2016/17,Class 2015,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe52sd007ohxph277qiz4b,"Jul 6, 2025",4:50 PM,Class 2010,Class 05,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe53ly007uhxphsbyinqd1,"Jul 6, 2025",6:00 PM,Class 2007,Class 02/04,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe54d60080hxphe9r2cvv8,"Jul 6, 2025",7:10 PM,Class 2014,Class 12 Pack,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe553q0086hxphux1l06o9,"Jul 6, 2025",8:20 PM,Class 2018/19,Class 2021,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe55uf008chxphnsbl577b,"Jul 7, 2025",6:00 PM,Class 1991,Class 430-5,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe56la008ihxphif8zmr94,"Jul 7, 2025",7:10 PM,Class FS3,Class FS2,Special,Father-Son,FS,FD Jungle,scheduled,streamUrl
+cmmbe57du008ohxph62njs3di,"Jul 7, 2025",8:20 PM,Class 2022,Class 2020,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5866008uhxphb9chlhea,"Jul 8, 2025",6:00 PM,Class 98,Class 96/97,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe58wv0090hxphox7c8t39,"Jul 8, 2025",7:10 PM,Class 2015,Class 08/09,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe59o60096hxphv7a2ljim,"Jul 8, 2025",8:20 PM,Class 2010,Class 2007,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5ag2009chxphtxib18o7,"Jul 9, 2025",6:00 PM,Class 60S FS,Class 60 FS,Special,Father-Son,,FD Jungle,scheduled,streamUrl
+cmmbe5bde009ihxphdd4h0ty9,"Jul 9, 2025",7:10 PM,Class 79/80,Class 75,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5c4n009ohxphwgtsaqh1,"Jul 9, 2025",8:20 PM,Class 99/01/03,Class 430-5,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5cxe009uhxph0v4ov8yd,"Jul 10, 2025",6:00 PM,Class 1988,Class 84/85,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5dqg00a0hxphdeiaj40x,"Jul 10, 2025",7:10 PM,Class 1989,Class 82/86/AD7/92,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5ehq00a6hxphr0a09vw2,"Jul 10, 2025",8:20 PM,Class 2025,Class 2013,Maroon,Pool,,FD Jungle,final,streamUrl
+cmmbe5fcy00achxpho1cx2dgo,"Jul 11, 2025",6:00 PM,Class 99/01/03,Class 1991,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5g4q00aihxphrk6081jj,"Jul 11, 2025",7:10 PM,Class 05,Class 2006,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5gx200aohxphre8dl87l,"Jul 11, 2025",8:20 PM,Class 2010,Class 08/09,Maroon,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe5ho600auhxphuyp2fbw3,"Jul 12, 2025",11:00 AM,Class 2024,Class 2014,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5igu00b0hxph63m8o73u,"Jul 12, 2025",12:10 PM,Class 2020,Class 2016/17,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5j9100b6hxpha4akarmp,"Jul 12, 2025",1:20 PM,Class 08/09,Class 2007,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5k1e00bchxphqp2yhx2u,"Jul 12, 2025",2:30 PM,Class 1988,Class 75,Platinum,Playoff (PP),PP,FD Jungle,scheduled,streamUrl
+cmmbe5ksd00bihxph3o4g3cs7,"Jul 12, 2025",3:40 PM,Class 2022,Class 2025,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5lli00bohxphyihoqbyt,"Jul 12, 2025",4:50 PM,Class 2023,Class 18/19,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5mcm00buhxphe9p0i2zn,"Jul 12, 2025",6:00 PM,Class 84/85,Class 1989,Platinum,Playoff (PP),PP,FD Jungle,scheduled,streamUrl
+cmmbe5nal00c0hxphh0uv7ajb,"Jul 12, 2025",7:10 PM,Class 2021,Class 12 Pack,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5o2p00c6hxphfgpk4gj6,"Jul 12, 2025",8:20 PM,Class 2015,Class 2013,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5oua00cchxphpwy0bo8u,"Jul 13, 2025",12:10 PM,Class 430-5,Class 91,Gold,Playoff (GP),GP,FD Jungle,scheduled,streamUrl
+cmmbe5plt00cihxphcwtezps0,"Jul 13, 2025",1:20 PM,Class 2010,Class 2006,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5qem00cohxphhn01x0mx,"Jul 13, 2025",2:30 PM,Class WMP1,Class 02/04,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5r5t00cuhxphmugv5pmu,"Jul 13, 2025",3:40 PM,Class 05,Class 96/97/2000,Gold,Playoff (GP),GP,FD Jungle,scheduled,streamUrl
+cmmbe5rwh00d0hxphwfa2s9n7,"Jul 13, 2025",4:50 PM,Class WMP4,Class WMP5,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5so500d6hxphtgobrjbf,"Jul 13, 2025",6:00 PM,Class WMP3,Class WMP2,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5tff00dchxphjutbh1sz,"Jul 14, 2025",6:00 PM,Class WPP1,Class 79/80,Platinum,Playoff (PP),PP,FD Jungle,scheduled,streamUrl
+cmmbe5u7000dihxphkpelkw5g,"Jul 14, 2025",7:10 PM,Class WMP8,Class WMP7,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5uy200dohxphtwirad68,"Jul 14, 2025",8:20 PM,Class WMP6,Class WMP9,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5vq200duhxph9zsc777z,"Jul 15, 2025",6:00 PM,Class WPP2,Class 82/86/AD7/92,Platinum,Playoff (PP),PP,FD Jungle,scheduled,streamUrl
+cmmbe5wkl00e0hxphb70rgf93,"Jul 15, 2025",7:10 PM,Class WGP1,Class 99/01/03,Gold,Playoff (GP),GP,FD Jungle,scheduled,streamUrl
+cmmbe5xbp00e6hxphs3ck1o3n,"Jul 15, 2025",8:20 PM,Class WGP2,Class 98,Gold,Playoff (GP),GP,FD Jungle,scheduled,streamUrl
+cmmbe5y4u00echxphishg9hdh,"Jul 16, 2025",6:30 PM,Class WMP12,Class WMP11,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5z4100eihxphexerlhr6,"Jul 16, 2025",7:45 PM,Class WMP13,Class WMP10,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl
+cmmbe5zv800eohxphlc8y6gjo,"Jul 17, 2025",6:00 PM,Class TBD,Class TBD,Special,Playoff (TBD),TBD,FD Jungle,scheduled,streamUrl
+cmmbe60mx00euhxph0l39ifva,"Jul 17, 2025",7:10 PM,Class WPP4,Class WPP3,Platinum,Playoff (PP),PP,FD Jungle,scheduled,streamUrl
+cmmbe61f900f0hxphw9sufmxy,"Jul 17, 2025",8:20 PM,Class WGP4,Class WGP3,Gold,Playoff (GP),GP,FD Jungle,scheduled,streamUrl
+cmmbe627h00f6hxphazm4glpk,"Jul 18, 2025",6:00 PM,Class FS,Class FS,Special,Father-Son,FS,FD Jungle,scheduled,streamUrl
+cmmbe630v00fchxphf7a5kxzp,"Jul 18, 2025",7:10 PM,Class 90,Class 95,Gold,Pool,,FD Jungle,scheduled,streamUrl
+cmmbe63t400fihxph9u6yn00u,"Jul 18, 2025",8:20 PM,Class WMP15,Class WMP14,Maroon,Playoff (MP),MP,FD Jungle,scheduled,streamUrl

--- a/docs/exports/2025-fd-alumni-basketball-tournament-missing-ticket-links.csv
+++ b/docs/exports/2025-fd-alumni-basketball-tournament-missing-ticket-links.csv
@@ -1,0 +1,99 @@
+# FD Alumni Hub — Games Missing Ticket Links
+# Tournament: FD Alumni Basketball Tournament 2025
+# Generated: 2026-03-04T04:14:34.383Z
+# Partner: GuamTime (ticketing)
+# Total: 93 of 93 games
+Game ID,Date,Time,Away Team,Home Team,Division,Phase,Bracket Code,Venue,Status,Missing Fields
+cmmbe40zz0006hxphcs5yw4a5,"Jun 27, 2025",6:00 PM,Class 84/85,Class 79/80,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe422a000chxphf6xwlcwg,"Jun 27, 2025",7:10 PM,Class 2013,Class 02/04,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe42uz000ihxphska5lmdu,"Jun 27, 2025",8:20 PM,Class 2016/17,Class 2025,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe43nh000ohxphzrk8x1p5,"Jun 28, 2025",12:10 PM,Class 2018/19,Class 2015,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe44gr000uhxphksyjzsvs,"Jun 28, 2025",1:20 PM,Class 2014,Class 08/09,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe459p0010hxphah3dzu1f,"Jun 28, 2025",2:30 PM,Class FS3,Class FS1,Special,Father-Son,FS,FD Jungle,scheduled,ticketUrl
+cmmbe461i0016hxph7dtm44qt,"Jun 28, 2025",3:40 PM,Class 98,Class 1991,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe46tx001chxphlrsnaabx,"Jun 28, 2025",4:50 PM,Class 1988,Class 82/86/AD7/92,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe47l2001ihxphgfqt990h,"Jun 28, 2025",6:00 PM,Class 05,Class 2007,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe48di001ohxphys6ldalg,"Jun 28, 2025",7:10 PM,Class 2010,Class 12 Pack,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4948001uhxphxlgqudr2,"Jun 28, 2025",8:20 PM,Class 2023,Class 2022,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe49vh0020hxph0ka4co6b,"Jun 29, 2025",12:10 PM,Class 2024,Class 2021,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4amm0026hxphtd8gy9kg,"Jun 29, 2025",1:20 PM,Class 60s,Class 60s,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4bll002chxphnwzvntbz,"Jun 29, 2025",2:30 PM,Class 2023,Class 2020,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4dtp002ihxphmi7f0o2p,"Jun 29, 2025",3:40 PM,Class 1989,Class 75,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4f5h002ohxph3k83lbv8,"Jun 29, 2025",4:50 PM,Class 96/97,Class 430-5,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4fy1002uhxphrrvarsj1,"Jun 29, 2025",6:00 PM,Class 2006,Class 02/04,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4gq50030hxph1rznpvkk,"Jun 29, 2025",7:10 PM,Class 2025,Class 2022,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4hnu0036hxph7icsbjqi,"Jun 29, 2025",8:20 PM,Class 2018/19,Class 2016/17,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4if1003chxph49kawvn4,"Jun 30, 2025",6:00 PM,Class 2021,Class 2020,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe4j5l003ihxphufs6p1i5,"Jun 30, 2025",7:10 PM,Class 12 Pack,Class 2024,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe4k4q003ohxphfqp65dl6,"Jun 30, 2025",8:20 PM,Class 99/01/03,Class 98,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe4kv5003uhxphcizp5rig,"Jul 1, 2025",6:00 PM,Class 96/97,Class 84/85,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe4llu0040hxphnjglph25,"Jul 1, 2025",7:10 PM,Class 2006,Class 2007,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe4mcm0046hxphbzlzfr4f,"Jul 1, 2025",8:20 PM,Class 2025,Class 2023,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe4n9p004chxphjg6mcxf5,"Jul 2, 2025",6:00 PM,Class 1988,Class 79/80,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe4o0h004ihxph365w1vau,"Jul 2, 2025",7:10 PM,Class 1989,Class 1991,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe4oru004ohxph9vxc2rdx,"Jul 2, 2025",8:20 PM,Class 2013,Class 12 Pack,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4pim004uhxphl7yi6y0q,"Jul 3, 2025",6:00 PM,Class 82/86/AD7/92,Class 75,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe4q8t0050hxphj1c7oxpk,"Jul 3, 2025",7:10 PM,Class 430-5,Class 98,Gold,Pool,,FD Jungle,final,ticketUrl
+cmmbe4qze0056hxphfp0zc3cr,"Jul 3, 2025",8:20 PM,Class 2018/19,Class 2014,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe4rpi005chxphwm49jk8t,"Jul 4, 2025",6:00 PM,Class 99/01/03,Class 96/97,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4sgg005ihxphon9udsfg,"Jul 4, 2025",7:10 PM,Class 05,Class 02/04,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4t7s005ohxph8i76rizv,"Jul 4, 2025",8:20 PM,Class 2016/17,Class 2013,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4tyx005uhxphiq47xvek,"Jul 5, 2025",12:10 PM,Class 60s,Class 60s,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4us50060hxphvvan2w4r,"Jul 5, 2025",1:20 PM,Class 1989,Class 1988,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4vn40066hxphny8vskcq,"Jul 5, 2025",2:30 PM,Class FS2,Class FS1,Special,Father-Son,FS,FD Jungle,scheduled,ticketUrl
+cmmbe4wgh006chxphk6tzzzhb,"Jul 5, 2025",3:40 PM,Class 2015,Class 2014,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4x8l006ihxpha2o273io,"Jul 5, 2025",4:50 PM,Class 82/86/AD7/92,Class 79/80,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4xzl006ohxpht9rhpdrc,"Jul 5, 2025",6:00 PM,Class 2024,Class 2023,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4yq9006uhxph86y7zoqu,"Jul 5, 2025",7:10 PM,Class 08/09,Class 2006,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe4zo50070hxphknsrcguo,"Jul 5, 2025",8:20 PM,Class 2022,Class 2021,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe50fl0076hxph033qp24g,"Jul 6, 2025",1:20 PM,Class 2024,Class 2020,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe516h007chxphugls3ts8,"Jul 6, 2025",2:30 PM,Class 84/85,Class 75,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe51xp007ihxphafjrd3px,"Jul 6, 2025",3:40 PM,Class 2016/17,Class 2015,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe52sd007ohxph277qiz4b,"Jul 6, 2025",4:50 PM,Class 2010,Class 05,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe53ly007uhxphsbyinqd1,"Jul 6, 2025",6:00 PM,Class 2007,Class 02/04,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe54d60080hxphe9r2cvv8,"Jul 6, 2025",7:10 PM,Class 2014,Class 12 Pack,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe553q0086hxphux1l06o9,"Jul 6, 2025",8:20 PM,Class 2018/19,Class 2021,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe55uf008chxphnsbl577b,"Jul 7, 2025",6:00 PM,Class 1991,Class 430-5,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe56la008ihxphif8zmr94,"Jul 7, 2025",7:10 PM,Class FS3,Class FS2,Special,Father-Son,FS,FD Jungle,scheduled,ticketUrl
+cmmbe57du008ohxph62njs3di,"Jul 7, 2025",8:20 PM,Class 2022,Class 2020,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5866008uhxphb9chlhea,"Jul 8, 2025",6:00 PM,Class 98,Class 96/97,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe58wv0090hxphox7c8t39,"Jul 8, 2025",7:10 PM,Class 2015,Class 08/09,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe59o60096hxphv7a2ljim,"Jul 8, 2025",8:20 PM,Class 2010,Class 2007,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5ag2009chxphtxib18o7,"Jul 9, 2025",6:00 PM,Class 60S FS,Class 60 FS,Special,Father-Son,,FD Jungle,scheduled,ticketUrl
+cmmbe5bde009ihxphdd4h0ty9,"Jul 9, 2025",7:10 PM,Class 79/80,Class 75,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5c4n009ohxphwgtsaqh1,"Jul 9, 2025",8:20 PM,Class 99/01/03,Class 430-5,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5cxe009uhxph0v4ov8yd,"Jul 10, 2025",6:00 PM,Class 1988,Class 84/85,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5dqg00a0hxphdeiaj40x,"Jul 10, 2025",7:10 PM,Class 1989,Class 82/86/AD7/92,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5ehq00a6hxphr0a09vw2,"Jul 10, 2025",8:20 PM,Class 2025,Class 2013,Maroon,Pool,,FD Jungle,final,ticketUrl
+cmmbe5fcy00achxpho1cx2dgo,"Jul 11, 2025",6:00 PM,Class 99/01/03,Class 1991,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5g4q00aihxphrk6081jj,"Jul 11, 2025",7:10 PM,Class 05,Class 2006,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5gx200aohxphre8dl87l,"Jul 11, 2025",8:20 PM,Class 2010,Class 08/09,Maroon,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe5ho600auhxphuyp2fbw3,"Jul 12, 2025",11:00 AM,Class 2024,Class 2014,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5igu00b0hxph63m8o73u,"Jul 12, 2025",12:10 PM,Class 2020,Class 2016/17,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5j9100b6hxpha4akarmp,"Jul 12, 2025",1:20 PM,Class 08/09,Class 2007,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5k1e00bchxphqp2yhx2u,"Jul 12, 2025",2:30 PM,Class 1988,Class 75,Platinum,Playoff (PP),PP,FD Jungle,scheduled,ticketUrl
+cmmbe5ksd00bihxph3o4g3cs7,"Jul 12, 2025",3:40 PM,Class 2022,Class 2025,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5lli00bohxphyihoqbyt,"Jul 12, 2025",4:50 PM,Class 2023,Class 18/19,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5mcm00buhxphe9p0i2zn,"Jul 12, 2025",6:00 PM,Class 84/85,Class 1989,Platinum,Playoff (PP),PP,FD Jungle,scheduled,ticketUrl
+cmmbe5nal00c0hxphh0uv7ajb,"Jul 12, 2025",7:10 PM,Class 2021,Class 12 Pack,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5o2p00c6hxphfgpk4gj6,"Jul 12, 2025",8:20 PM,Class 2015,Class 2013,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5oua00cchxphpwy0bo8u,"Jul 13, 2025",12:10 PM,Class 430-5,Class 91,Gold,Playoff (GP),GP,FD Jungle,scheduled,ticketUrl
+cmmbe5plt00cihxphcwtezps0,"Jul 13, 2025",1:20 PM,Class 2010,Class 2006,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5qem00cohxphhn01x0mx,"Jul 13, 2025",2:30 PM,Class WMP1,Class 02/04,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5r5t00cuhxphmugv5pmu,"Jul 13, 2025",3:40 PM,Class 05,Class 96/97/2000,Gold,Playoff (GP),GP,FD Jungle,scheduled,ticketUrl
+cmmbe5rwh00d0hxphwfa2s9n7,"Jul 13, 2025",4:50 PM,Class WMP4,Class WMP5,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5so500d6hxphtgobrjbf,"Jul 13, 2025",6:00 PM,Class WMP3,Class WMP2,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5tff00dchxphjutbh1sz,"Jul 14, 2025",6:00 PM,Class WPP1,Class 79/80,Platinum,Playoff (PP),PP,FD Jungle,scheduled,ticketUrl
+cmmbe5u7000dihxphkpelkw5g,"Jul 14, 2025",7:10 PM,Class WMP8,Class WMP7,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5uy200dohxphtwirad68,"Jul 14, 2025",8:20 PM,Class WMP6,Class WMP9,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5vq200duhxph9zsc777z,"Jul 15, 2025",6:00 PM,Class WPP2,Class 82/86/AD7/92,Platinum,Playoff (PP),PP,FD Jungle,scheduled,ticketUrl
+cmmbe5wkl00e0hxphb70rgf93,"Jul 15, 2025",7:10 PM,Class WGP1,Class 99/01/03,Gold,Playoff (GP),GP,FD Jungle,scheduled,ticketUrl
+cmmbe5xbp00e6hxphs3ck1o3n,"Jul 15, 2025",8:20 PM,Class WGP2,Class 98,Gold,Playoff (GP),GP,FD Jungle,scheduled,ticketUrl
+cmmbe5y4u00echxphishg9hdh,"Jul 16, 2025",6:30 PM,Class WMP12,Class WMP11,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5z4100eihxphexerlhr6,"Jul 16, 2025",7:45 PM,Class WMP13,Class WMP10,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl
+cmmbe5zv800eohxphlc8y6gjo,"Jul 17, 2025",6:00 PM,Class TBD,Class TBD,Special,Playoff (TBD),TBD,FD Jungle,scheduled,ticketUrl
+cmmbe60mx00euhxph0l39ifva,"Jul 17, 2025",7:10 PM,Class WPP4,Class WPP3,Platinum,Playoff (PP),PP,FD Jungle,scheduled,ticketUrl
+cmmbe61f900f0hxphw9sufmxy,"Jul 17, 2025",8:20 PM,Class WGP4,Class WGP3,Gold,Playoff (GP),GP,FD Jungle,scheduled,ticketUrl
+cmmbe627h00f6hxphazm4glpk,"Jul 18, 2025",6:00 PM,Class FS,Class FS,Special,Father-Son,FS,FD Jungle,scheduled,ticketUrl
+cmmbe630v00fchxphf7a5kxzp,"Jul 18, 2025",7:10 PM,Class 90,Class 95,Gold,Pool,,FD Jungle,scheduled,ticketUrl
+cmmbe63t400fihxph9u6yn00u,"Jul 18, 2025",8:20 PM,Class WMP15,Class WMP14,Maroon,Playoff (MP),MP,FD Jungle,scheduled,ticketUrl


### PR DESCRIPTION
## Summary
This PR adds the partner handoff package baseline for the 2025 FD Alumni tournament.

## Included
- `docs/exports/2025-fd-alumni-basketball-tournament-missing-ticket-links.csv`
- `docs/exports/2025-fd-alumni-basketball-tournament-missing-stream-links.csv`
- `docs/LINK-HEALTH-REPORT.md` baseline (no links populated yet)
- `docs/PROJECT-STATUS-2026-03-04.md` updated with current partner ops baseline

## Why
Leon requested branch/PR workflow and a polished, partner-ready operational package before outreach to Clutch/GuamTime.

## Notes
- Baseline health check reports 0 URLs checked because ticket/stream links are not populated yet for 2025.
- These exports are ready to share with Matt/GuamTime and Zay/Clutch for data handoff.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes the partner handoff package baseline for the 2025 FD Alumni tournament, providing operational documentation and data exports ready for Clutch (streaming) and GuamTime (ticketing) partners.

**What's included:**
- Link health baseline report (`LINK-HEALTH-REPORT.md`) documenting current state: 0 URLs checked, 93 missing ticket links, 93 missing stream links
- Partner-ready CSV exports with complete game metadata for both ticket and stream link collection
- Updated project status documentation with new "Current Partner Ops Baseline" section

**Quality notes:**
- All data is accurate and matches the expected baseline state (links not yet populated for 2025)
- CSV exports contain all 93 games with comprehensive details (date, time, teams, division, phase, venue, status)
- Documentation is clear, well-structured, and includes proper usage instructions
- No code changes, zero runtime impact

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with zero risk — documentation and data exports only, no code or runtime impact
- Perfect confidence score reflects: (1) documentation-only changes with no code modifications, (2) accurate baseline data matching expected state, (3) well-structured partner-ready exports, (4) clear operational documentation, and (5) zero potential for runtime issues or regressions
- No files require special attention — all deliverables are documentation and data exports in proper format

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/LINK-HEALTH-REPORT.md | Added baseline link health report documenting 0 URLs checked and 93 missing links (ticket + stream) for 2025 tournament |
| docs/PROJECT-STATUS-2026-03-04.md | Added Current Partner Ops Baseline section documenting new CSV exports and link health report |
| docs/exports/2025-fd-alumni-basketball-tournament-missing-stream-links.csv | Added comprehensive CSV export of all 93 games missing stream links for Clutch (streaming partner) |
| docs/exports/2025-fd-alumni-basketball-tournament-missing-ticket-links.csv | Added comprehensive CSV export of all 93 games missing ticket links for GuamTime (ticketing partner) |

</details>


</details>


<sub>Last reviewed commit: 07dcf7d</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->