### PR TITLE
feat: PR9 featured curation UI for gallery/history

### DIFF
--- a/apps/web/src/app/(public)/gallery/page.tsx
+++ b/apps/web/src/app/(public)/gallery/page.tsx
@@ -24,13 +24,18 @@ export default async function GalleryPage({
       }
     : undefined
 
-  const items = await db.mediaAsset.findMany({
-    where,
-    orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
-    take: 300,
-  })
-
-  const featured = items.filter((i) => (i.tags || '').split(',').map(t => t.trim()).includes('featured')).slice(0, 3)
+  const [items, featured] = await Promise.all([
+    db.mediaAsset.findMany({
+      where,
+      orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
+      take: 300,
+    }),
+    db.mediaAsset.findMany({
+      where: where ? { ...where, tags: { contains: 'featured' } } : undefined,
+      orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
+      take: 3,
+    }),
+  ])
 
   const sourceRows = tournament
     ? await db.mediaAsset.findMany({ where: { tournamentId: tournament.id }, select: { source: true }, distinct: ['source'], orderBy: { source: 'asc' } })

--- a/apps/web/src/app/(public)/history/page.tsx
+++ b/apps/web/src/app/(public)/history/page.tsx
@@ -13,6 +13,7 @@ export default async function HistoryPage() {
         take: 1,
       },
       media: {
+        where: { tags: { contains: 'featured' } },
         orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
         take: 1,
       },


### PR DESCRIPTION
## Summary
PR9 surfaces editorial curation that was already tagged in data (`featured`) so the archive feels intentional, not raw-imported.

## Included
- `gallery` page now shows a dedicated **Featured** section first (top 3 featured items)
- `history` cards now show:
  - media count
  - featured preview thumbnail per tournament year

## Why
Leon asked for a polished archive experience with curated presentation across years.

## Validation
- `npm --workspace @fd/web run build` passes locally

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR successfully implements featured curation UI by surfacing editorial `featured` tags across the gallery and history pages. Both pages now use DB-level filtering (`tags: { contains: 'featured' }`) rather than client-side filtering, addressing previous review feedback.

**Key changes:**
- Gallery page displays a dedicated Featured section with top 3 featured items using parallel queries for optimal performance
- History cards now show media count and featured preview thumbnails per tournament year
- Both implementations properly filter at the database level for better performance and scalability

The implementation is clean, addresses all previous feedback, and achieves the stated goal of creating a more polished, curated archive experience.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- Clean implementation that fully addresses previous review feedback by moving featured filtering to the database level. No logical errors, security issues, or syntax problems detected. Uses proper parallel queries for performance optimization.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/app/(public)/gallery/page.tsx | Added Featured section with DB-level filtering for top 3 featured items using parallel queries |
| apps/web/src/app/(public)/history/page.tsx | Added featured media thumbnail and media count to tournament cards with proper DB-level filtering |

</details>


</details>


<sub>Last reviewed commit: 87ab66c</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->