### PR TITLE
#18: Explicit signed-out handling for admin pages and APIs

### DIFF
--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -5,14 +5,16 @@ const isAdminPageRoute = createRouteMatcher(['/admin(.*)'])
 const isAdminApiRoute = createRouteMatcher(['/api/admin(.*)'])
 
 export default clerkMiddleware(async (auth, req) => {
-  const { userId } = await auth()
+  if (isAdminApiRoute(req) || isAdminPageRoute(req)) {
+    const { userId } = await auth()
 
-  if (isAdminApiRoute(req) && !userId) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-  } else if (isAdminPageRoute(req) && !userId) {
-    const signInUrl = new URL('/sign-in', req.url)
-    signInUrl.searchParams.set('redirect_url', req.url)
-    return NextResponse.redirect(signInUrl)
+    if (isAdminApiRoute(req) && !userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    } else if (isAdminPageRoute(req) && !userId) {
+      const signInUrl = new URL('/sign-in', req.url)
+      signInUrl.searchParams.set('redirect_url', req.url)
+      return NextResponse.redirect(signInUrl)
+    }
   }
 })
 


### PR DESCRIPTION
## Summary
Implements issue #18 by making signed-out admin behavior explicit and predictable.

## What changed
- Updated `proxy.ts` auth handling:
  - `/admin(.*)` (pages): signed-out users are redirected to `/sign-in?redirect_url=<current-url>`
  - `/api/admin(.*)` (APIs): signed-out users receive explicit `401 { error: "Unauthorized" }`
- Keeps existing route-level role guards (`requireStaff` / `requireAdmin`) as defense-in-depth.

## Why
Previously signed-out `/admin` requests could surface ambiguous protect-rewrite/404 behavior. This makes UX and API responses clear for operators and users.

## Validation
- `npm --workspace @fd/web run build` passes locally

Closes #18

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements explicit signed-out handling for admin routes by replacing `auth.protect()` with concrete userId checks: `/api/admin(.*)` calls from unauthenticated clients would receive `401 { error: "Unauthorized" }`, and `/admin(.*)` page requests would redirect to `/sign-in` with a redirect URL parameter.

**Critical issue:** This file is named `proxy.ts` rather than `middleware.ts`, so Next.js does not load it as middleware at runtime. All auth logic inside this file—both the old `auth.protect()` call and these new userId checks—is silently skipped in production. The actual authorization protection comes solely from route-level guards (`requireStaff` / `requireAdmin` in `authz.ts`), which means this PR does not deliver the intended security improvement until the file is renamed to `apps/web/middleware.ts`.

**In-file logic:** Within the file itself, the implementation is correct—the two route matchers are mutually exclusive, auth() is appropriately scoped, and the 401/redirect branches execute their intended paths.

<h3>Confidence Score: 1/5</h3>

- Not safe to merge in current form; the critical prerequisite (renaming file to middleware.ts) must be completed for the intended protection to take effect.
- The in-file logic is implemented correctly, but because the file is named `proxy.ts` instead of `middleware.ts`, Next.js does not load it as middleware. This means all auth checks are silently bypassed in production, and the PR fails to deliver its intended security improvement. The route-level guards remain the only active protection layer. Rename to `middleware.ts` is a blocking prerequisite.
- File must be renamed: `apps/web/src/proxy.ts` → `apps/web/src/middleware.ts` (or `apps/web/middleware.ts` if preferred).

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Incoming Request] --> B{Matches config.matcher?}
    B -- No --> Z[Pass through - no auth check]
    B -- Yes --> C{isAdminApiRoute OR isAdminPageRoute?}
    C -- No --> Z
    C -- Yes --> D["⚠️ File not loaded by Next.js<br/>(named proxy.ts not middleware.ts)<br/>Auth logic silently skipped"]
    D --> E[Fall through to route-level<br/>requireStaff/requireAdmin guards]
    E -- Authorized --> K[Handle request]
    E -- Unauthorized --> L[403 or error response]
```

<sub>Last reviewed commit: 8e7258b</sub>

<!-- /greptile_comment -->