### PR TITLE
#23: Partner closeout pack for final stream/score gaps

### DIFF
--- a/apps/web/docs/OUTREACH-DRAFTS.md
+++ b/apps/web/docs/OUTREACH-DRAFTS.md
@@ -1,0 +1,32 @@
+
+---
+
+## Partner Closeout Draft — Batch 1 Final Gaps (2026-03-06)
+
+### Clutch (Streaming URLs) — Final Games Only
+
+Hi team — quick closeout request for FD Alumni Hub.
+
+We’ve completed ticket-link coverage for all finalized games and now only need stream/replay URLs for the remaining finalized matchups.
+
+Could you please fill the attached CSV and return stream URLs for each row?
+
+- File: `docs/exports/partner-clutch-final-stream-gaps.csv`
+- Rows: 15 finalized games
+- Needed field: stream URL (live/replay)
+
+Once we receive this, we can apply immediately and close out the remaining stream gaps.
+
+Thanks as always 🙏
+
+### Score Source Confirmation — Final Score Gap (1 game)
+
+Hi team — we have one remaining finalized game with missing score values.
+
+Please confirm final score for this matchup:
+
+- File: `docs/exports/partner-score-final-gap.csv`
+- Rows: 1
+- Needed fields: home_score, away_score
+
+As soon as confirmed, we’ll update and close the final score gap.

--- a/apps/web/docs/OUTREACH-DRAFTS.md
+++ b/apps/web/docs/OUTREACH-DRAFTS.md
@@ -14,6 +14,7 @@ Could you please fill the attached CSV and return stream URLs for each row?
 - File: `docs/exports/partner-clutch-final-stream-gaps.csv`
 - Rows: 15 finalized games
 - Needed field: stream URL (live/replay)
+- Coordination note: one row (`cmmbe4mcm0046hxphbzlzfr4f`) is marked `requires_score_confirmation_too` because score confirmation is being requested from a separate source.
 
 Once we receive this, we can apply immediately and close out the remaining stream gaps.
 
@@ -28,5 +29,6 @@ Please confirm final score for this matchup:
 - File: `docs/exports/partner-score-final-gap.csv`
 - Rows: 1
 - Needed fields: home_score, away_score
+- Coordination note: row is marked `requires_stream_url_too`; do not mark this game fully closed until stream URL is also received from Clutch.
 
 As soon as confirmed, we’ll update and close the final score gap.

--- a/apps/web/docs/exports/partner-clutch-final-stream-gaps.csv
+++ b/apps/web/docs/exports/partner-clutch-final-stream-gaps.csv
@@ -1,4 +1,4 @@
-game_id,year,date,time,matchup,division,bracket,venue,status,request
+game_id,year,date,time,matchup,division,bracket,venue,status,request,coordination_note
 cmmbe40zz0006hxphcs5yw4a5,2025,2025-06-27,08:00,"Class 79/80 vs Class 84/85",Gold,,FD Jungle,final,stream_url
 cmmbe422a000chxphf6xwlcwg,2025,2025-06-27,09:10,"Class 02/04 vs Class 2013",Maroon,,FD Jungle,final,stream_url
 cmmbe42uz000ihxphska5lmdu,2025,2025-06-27,10:20,"Class 2025 vs Class 2016/17",Maroon,,FD Jungle,final,stream_url
@@ -7,7 +7,7 @@ cmmbe4j5l003ihxphufs6p1i5,2025,2025-06-30,09:10,"Class 2024 vs Class 12 Pack",Ma
 cmmbe4k4q003ohxphfqp65dl6,2025,2025-06-30,10:20,"Class 98 vs Class 99/01/03",Gold,,FD Jungle,final,stream_url
 cmmbe4kv5003uhxphcizp5rig,2025,2025-07-01,08:00,"Class 84/85 vs Class 96/97",Gold,,FD Jungle,final,stream_url
 cmmbe4llu0040hxphnjglph25,2025,2025-07-01,09:10,"Class 2007 vs Class 2006",Maroon,,FD Jungle,final,stream_url
-cmmbe4mcm0046hxphbzlzfr4f,2025,2025-07-01,10:20,"Class 2023 vs Class 2025",Maroon,,FD Jungle,final,stream_url
+cmmbe4mcm0046hxphbzlzfr4f,2025,2025-07-01,10:20,"Class 2023 vs Class 2025",Maroon,,FD Jungle,final,stream_url,requires_score_confirmation_too
 cmmbe4n9p004chxphjg6mcxf5,2025,2025-07-02,08:00,"Class 79/80 vs Class 1988",Gold,,FD Jungle,final,stream_url
 cmmbe4o0h004ihxph365w1vau,2025,2025-07-02,09:10,"Class 1991 vs Class 1989",Gold,,FD Jungle,final,stream_url
 cmmbe4pim004uhxphl7yi6y0q,2025,2025-07-03,08:00,"Class 75 vs Class 82/86/AD7/92",Gold,,FD Jungle,final,stream_url

--- a/apps/web/docs/exports/partner-clutch-final-stream-gaps.csv
+++ b/apps/web/docs/exports/partner-clutch-final-stream-gaps.csv
@@ -1,0 +1,16 @@
+game_id,year,date,time,matchup,division,bracket,venue,status,request
+cmmbe40zz0006hxphcs5yw4a5,2025,2025-06-27,08:00,"Class 79/80 vs Class 84/85",Gold,,FD Jungle,final,stream_url
+cmmbe422a000chxphf6xwlcwg,2025,2025-06-27,09:10,"Class 02/04 vs Class 2013",Maroon,,FD Jungle,final,stream_url
+cmmbe42uz000ihxphska5lmdu,2025,2025-06-27,10:20,"Class 2025 vs Class 2016/17",Maroon,,FD Jungle,final,stream_url
+cmmbe4if1003chxph49kawvn4,2025,2025-06-30,08:00,"Class 2020 vs Class 2021",Maroon,,FD Jungle,final,stream_url
+cmmbe4j5l003ihxphufs6p1i5,2025,2025-06-30,09:10,"Class 2024 vs Class 12 Pack",Maroon,,FD Jungle,final,stream_url
+cmmbe4k4q003ohxphfqp65dl6,2025,2025-06-30,10:20,"Class 98 vs Class 99/01/03",Gold,,FD Jungle,final,stream_url
+cmmbe4kv5003uhxphcizp5rig,2025,2025-07-01,08:00,"Class 84/85 vs Class 96/97",Gold,,FD Jungle,final,stream_url
+cmmbe4llu0040hxphnjglph25,2025,2025-07-01,09:10,"Class 2007 vs Class 2006",Maroon,,FD Jungle,final,stream_url
+cmmbe4mcm0046hxphbzlzfr4f,2025,2025-07-01,10:20,"Class 2023 vs Class 2025",Maroon,,FD Jungle,final,stream_url
+cmmbe4n9p004chxphjg6mcxf5,2025,2025-07-02,08:00,"Class 79/80 vs Class 1988",Gold,,FD Jungle,final,stream_url
+cmmbe4o0h004ihxph365w1vau,2025,2025-07-02,09:10,"Class 1991 vs Class 1989",Gold,,FD Jungle,final,stream_url
+cmmbe4pim004uhxphl7yi6y0q,2025,2025-07-03,08:00,"Class 75 vs Class 82/86/AD7/92",Gold,,FD Jungle,final,stream_url
+cmmbe4q8t0050hxphj1c7oxpk,2025,2025-07-03,09:10,"Class 98 vs Class 430-5",Gold,,FD Jungle,final,stream_url
+cmmbe4qze0056hxphfp0zc3cr,2025,2025-07-03,10:20,"Class 2014 vs Class 2018/19",Maroon,,FD Jungle,final,stream_url
+cmmbe5ehq00a6hxphr0a09vw2,2025,2025-07-10,10:20,"Class 2013 vs Class 2025",Maroon,,FD Jungle,final,stream_url

--- a/apps/web/docs/exports/partner-score-final-gap.csv
+++ b/apps/web/docs/exports/partner-score-final-gap.csv
@@ -1,2 +1,2 @@
-game_id,year,date,time,matchup,division,bracket,venue,status,home_score,away_score,request
-cmmbe4mcm0046hxphbzlzfr4f,2025,2025-07-01,10:20,"Class 2023 vs Class 2025",Maroon,,FD Jungle,final,,,score_confirmation
+game_id,year,date,time,matchup,division,bracket,venue,status,home_score,away_score,request,coordination_note
+cmmbe4mcm0046hxphbzlzfr4f,2025,2025-07-01,10:20,"Class 2023 vs Class 2025",Maroon,,FD Jungle,final,,,score_confirmation,requires_stream_url_too

--- a/apps/web/docs/exports/partner-score-final-gap.csv
+++ b/apps/web/docs/exports/partner-score-final-gap.csv
@@ -1,0 +1,2 @@
+game_id,year,date,time,matchup,division,bracket,venue,status,home_score,away_score,request
+cmmbe4mcm0046hxphbzlzfr4f,2025,2025-07-01,10:20,"Class 2023 vs Class 2025",Maroon,,FD Jungle,final,,,score_confirmation


### PR DESCRIPTION
## Summary
Prepare partner-ready closeout assets to finish remaining #23 blockers.

## Included
- `apps/web/docs/exports/partner-clutch-final-stream-gaps.csv` (15 final-game stream gaps)
- `apps/web/docs/exports/partner-score-final-gap.csv` (1 final-game score confirmation gap)
- Added outreach templates to `apps/web/docs/OUTREACH-DRAFTS.md`

## Why
Enables immediate handoff to Clutch/score source and faster final data closure.

Refs #23

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds three static documentation and data export files to support partner closeout for the remaining #23 blockers:
- `partner-clutch-final-stream-gaps.csv`: 15 finalized games awaiting stream URLs from Clutch
- `partner-score-final-gap.csv`: 1 finalized game awaiting score confirmation
- `OUTREACH-DRAFTS.md`: Outreach templates for both partner requests

The overlapping game (`cmmbe4mcm0046hxphbzlzfr4f`) that requires both stream URL and score confirmation is correctly flagged in both CSVs with `coordination_note` fields (`requires_score_confirmation_too` / `requires_stream_url_too`) and explained in the outreach templates.

Since this PR modifies only static documentation and CSV exports with no runtime code changes, it poses no functional risk.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds static documentation and data exports only, with no code changes or runtime impact.
- All changes are static files (CSV exports and Markdown documentation). No functional logic, no dependencies, no tests affected. The dual-partner coordination flags are correctly applied via `coordination_note` fields in both CSVs and explained in outreach drafts. This PR is ready to hand off to partners immediately.
- No files require special attention.

<sub>Last reviewed commit: a1f5e9f</sub>

<!-- /greptile_comment -->