### PR TITLE
Audit data refresh and readiness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 .npm/
 .env*
+!.env.example
+!apps/*/.env.example
 .next/
 dist/
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Spreadsheet-simple UX first. Add advanced stats/automation later.
 - Prisma + Postgres configured
 
 ### Setup
-1. Copy `apps/web/.env.example` to `apps/web/.env.local`
-2. Fill Clerk + DB values for full admin/live-data mode. If `DATABASE_URL` is omitted, local dev runs in public archive-preview mode.
+1. Copy `apps/web/.env.example` to either repo-root `.env` or `apps/web/.env.local`
+2. Fill Clerk + DB values for full admin/live-data mode. If `DATABASE_URL` is omitted, local dev runs in public archive-preview mode. Restart `npm run dev` after changing env values.
 3. Run `npm install`
 4. Run `npm --workspace @fd/web exec prisma migrate dev`
 5. Seed baseline data: `npm --workspace @fd/web exec prisma db seed`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FD Alumni Basketball Tournament Hub
 
-Official-style hub concept for Father Duenas Memorial School Alumni Basketball Tournament.
+Central hub concept for Father Duenas Memorial School Alumni Basketball Tournament information, built to route fans toward partner ticketing, streaming, and coverage sources.
 
 ## V1 Goal
 Single source of truth for:
@@ -8,7 +8,7 @@ Single source of truth for:
 - Standings
 - Watch links (Clutch)
 - Ticket links (GuamTime)
-- News/articles (GSPN + official updates)
+- News/articles (GSPN + organizer updates)
 - Sponsors
 
 ## Product Principle
@@ -41,22 +41,26 @@ Spreadsheet-simple UX first. Add advanced stats/automation later.
 ### Setup
 1. Copy `apps/web/.env.example` to `apps/web/.env.local`
 2. Fill Clerk + DB values
-3. Run `cd apps/web && npx prisma migrate dev --name init_auth`
-4. Start app: `npm run dev`
+3. Run `npm install`
+4. Run `npm --workspace @fd/web exec prisma migrate dev`
+5. Seed baseline data: `npm --workspace @fd/web exec prisma db seed`
+6. Optional archive import: `npm --workspace @fd/web run import:archive-content`
+7. Start app: `npm run dev`
 
 ### Bootstrap first admin
 `POST /api/admin/bootstrap-whitelist` with header `x-bootstrap-secret` and JSON `{ "email": "you@example.com" }`
 
 ## Next Actions (Foundation Complete)
 1. Configure `apps/web/.env.local`
-2. Run DB migration: `cd apps/web && npx prisma migrate dev --name init_foundation`
-3. Seed sample data: `cd apps/web && npx prisma db seed`
-4. Bootstrap first admin whitelist:
+2. Run DB migrations: `npm --workspace @fd/web exec prisma migrate dev`
+3. Seed sample data: `npm --workspace @fd/web exec prisma db seed`
+4. Import researched archive content: `npm --workspace @fd/web run import:archive-content`
+5. Bootstrap first admin whitelist:
    - `curl -X POST http://localhost:3000/api/admin/bootstrap-whitelist \
       -H "Content-Type: application/json" \
       -H "x-bootstrap-secret: <BOOTSTRAP_SECRET>" \
       -d '{"email":"you@example.com"}'`
-5. Sign in via Clerk and visit `/admin`
+6. Sign in via Clerk and visit `/admin`
 
 ### Foundation APIs
 - Public: `/api/public/home`, `/api/public/schedule`, `/api/public/standings`

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Spreadsheet-simple UX first. Add advanced stats/automation later.
 
 ### Setup
 1. Copy `apps/web/.env.example` to `apps/web/.env.local`
-2. Fill Clerk + DB values
+2. Fill Clerk + DB values for full admin/live-data mode. If `DATABASE_URL` is omitted, local dev runs in public archive-preview mode.
 3. Run `npm install`
 4. Run `npm --workspace @fd/web exec prisma migrate dev`
 5. Seed baseline data: `npm --workspace @fd/web exec prisma db seed`

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,19 @@
+# Database
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:5432/fd_alumni_hub?schema=public"
+
+# Clerk auth
+NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY="pk_test_..."
+CLERK_SECRET_KEY="sk_test_..."
+
+# Initial admin bootstrap. Remove or rotate after first admin is provisioned.
+BOOTSTRAP_SECRET="replace-with-a-long-random-string"
+
+# Optional public ticket fallback for the home CTA
+NEXT_PUBLIC_GUAMTIME_URL="https://events.guamtime.net/event/fd-alumni-basketball-tournament-2025"
+
+# Optional S3 media upload support
+S3_BUCKET=""
+S3_REGION="ap-southeast-2"
+S3_ACCESS_KEY_ID=""
+S3_SECRET_ACCESS_KEY=""
+S3_PUBLIC_BASE_URL=""

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,36 +1,24 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# FD Alumni Hub Web App
 
-## Getting Started
+Next.js app for the FD Alumni Basketball Tournament Hub.
 
-First, run the development server:
+## Local setup
 
 ```bash
+cp apps/web/.env.example apps/web/.env.local
+npm install
+npm --workspace @fd/web exec prisma migrate dev
+npm --workspace @fd/web exec prisma db seed
+npm --workspace @fd/web run import:archive-content # optional researched archive import
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Required environment values live in `apps/web/.env.example`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Build
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+npm --workspace @fd/web run build
+```
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+The build script runs `prisma generate` before `next build` so fresh checkouts and Netlify builds have a generated Prisma client.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -5,7 +5,7 @@ Next.js app for the FD Alumni Basketball Tournament Hub.
 ## Local setup
 
 ```bash
-cp apps/web/.env.example apps/web/.env.local
+cp apps/web/.env.example .env # from repo root; apps/web/.env.local also works
 npm install
 npm --workspace @fd/web exec prisma migrate dev
 npm --workspace @fd/web exec prisma db seed
@@ -13,7 +13,7 @@ npm --workspace @fd/web run import:archive-content # optional researched archive
 npm run dev
 ```
 
-Required production/admin environment values live in `apps/web/.env.example`. Without `DATABASE_URL`, local dev falls back to a public archive-preview mode instead of crashing; live schedule/admin data still requires the database.
+Required production/admin environment values live in `apps/web/.env.example`. The dev/build scripts load env files from both the repo root and `apps/web`; restart `npm run dev` after changes. Without `DATABASE_URL`, local dev falls back to a public archive-preview mode instead of crashing; live schedule/admin data still requires the database.
 
 ## Build
 

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -13,7 +13,7 @@ npm --workspace @fd/web run import:archive-content # optional researched archive
 npm run dev
 ```
 
-Required environment values live in `apps/web/.env.example`.
+Required production/admin environment values live in `apps/web/.env.example`. Without `DATABASE_URL`, local dev falls back to a public archive-preview mode instead of crashing; live schedule/admin data still requires the database.
 
 ## Build
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "prisma generate && next dev",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -4,24 +4,25 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "prisma generate && next build",
     "start": "next start",
     "lint": "eslint",
     "partner-package": "tsx scripts/generate-partner-package.ts",
     "export:historical-gap-batch1": "tsx scripts/export-historical-gap-batch1.ts",
     "apply:historical-gap-batch1": "tsx scripts/apply-historical-gap-batch1.ts",
     "finalize:historical-gap-batch1": "tsx scripts/finalize-historical-gap-batch1.ts",
-    "qa-check": "tsx scripts/qa-smoke-check.ts"
+    "qa-check": "tsx scripts/qa-smoke-check.ts",
+    "import:archive-content": "tsx scripts/import-archive-content.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1001.0",
     "@aws-sdk/s3-presigned-post": "^3.1001.0",
-    "@clerk/nextjs": "^6.39.0",
+    "@clerk/nextjs": "^6.39.5",
     "@netlify/plugin-nextjs": "^5.8.1",
-    "@prisma/client": "^6.16.2",
+    "@prisma/client": "^6.19.3",
     "csv-parse": "^6.1.0",
     "lucide-react": "^0.577.0",
-    "next": "16.1.6",
+    "next": "^16.2.9",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "zod": "^4.3.6"
@@ -32,8 +33,8 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.1.6",
-    "prisma": "^6.16.2",
+    "eslint-config-next": "^16.2.9",
+    "prisma": "^6.19.3",
     "tailwindcss": "^4",
     "tsx": "^4.21.0",
     "typescript": "^5"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "prisma generate && next dev",
-    "build": "prisma generate && next build",
+    "dev": "node ../../scripts/with-env.mjs sh -c 'prisma generate && next dev'",
+    "build": "node ../../scripts/with-env.mjs sh -c 'prisma generate && next build'",
     "start": "next start",
     "lint": "eslint",
     "partner-package": "tsx scripts/generate-partner-package.ts",

--- a/apps/web/prisma/migrations/0008_add_cancelled_tournament_status/migration.sql
+++ b/apps/web/prisma/migrations/0008_add_cancelled_tournament_status/migration.sql
@@ -1,0 +1,3 @@
+-- Allow archive/import workflows to represent tournaments that were cancelled
+-- instead of forcing them into completed/upcoming/live.
+ALTER TYPE "TournamentStatus" ADD VALUE IF NOT EXISTS 'cancelled';

--- a/apps/web/prisma/schema.prisma
+++ b/apps/web/prisma/schema.prisma
@@ -182,6 +182,7 @@ enum TournamentStatus {
   upcoming
   live
   completed
+  cancelled
 }
 
 enum GameStatus {

--- a/apps/web/scripts/check-link-health.ts
+++ b/apps/web/scripts/check-link-health.ts
@@ -10,7 +10,7 @@
  */
 
 import { PrismaClient } from '@prisma/client'
-import { writeFileSync, mkdirSync } from 'fs'
+import { writeFileSync } from 'fs'
 import { resolve } from 'path'
 
 const db = new PrismaClient()

--- a/apps/web/scripts/export-missing-links.ts
+++ b/apps/web/scripts/export-missing-links.ts
@@ -11,7 +11,7 @@
 
 import { PrismaClient } from '@prisma/client'
 import { writeFileSync, mkdirSync } from 'fs'
-import { resolve, dirname } from 'path'
+import { resolve } from 'path'
 
 const db = new PrismaClient()
 
@@ -26,6 +26,14 @@ function escapeCsv(val: string | null | undefined): string {
 
 function row(...cells: (string | null | undefined)[]): string {
   return cells.map(escapeCsv).join(',')
+}
+
+function formatGuamDate(value: Date): string {
+  return value.toLocaleDateString('en-US', { timeZone: 'Pacific/Guam', month: 'short', day: 'numeric', year: 'numeric' })
+}
+
+function formatGuamTime(value: Date): string {
+  return value.toLocaleTimeString('en-US', { timeZone: 'Pacific/Guam', hour: 'numeric', minute: '2-digit' })
 }
 
 function phaseOf(bracketCode: string | null, teamName: string): string {
@@ -48,7 +56,7 @@ async function main() {
     process.exit(1)
   }
 
-  console.log(`\n📊 Exporting missing links for: ${tournament.name} ${tournament.year}\n`)
+  console.log(`\nExporting missing links for: ${tournament.name} ${tournament.year}\n`)
 
   const games = await db.game.findMany({
     where: { tournamentId: tournament.id },
@@ -63,8 +71,8 @@ async function main() {
 
   const toRow = (g: typeof games[0], missingField: string) => row(
     g.id,
-    new Date(g.startTime).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' }),
-    new Date(g.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }),
+    formatGuamDate(g.startTime),
+    formatGuamTime(g.startTime),
     g.awayTeam.displayName,
     g.homeTeam.displayName,
     g.division ?? g.homeTeam.division ?? '',
@@ -107,9 +115,9 @@ async function main() {
   writeFileSync(ticketPath, ticketLines.join('\n'), 'utf-8')
   writeFileSync(streamPath, streamLines.join('\n'), 'utf-8')
 
-  console.log(`✅ Exported ${missingTicket.length} games missing ticket links → ${ticketPath}`)
-  console.log(`✅ Exported ${missingStream.length} games missing stream links → ${streamPath}`)
-  console.log(`\n📁 Files in: ${exportsDir}\n`)
+  console.log(`Exported ${missingTicket.length} games missing ticket links -> ${ticketPath}`)
+  console.log(`Exported ${missingStream.length} games missing stream links -> ${streamPath}`)
+  console.log(`\nFiles in: ${exportsDir}\n`)
 
   await db.$disconnect()
 }

--- a/apps/web/scripts/full-image-recovery.ts
+++ b/apps/web/scripts/full-image-recovery.ts
@@ -36,7 +36,7 @@ async function findWorkingImage(articleUrl: string): Promise<string | null> {
     const imgMatches = html.matchAll(/<img[^>]*src=["'](https?:\/\/[^"']+\.(?:jpg|jpeg|png|gif|webp))["']/gi)
     
     for (const match of imgMatches) {
-      let imgUrl = match[1].replace(/&amp;/g, '&')
+      const imgUrl = match[1].replace(/&amp;/g, '&')
       
       // Skip thumbnails, icons, logos
       if (imgUrl.includes('-150x') || imgUrl.includes('-100x') || 
@@ -97,7 +97,7 @@ async function main() {
   
   let recovered = 0
   let failed = 0
-  const results: any[] = []
+  const results: Array<{ url: string; year: number; status: 'recovered' | 'unrecoverable'; newUrl?: string }> = []
   
   for (const articleUrl of REMAINING_BROKEN) {
     const shortName = articleUrl.split('/').filter(Boolean).pop() || ''

--- a/apps/web/scripts/historical-quality-pass.ts
+++ b/apps/web/scripts/historical-quality-pass.ts
@@ -79,7 +79,7 @@ async function main(): Promise<QualityResult> {
   }
 
   // Remove duplicates (keep oldest)
-  for (const [url, articles] of articlesByUrl) {
+  for (const articles of articlesByUrl.values()) {
     if (articles.length > 1) {
       const [keep, ...remove] = articles
       for (const dup of remove) {
@@ -133,7 +133,7 @@ async function main(): Promise<QualityResult> {
   }
 
   // Remove duplicates (keep oldest)
-  for (const [url, mediaList] of mediaByUrl) {
+  for (const mediaList of mediaByUrl.values()) {
     if (mediaList.length > 1) {
       const [keep, ...remove] = mediaList
       for (const dup of remove) {

--- a/apps/web/scripts/import-2025-gspn-scores.ts
+++ b/apps/web/scripts/import-2025-gspn-scores.ts
@@ -20,6 +20,22 @@ const rows: ScoreRow[] = [
   { date: '2025-06-27', winner: '79/80', loser: '84/85', winnerScore: 46, loserScore: 29, source: 'gspn-opens-with-a-bang' },
   { date: '2025-06-27', winner: '02/04', loser: '2013', winnerScore: 56, loserScore: 48, source: 'gspn-opens-with-a-bang' },
 
+  // GSPN: RECAP OF FD ALUMNI BASKETBALL WEEKEND (Jun 29, 2025)
+  { date: '2025-06-28', winner: '18/19', loser: '2015', winnerScore: 71, loserScore: 62, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-28', winner: '08/09', loser: '2014', winnerScore: 68, loserScore: 59, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-28', winner: '1991', loser: '98', winnerScore: 46, loserScore: 37, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-28', winner: '82/86/AD7/92', loser: '1988', winnerScore: 36, loserScore: 25, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-28', winner: '2007', loser: '05', winnerScore: 39, loserScore: 38, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-28', winner: '12 Pack', loser: '2010', winnerScore: 87, loserScore: 69, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-28', winner: '2022', loser: '2023', winnerScore: 64, loserScore: 62, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '2021', loser: '2024', winnerScore: 57, loserScore: 54, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '2023', loser: '2020', winnerScore: 45, loserScore: 39, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '1989', loser: '75', winnerScore: 36, loserScore: 21, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '430-5', loser: '96/97', winnerScore: 56, loserScore: 52, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '2006', loser: '02/04', winnerScore: 69, loserScore: 68, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '2025', loser: '2022', winnerScore: 62, loserScore: 57, source: 'gspn-opening-weekend-recap' },
+  { date: '2025-06-29', winner: '2016/17', loser: '18/19', winnerScore: 57, loserScore: 50, source: 'gspn-opening-weekend-recap' },
+
   // GSPN: RESULTS FROM THIS WEEK'S FD ALUMNI HOOPS TOURNEY (Jul 4, 2025)
   { date: '2025-06-30', winner: '2020', loser: '2021', winnerScore: 62, loserScore: 57, source: 'gspn-results-week' },
   { date: '2025-06-30', winner: '2024', loser: '12 Pack', winnerScore: 54, loserScore: 47, source: 'gspn-results-week' },
@@ -44,6 +60,7 @@ const aliases: Record<string, string[]> = {
   '75': ['75', '1975'],
   '96/97': ['96/97', '96/97/2000'],
   '18/19': ['18/19', '2018/19'],
+  '05': ['05', '2005'],
 }
 
 function norm(label: string): string[] {

--- a/apps/web/scripts/import-2025-official-schedule.ts
+++ b/apps/web/scripts/import-2025-official-schedule.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Prisma } from '@prisma/client'
+import { PrismaClient } from '@prisma/client'
 
 const prisma = new PrismaClient()
 

--- a/apps/web/scripts/import-archive-content.ts
+++ b/apps/web/scripts/import-archive-content.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env npx tsx
+/**
+ * Import static public-archive content into the database.
+ *
+ * This lets local/prod operators materialize the researched article/media archive
+ * after deploy without depending on runtime static fallbacks.
+ */
+
+import { PrismaClient } from '@prisma/client'
+import {
+  ARCHIVE_ARTICLES,
+  STATIC_TOURNAMENT_YEARS,
+  archiveMediaForYear,
+  championForYear,
+} from '@/lib/historical-archive'
+
+const prisma = new PrismaClient()
+const TOURNAMENT_NAME = 'FD Alumni Basketball Tournament'
+
+function tournamentDates(year: number) {
+  return {
+    startDate: new Date(`${year}-06-01T00:00:00+10:00`),
+    endDate: new Date(`${year}-08-01T00:00:00+10:00`),
+  }
+}
+
+async function ensureTournament(year: number) {
+  const champion = championForYear(year)
+  const { startDate, endDate } = tournamentDates(year)
+
+  return prisma.tournament.upsert({
+    where: { year_name: { year, name: TOURNAMENT_NAME } },
+    update: {
+      status: champion?.status === 'cancelled' ? 'completed' : undefined,
+    },
+    create: {
+      year,
+      name: TOURNAMENT_NAME,
+      status: champion?.status === 'cancelled' ? 'completed' : 'completed',
+      startDate,
+      endDate,
+    },
+  })
+}
+
+async function upsertArticle(tournamentId: string, article: typeof ARCHIVE_ARTICLES[number]) {
+  const existing = await prisma.articleLink.findFirst({ where: { tournamentId, url: article.url } })
+  const data = {
+    tournamentId,
+    title: article.title,
+    source: article.source,
+    url: article.url,
+    imageUrl: article.imageUrl,
+    excerpt: article.excerpt,
+    publishedAt: article.publishedAt ? new Date(`${article.publishedAt}T00:00:00+10:00`) : null,
+  }
+
+  if (existing) {
+    await prisma.articleLink.update({ where: { id: existing.id }, data })
+    return 'updated'
+  }
+
+  await prisma.articleLink.create({ data })
+  return 'created'
+}
+
+async function upsertMedia(tournamentId: string, media: ReturnType<typeof archiveMediaForYear>[number]) {
+  const existing = await prisma.mediaAsset.findFirst({ where: { tournamentId, imageUrl: media.imageUrl } })
+  const data = {
+    tournamentId,
+    title: media.title,
+    source: media.source,
+    imageUrl: media.imageUrl,
+    articleUrl: media.articleUrl ?? null,
+    caption: media.caption ?? null,
+    tags: media.tags ?? null,
+    takenAt: media.takenAt ? new Date(`${media.takenAt}T00:00:00+10:00`) : null,
+  }
+
+  if (existing) {
+    await prisma.mediaAsset.update({ where: { id: existing.id }, data })
+    return 'updated'
+  }
+
+  await prisma.mediaAsset.create({ data })
+  return 'created'
+}
+
+async function main() {
+  let articleCreated = 0
+  let articleUpdated = 0
+  let mediaCreated = 0
+  let mediaUpdated = 0
+
+  for (const year of STATIC_TOURNAMENT_YEARS) {
+    const tournament = await ensureTournament(year)
+    for (const article of ARCHIVE_ARTICLES.filter((item) => item.year === year)) {
+      const result = await upsertArticle(tournament.id, article)
+      if (result === 'created') articleCreated++
+      else articleUpdated++
+    }
+
+    for (const media of archiveMediaForYear(year)) {
+      if (!media.imageUrl) continue
+      const result = await upsertMedia(tournament.id, media)
+      if (result === 'created') mediaCreated++
+      else mediaUpdated++
+    }
+  }
+
+  console.log({ articleCreated, articleUpdated, mediaCreated, mediaUpdated })
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exit(1)
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/apps/web/scripts/import-archive-content.ts
+++ b/apps/web/scripts/import-archive-content.ts
@@ -32,7 +32,7 @@ async function ensureTournament(year: number) {
   return prisma.tournament.upsert({
     where: { year_name: { year, name: TOURNAMENT_NAME } },
     update: {
-      status: champion?.status === 'cancelled' ? 'cancelled' : undefined,
+      status: champion?.status === 'cancelled' ? 'cancelled' : 'completed',
     },
     create: {
       year,

--- a/apps/web/scripts/import-archive-content.ts
+++ b/apps/web/scripts/import-archive-content.ts
@@ -13,14 +13,15 @@ import {
   archiveMediaForYear,
   championForYear,
 } from '@/lib/historical-archive'
+import { guamDateStringToDate, guamLocalDateTimeToUtc } from '@/lib/datetime'
 
 const prisma = new PrismaClient()
 const TOURNAMENT_NAME = 'FD Alumni Basketball Tournament'
 
 function tournamentDates(year: number) {
   return {
-    startDate: new Date(`${year}-06-01T00:00:00+10:00`),
-    endDate: new Date(`${year}-08-01T00:00:00+10:00`),
+    startDate: guamLocalDateTimeToUtc(year, 6, 1, 0, 0, 0, 0),
+    endDate: guamLocalDateTimeToUtc(year, 8, 1, 23, 59, 59, 999),
   }
 }
 
@@ -52,7 +53,7 @@ async function upsertArticle(tournamentId: string, article: typeof ARCHIVE_ARTIC
     url: article.url,
     imageUrl: article.imageUrl,
     excerpt: article.excerpt,
-    publishedAt: article.publishedAt ? new Date(`${article.publishedAt}T00:00:00+10:00`) : null,
+    publishedAt: article.publishedAt ? guamDateStringToDate(article.publishedAt) : null,
   }
 
   if (existing) {
@@ -74,7 +75,7 @@ async function upsertMedia(tournamentId: string, media: ReturnType<typeof archiv
     articleUrl: media.articleUrl ?? null,
     caption: media.caption ?? null,
     tags: media.tags ?? null,
-    takenAt: media.takenAt ? new Date(`${media.takenAt}T00:00:00+10:00`) : null,
+    takenAt: media.takenAt ? guamDateStringToDate(media.takenAt) : null,
   }
 
   if (existing) {

--- a/apps/web/scripts/import-archive-content.ts
+++ b/apps/web/scripts/import-archive-content.ts
@@ -32,12 +32,12 @@ async function ensureTournament(year: number) {
   return prisma.tournament.upsert({
     where: { year_name: { year, name: TOURNAMENT_NAME } },
     update: {
-      status: champion?.status === 'cancelled' ? 'completed' : undefined,
+      status: champion?.status === 'cancelled' ? 'cancelled' : undefined,
     },
     create: {
       year,
       name: TOURNAMENT_NAME,
-      status: champion?.status === 'cancelled' ? 'completed' : 'completed',
+      status: champion?.status === 'cancelled' ? 'cancelled' : 'completed',
       startDate,
       endDate,
     },

--- a/apps/web/scripts/media-health-check.ts
+++ b/apps/web/scripts/media-health-check.ts
@@ -47,7 +47,7 @@ async function checkUrl(url: string): Promise<{ status: number; finalUrl: string
       finalUrl: response.url,
       ok: response.ok
     }
-  } catch (err) {
+  } catch {
     return { status: 0, finalUrl: url, ok: false }
   }
 }

--- a/apps/web/scripts/wayback-image-recovery.ts
+++ b/apps/web/scripts/wayback-image-recovery.ts
@@ -99,7 +99,7 @@ async function findAlternativeImage(articleUrl: string): Promise<string | null> 
     const imgMatches = html.matchAll(/<img[^>]*src=["'](https?:\/\/[^"']+(?:\/wp-content\/uploads\/[^"']+\.(?:jpg|jpeg|png)))["']/gi)
     
     for (const match of imgMatches) {
-      let imgUrl = match[1].replace(/&amp;/g, '&')
+      const imgUrl = match[1].replace(/&amp;/g, '&')
       
       // Skip thumbnails and small versions
       if (imgUrl.includes('-150x') || imgUrl.includes('-300x') || imgUrl.includes('-100x')) continue
@@ -125,7 +125,7 @@ async function main() {
   
   let recovered = 0
   let failed = 0
-  const results: any[] = []
+  const results: Array<{ url: string; status: string; newUrl?: string }> = []
   
   for (const item of BROKEN_IMAGES) {
     console.log(`\nProcessing: ${item.articleUrl.split('/').pop()}`)

--- a/apps/web/src/app/(public)/gallery/page.tsx
+++ b/apps/web/src/app/(public)/gallery/page.tsx
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic'
 
-import { db } from '@/lib/db'
+import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 import { archiveMediaForYear } from '@/lib/historical-archive'
 import Link from 'next/link'
@@ -27,20 +27,20 @@ export default async function GalleryPage({
   const yearFilter = params.year ? Number(params.year) : null
 
   const tournament = tournamentId
-    ? await db.tournament.findUnique({ where: { id: tournamentId } })
+    ? await withDatabaseFallback(() => db.tournament.findUnique({ where: { id: tournamentId } }), null)
     : yearFilter
-      ? await db.tournament.findFirst({ where: { year: yearFilter } })
+      ? await withDatabaseFallback(() => db.tournament.findFirst({ where: { year: yearFilter } }), null)
       : await getActiveTournament()
 
-  const displayYear = yearFilter ?? tournament?.year ?? null
+  const displayYear = yearFilter ?? tournament?.year ?? 2025
   const where = tournament ? { tournamentId: tournament.id } : undefined
 
   const dbItems = where
-    ? await db.mediaAsset.findMany({
+    ? await withDatabaseFallback(() => db.mediaAsset.findMany({
         where,
         orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
         take: 300,
-      })
+      }), [])
     : []
 
   const staticItems: GalleryItem[] = displayYear
@@ -74,7 +74,7 @@ export default async function GalleryPage({
       <div>
         <h1 className="text-2xl font-bold md:text-3xl" style={{ color: 'var(--fd-maroon)' }}>Gallery</h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          {tournament ? `${tournament.name} ${tournament.year}` : displayYear ? `FD Alumni Basketball Tournament ${displayYear}` : 'No active tournament loaded yet.'}
+          {tournament ? `${tournament.name} ${tournament.year}` : displayYear ? `FD Alumni Basketball Tournament ${displayYear}` : 'Tournament photos and media will appear here when available.'}
         </p>
         {sources.length > 1 ? (
           <div className="mt-3 flex flex-wrap items-center gap-1.5">
@@ -114,7 +114,7 @@ export default async function GalleryPage({
 
       {items.length === 0 ? (
         <div className="rounded-xl border bg-white p-8 text-sm text-neutral-600" style={{ borderColor: 'var(--border-subtle)' }}>
-          No media uploaded yet for this tournament.
+          No public media has been published for this tournament yet.
         </div>
       ) : (
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">

--- a/apps/web/src/app/(public)/gallery/page.tsx
+++ b/apps/web/src/app/(public)/gallery/page.tsx
@@ -25,7 +25,10 @@ export default async function GalleryPage({
   const params = await searchParams
   const tournamentId = params.tournamentId ?? undefined
   const sourceFilter = params.source ?? null
-  const yearFilter = params.year ? Number(params.year) : null
+  const parsedYear = params.year ? Number(params.year) : null
+  const yearFilter = parsedYear && Number.isInteger(parsedYear) && parsedYear >= 1900 && parsedYear <= 2200
+    ? parsedYear
+    : null
 
   const tournament = tournamentId
     ? await withDatabaseFallback(() => db.tournament.findUnique({ where: { id: tournamentId } }), null)

--- a/apps/web/src/app/(public)/gallery/page.tsx
+++ b/apps/web/src/app/(public)/gallery/page.tsx
@@ -1,6 +1,7 @@
 export const dynamic = 'force-dynamic'
 
 import { db, withDatabaseFallback } from '@/lib/db'
+import { formatGuamDate } from '@/lib/datetime'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 import { LATEST_ARCHIVE_YEAR, archiveMediaForYear } from '@/lib/historical-archive'
 import Link from 'next/link'
@@ -126,7 +127,7 @@ export default async function GalleryPage({
               <p className="mt-1 font-medium leading-snug">{item.title}</p>
               {item.caption ? <p className="mt-1 text-xs text-neutral-600 line-clamp-2">{item.caption}</p> : null}
               <div className="mt-2 flex items-center justify-between text-xs text-neutral-500">
-                <span>{item.takenAt ? new Date(item.takenAt).toLocaleDateString('en-US') : 'No date'}</span>
+                <span>{item.takenAt ? formatGuamDate(item.takenAt) : 'No date'}</span>
                 {item.articleUrl ? <a href={item.articleUrl} target="_blank" rel="noreferrer" className="underline">Source</a> : null}
               </div>
             </article>

--- a/apps/web/src/app/(public)/gallery/page.tsx
+++ b/apps/web/src/app/(public)/gallery/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
-import { archiveMediaForYear } from '@/lib/historical-archive'
+import { LATEST_ARCHIVE_YEAR, archiveMediaForYear } from '@/lib/historical-archive'
 import Link from 'next/link'
 
 type GalleryItem = {
@@ -32,7 +32,7 @@ export default async function GalleryPage({
       ? await withDatabaseFallback(() => db.tournament.findFirst({ where: { year: yearFilter } }), null)
       : await getActiveTournament()
 
-  const displayYear = yearFilter ?? tournament?.year ?? 2025
+  const displayYear = yearFilter ?? tournament?.year ?? LATEST_ARCHIVE_YEAR
   const where = tournament ? { tournamentId: tournament.id } : undefined
 
   const dbItems = where

--- a/apps/web/src/app/(public)/gallery/page.tsx
+++ b/apps/web/src/app/(public)/gallery/page.tsx
@@ -2,61 +2,89 @@ export const dynamic = 'force-dynamic'
 
 import { db } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
+import { archiveMediaForYear } from '@/lib/historical-archive'
 import Link from 'next/link'
+
+type GalleryItem = {
+  id: string
+  source: string
+  title: string
+  imageUrl: string
+  articleUrl?: string | null
+  caption?: string | null
+  tags?: string | null
+  takenAt?: Date | string | null
+}
 
 export default async function GalleryPage({
   searchParams,
 }: {
-  searchParams: Promise<{ tournamentId?: string; source?: string }>
+  searchParams: Promise<{ tournamentId?: string; source?: string; year?: string }>
 }) {
   const params = await searchParams
   const tournamentId = params.tournamentId ?? undefined
   const sourceFilter = params.source ?? null
+  const yearFilter = params.year ? Number(params.year) : null
 
   const tournament = tournamentId
     ? await db.tournament.findUnique({ where: { id: tournamentId } })
-    : await getActiveTournament()
+    : yearFilter
+      ? await db.tournament.findFirst({ where: { year: yearFilter } })
+      : await getActiveTournament()
 
-  const where = tournament
-    ? {
-        tournamentId: tournament.id,
-        ...(sourceFilter ? { source: sourceFilter } : {}),
-      }
-    : undefined
+  const displayYear = yearFilter ?? tournament?.year ?? null
+  const where = tournament ? { tournamentId: tournament.id } : undefined
 
-  const [items, featured] = await Promise.all([
-    db.mediaAsset.findMany({
-      where,
-      orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
-      take: 300,
-    }),
-    db.mediaAsset.findMany({
-      where: where ? { ...where, tags: { contains: 'featured' } } : undefined,
-      orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
-      take: 3,
-    }),
-  ])
-
-  const sourceRows = tournament
-    ? await db.mediaAsset.findMany({ where: { tournamentId: tournament.id }, select: { source: true }, distinct: ['source'], orderBy: { source: 'asc' } })
+  const dbItems = where
+    ? await db.mediaAsset.findMany({
+        where,
+        orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
+        take: 300,
+      })
     : []
-  const sources = sourceRows.map(s => s.source)
+
+  const staticItems: GalleryItem[] = displayYear
+    ? archiveMediaForYear(displayYear).map((item) => ({
+        id: `archive:${item.imageUrl}`,
+        source: item.source,
+        title: item.title,
+        imageUrl: item.imageUrl,
+        articleUrl: item.articleUrl,
+        caption: item.caption,
+        tags: item.tags,
+        takenAt: item.takenAt,
+      }))
+    : []
+
+  const seenImages = new Set<string>()
+  const allItems = [...dbItems, ...staticItems].filter((item) => {
+    if (seenImages.has(item.imageUrl)) return false
+    seenImages.add(item.imageUrl)
+    return true
+  })
+  const items = allItems
+    .filter((item) => !sourceFilter || item.source === sourceFilter)
+    .sort((a, b) => new Date(b.takenAt ?? 0).getTime() - new Date(a.takenAt ?? 0).getTime())
+  const featured = items.filter((item) => item.tags?.includes('featured')).slice(0, 3)
+
+  const sources = Array.from(new Set(allItems.map((item) => item.source))).sort()
 
   return (
     <section className="space-y-5">
       <div>
         <h1 className="text-2xl font-bold md:text-3xl" style={{ color: 'var(--fd-maroon)' }}>Gallery</h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          {tournament ? `${tournament.name} ${tournament.year}` : 'No active tournament loaded yet.'}
+          {tournament ? `${tournament.name} ${tournament.year}` : displayYear ? `FD Alumni Basketball Tournament ${displayYear}` : 'No active tournament loaded yet.'}
         </p>
         {sources.length > 1 ? (
           <div className="mt-3 flex flex-wrap items-center gap-1.5">
-            <Link href={`/gallery${tournamentId ? `?tournamentId=${encodeURIComponent(tournamentId)}` : ''}`} className="rounded-full px-3 py-1.5 text-xs font-semibold" style={!sourceFilter ? { background: 'var(--fd-ink)', color: '#fff' } : { background: 'var(--neutral-100)', color: 'var(--neutral-700)', border: '1px solid var(--border-subtle)' }}>
+            <Link href={`/gallery${tournamentId ? `?tournamentId=${encodeURIComponent(tournamentId)}` : displayYear ? `?year=${displayYear}` : ''}`} className="rounded-full px-3 py-1.5 text-xs font-semibold" style={!sourceFilter ? { background: 'var(--fd-ink)', color: '#fff' } : { background: 'var(--neutral-100)', color: 'var(--neutral-700)', border: '1px solid var(--border-subtle)' }}>
               All sources
             </Link>
             {sources.map((s) => {
               const p = new URLSearchParams()
               if (tournamentId) p.set('tournamentId', tournamentId)
+              else if (displayYear) p.set('year', String(displayYear))
               p.set('source', s)
               return (
                 <Link key={s} href={`/gallery?${p.toString()}`} className="rounded-full px-3 py-1.5 text-xs font-semibold" style={sourceFilter===s ? { background: 'var(--fd-maroon)', color: '#fff' } : { background: 'var(--neutral-100)', color: 'var(--neutral-700)', border: '1px solid var(--border-subtle)' }}>

--- a/apps/web/src/app/(public)/history/page.tsx
+++ b/apps/web/src/app/(public)/history/page.tsx
@@ -2,67 +2,71 @@ export const dynamic = 'force-dynamic'
 
 import Link from 'next/link'
 import { db } from '@/lib/db'
+import {
+  STATIC_TOURNAMENT_YEARS,
+  archiveArticlesForYear,
+  archiveMediaForYear,
+  championForYear,
+} from '@/lib/historical-archive'
 
-// Historical champions data (verified from GSPN and GuamPDN)
-const VERIFIED_CHAMPIONS: Record<number, { champion: string; runnerUp?: string; score?: string; source: string }> = {
-  2025: { champion: 'Class of 2002/04', runnerUp: 'Class of 2013', score: '50-44', source: 'GuamPDN' },
-  2024: { champion: 'Class of 2016/17', runnerUp: 'Class of 2013', score: '58-56', source: 'GSPN' },
-  2023: { champion: 'Class of 2013', source: 'GSPN' },
-  2022: { champion: 'Class of 2002/04', runnerUp: 'Class of 2020', score: '62-52', source: 'GSPN' },
-  2021: { champion: 'Class of 2006', runnerUp: 'Class of 2002/04', score: '58-38', source: 'GSPN' },
-  // 2020: cancelled (COVID-19)
-  2019: { champion: 'Class of 2006', source: 'GSPN' },
-  2018: { champion: 'Class of 2002/04', source: 'GSPN' },
-  2017: { champion: 'Class of 2002/04', source: 'GSPN' },
-  // 2016: No verified data available
-  2015: { champion: 'Class of 2013', runnerUp: 'Class of 2004', score: '60-48', source: 'GSPN' },
-  2014: { champion: 'Class of 2004', source: 'GSPN' },
-  2013: { champion: 'Class of 2006', source: 'Historical' },
-  2012: { champion: 'Class of 2006', source: 'Historical' },
-  2011: { champion: 'Class of 2006', source: 'Historical' },
-  2010: { champion: 'Class of 2006', source: 'Historical' },
-  2009: { champion: 'Class of 2002', source: 'Historical' },
-  2008: { champion: 'Class of 1995', source: 'Historical' },
-  2007: { champion: 'Class of 2006', source: 'Historical' },
-  2006: { champion: 'Class of 2002/03', source: 'Historical' },
-  2005: { champion: 'Class of 1991', source: 'Historical' },
+function TrophyIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <path d="M6 9H4.5a2.5 2.5 0 0 1 0-5H6" />
+      <path d="M18 9h1.5a2.5 2.5 0 0 0 0-5H18" />
+      <path d="M4 22h16" />
+      <path d="M10 14.66V17c0 .55-.47.98-.97 1.21C7.85 18.75 7 20.24 7 22" />
+      <path d="M14 14.66V17c0 .55.47.98.97 1.21C16.15 18.75 17 20.24 17 22" />
+      <path d="M18 2H6v7a6 6 0 0 0 12 0V2Z" />
+    </svg>
+  )
+}
+
+function RunnerUpIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+      <circle cx="12" cy="8" r="6" />
+      <path d="M8.2 13 7 22l5-3 5 3-1.2-9" />
+    </svg>
+  )
 }
 
 function ChampionBadge({ year }: { year: number }) {
-  const data = VERIFIED_CHAMPIONS[year]
-  if (!data) {
-    if (year === 2020) {
-      return (
-        <div className="mt-2 flex items-center gap-1.5 text-xs" style={{ color: 'var(--neutral-500)' }}>
-          <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5" style={{ background: 'var(--neutral-100)' }}>
-            ⏸️ Cancelled (COVID-19)
-          </span>
-        </div>
-      )
-    }
-    if (year === 2016) {
-      return (
-        <div className="mt-2 flex items-center gap-1.5 text-xs" style={{ color: 'var(--neutral-500)' }}>
-          <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5" style={{ background: 'var(--neutral-100)' }}>
-            ❓ Champion data unavailable
-          </span>
-        </div>
-      )
-    }
-    return null
+  const data = championForYear(year)
+  if (!data) return null
+
+  if (data.status === 'cancelled') {
+    return (
+      <div className="mt-2 text-xs" style={{ color: 'var(--neutral-500)' }}>
+        <span className="inline-flex items-center rounded-full px-2 py-0.5" style={{ background: 'var(--neutral-100)' }}>
+          Cancelled{data.note ? ` — ${data.note}` : ''}
+        </span>
+      </div>
+    )
+  }
+
+  if (data.status === 'unknown' || !data.champion) {
+    return (
+      <div className="mt-2 text-xs" style={{ color: 'var(--neutral-500)' }}>
+        <span className="inline-flex items-center rounded-full px-2 py-0.5" style={{ background: 'var(--neutral-100)' }}>
+          Champion data unavailable{data.note ? ` — ${data.note}` : ''}
+        </span>
+      </div>
+    )
   }
 
   return (
     <div className="mt-2 space-y-1">
       <div className="flex flex-wrap items-center gap-1.5 text-xs">
-        <span 
+        <span
           className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 font-medium"
           style={{ background: 'var(--fd-gold)', color: 'var(--fd-maroon)' }}
         >
-          🏆 {data.champion}
+          <TrophyIcon />
+          {data.champion}
         </span>
         {data.score && (
-          <span 
+          <span
             className="rounded-full px-2 py-0.5 font-mono"
             style={{ background: 'var(--neutral-100)', color: 'var(--neutral-700)' }}
           >
@@ -73,7 +77,8 @@ function ChampionBadge({ year }: { year: number }) {
       {data.runnerUp && (
         <div className="flex items-center gap-1.5 text-xs" style={{ color: 'var(--neutral-500)' }}>
           <span className="inline-flex items-center gap-1 rounded-full px-2 py-0.5" style={{ background: 'var(--neutral-100)' }}>
-            🥈 {data.runnerUp}
+            <RunnerUpIcon />
+            {data.runnerUp}
           </span>
         </div>
       )}
@@ -83,43 +88,45 @@ function ChampionBadge({ year }: { year: number }) {
 
 function CoverageBadge({ scored, total }: { scored: number; total: number }) {
   if (total === 0) return null
-  
+
   const pct = Math.round((scored / total) * 100)
   const isComplete = pct === 100
   const isPartial = pct > 0 && pct < 100
-  
+
   return (
     <div className="mt-2 text-xs">
       <div className="flex items-center gap-2">
-        <div 
-          className="h-1.5 flex-1 rounded-full overflow-hidden"
+        <div
+          className="h-1.5 flex-1 overflow-hidden rounded-full"
           style={{ background: 'var(--neutral-200)' }}
         >
-          <div 
+          <div
             className="h-full rounded-full transition-all"
-            style={{ 
+            style={{
               width: `${pct}%`,
-              background: isComplete ? 'var(--green-500)' : 'var(--fd-maroon)'
+              background: isComplete ? 'var(--success)' : 'var(--fd-maroon)',
             }}
           />
         </div>
-        <span style={{ color: isComplete ? 'var(--green-600)' : 'var(--neutral-500)' }}>
-          {scored}/{total} {isComplete ? '✓' : isPartial ? 'results' : ''}
+        <span style={{ color: isComplete ? 'var(--success)' : 'var(--neutral-500)' }}>
+          {scored}/{total} {isComplete ? 'complete' : isPartial ? 'results' : ''}
         </span>
       </div>
     </div>
   )
 }
 
+function yearHref(path: string, tournamentId: string | null, year: number) {
+  return tournamentId
+    ? `${path}?tournamentId=${encodeURIComponent(tournamentId)}`
+    : `${path}?year=${year}`
+}
+
 export default async function HistoryPage() {
   const tournaments = await db.tournament.findMany({
     orderBy: [{ year: 'desc' }, { startDate: 'desc' }],
     include: {
-      standings: {
-        include: { team: true },
-        orderBy: [{ wins: 'desc' }, { losses: 'asc' }, { pointsFor: 'desc' }],
-        take: 1,
-      },
+      articles: { select: { url: true } },
       media: {
         where: { tags: { contains: 'featured' } },
         orderBy: [{ takenAt: 'desc' }, { createdAt: 'desc' }],
@@ -132,17 +139,16 @@ export default async function HistoryPage() {
           awayScore: true,
         },
       },
-      _count: { select: { games: true, articles: true, media: true } },
+      _count: { select: { games: true, media: true } },
     },
-    take: 20,
+    take: 50,
   })
 
-  // Compute coverage for each tournament
-  const tournamentData = tournaments.map(t => {
-    const totalGames = t.games.length
-    const scoredGames = t.games.filter(g => g.homeScore !== null && g.awayScore !== null).length
-    return { ...t, scoredGames, totalGames }
-  })
+  const tournamentByYear = new Map(tournaments.map((t) => [t.year, t]))
+  const years = Array.from(new Set([
+    ...STATIC_TOURNAMENT_YEARS,
+    ...tournaments.map((t) => t.year),
+  ])).sort((a, b) => b - a)
 
   return (
     <section className="space-y-5">
@@ -151,16 +157,15 @@ export default async function HistoryPage() {
           Tournament History
         </h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          Browse FD Alumni tournaments from 2014 to present. Champions, results, articles, and brackets.
+          Browse FD Alumni tournaments, champions, results, articles, and recovered media from public archives.
         </p>
       </div>
 
-      {/* Dynasty highlight */}
-      <div 
+      <div
         className="rounded-xl border p-4"
         style={{ borderColor: 'var(--fd-gold)', background: 'linear-gradient(135deg, rgba(214,175,84,0.1), rgba(138,21,56,0.05))' }}
       >
-        <h2 className="text-sm font-semibold" style={{ color: 'var(--fd-maroon)' }}>🏀 Dynasty Watch</h2>
+        <h2 className="text-sm font-semibold" style={{ color: 'var(--fd-maroon)' }}>Dynasty Watch</h2>
         <div className="mt-2 grid grid-cols-2 gap-3 text-xs md:grid-cols-4">
           <div>
             <span className="font-medium" style={{ color: 'var(--fd-ink)' }}>Class of 2006</span>
@@ -181,83 +186,83 @@ export default async function HistoryPage() {
         </div>
       </div>
 
-      {tournamentData.length === 0 ? (
+      {years.length === 0 ? (
         <div className="rounded-xl border bg-white p-8 text-sm" style={{ borderColor: 'var(--border-subtle)' }}>
           No tournaments found yet.
         </div>
       ) : (
         <div className="grid gap-3 md:grid-cols-2">
-          {tournamentData.map((t) => {
-            const hasChampion = !!VERIFIED_CHAMPIONS[t.year]
-            const isCompleted = t.status === 'completed'
-            
+          {years.map((year) => {
+            const t = tournamentByYear.get(year)
+            const archiveArticles = archiveArticlesForYear(year)
+            const archiveMedia = archiveMediaForYear(year)
+            const totalGames = t?.games.length ?? 0
+            const scoredGames = t?.games.filter((g) => g.homeScore !== null && g.awayScore !== null).length ?? 0
+            const articleCount = new Set([...(t?.articles.map((a) => a.url) ?? []), ...archiveArticles.map((a) => a.url)]).size
+            const mediaCount = Math.max(t?._count.media ?? 0, archiveMedia.length)
+            const champion = championForYear(year)
+            const isCompleted = t?.status === 'completed' || (!!champion?.champion && champion.status !== 'cancelled')
+            const featuredImage = t?.media[0]?.imageUrl ?? archiveMedia.find((m) => m.tags?.includes('featured'))?.imageUrl ?? archiveMedia[0]?.imageUrl
+            const tournamentId = t?.id ?? null
+
             return (
-              <article 
-                key={t.id} 
+              <article
+                key={year}
                 className="rounded-xl border bg-white p-5 transition-shadow hover:shadow-md"
-                style={{ borderColor: hasChampion ? 'var(--fd-gold)' : 'var(--border-subtle)' }}
+                style={{ borderColor: champion?.champion ? 'var(--fd-gold)' : 'var(--border-subtle)' }}
               >
                 <div className="flex items-center justify-between gap-2">
                   <h2 className="text-lg font-semibold" style={{ color: 'var(--fd-ink)' }}>
-                    {t.year} {t.name.replace('FD Alumni Basketball Tournament', 'Tournament')}
+                    {year} Tournament
                   </h2>
-                  <span 
-                    className="text-xs rounded-full px-2 py-0.5 capitalize"
-                    style={{ 
-                      background: isCompleted ? 'var(--green-100)' : 'var(--neutral-100)', 
-                      color: isCompleted ? 'var(--green-700)' : 'var(--neutral-600)' 
+                  <span
+                    className="rounded-full px-2 py-0.5 text-xs capitalize"
+                    style={{
+                      background: isCompleted ? '#dcfce7' : 'var(--neutral-100)',
+                      color: isCompleted ? '#166534' : 'var(--neutral-600)',
                     }}
                   >
-                    {t.status}
+                    {champion?.status === 'cancelled' ? 'cancelled' : t?.status ?? 'archive'}
                   </span>
                 </div>
 
-                <ChampionBadge year={t.year} />
-                
+                <ChampionBadge year={year} />
+
                 <p className="mt-3 text-xs" style={{ color: 'var(--neutral-500)' }}>
-                  {t._count.games} games · {t._count.articles} articles · {t._count.media} media
+                  {totalGames} games · {articleCount} articles · {mediaCount} media
                 </p>
 
-                <CoverageBadge scored={t.scoredGames} total={t.totalGames} />
+                <CoverageBadge scored={scoredGames} total={totalGames} />
 
-                {t.media[0] ? (
+                {featuredImage ? (
                   // eslint-disable-next-line @next/next/no-img-element
-                  <img 
-                    src={t.media[0].imageUrl} 
-                    alt={`${t.year} featured`} 
+                  <img
+                    src={featuredImage}
+                    alt={`${year} featured`}
                     className="mt-3 h-28 w-full rounded-md object-cover"
                     loading="lazy"
                   />
                 ) : null}
 
                 <div className="mt-4 flex flex-wrap gap-2 text-xs">
-                  <Link 
-                    className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" 
-                    style={{ borderColor: 'var(--border-subtle)' }} 
-                    href={`/schedule?tournamentId=${encodeURIComponent(t.id)}`}
-                  >
-                    Schedule
-                  </Link>
-                  <Link 
-                    className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" 
-                    style={{ borderColor: 'var(--border-subtle)' }} 
-                    href={`/standings?tournamentId=${encodeURIComponent(t.id)}`}
-                  >
-                    Standings
-                  </Link>
-                  <Link 
-                    className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" 
-                    style={{ borderColor: 'var(--border-subtle)' }} 
-                    href={`/watch?tournamentId=${encodeURIComponent(t.id)}`}
-                  >
-                    Watch
-                  </Link>
-                  <Link 
-                    className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" 
-                    style={{ borderColor: 'var(--border-subtle)' }} 
-                    href={`/news?tournamentId=${encodeURIComponent(t.id)}`}
-                  >
+                  {tournamentId ? (
+                    <>
+                      <Link className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" style={{ borderColor: 'var(--border-subtle)' }} href={yearHref('/schedule', tournamentId, year)}>
+                        Schedule
+                      </Link>
+                      <Link className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" style={{ borderColor: 'var(--border-subtle)' }} href={yearHref('/standings', tournamentId, year)}>
+                        Standings
+                      </Link>
+                      <Link className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" style={{ borderColor: 'var(--border-subtle)' }} href={yearHref('/watch', tournamentId, year)}>
+                        Watch
+                      </Link>
+                    </>
+                  ) : null}
+                  <Link className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" style={{ borderColor: 'var(--border-subtle)' }} href={yearHref('/news', tournamentId, year)}>
                     News
+                  </Link>
+                  <Link className="rounded-lg border px-2.5 py-1.5 transition-colors hover:bg-gray-50" style={{ borderColor: 'var(--border-subtle)' }} href={yearHref('/gallery', tournamentId, year)}>
+                    Gallery
                   </Link>
                 </div>
               </article>
@@ -266,12 +271,10 @@ export default async function HistoryPage() {
         </div>
       )}
 
-      {/* Data trust notice */}
       <div className="rounded-xl border bg-white p-4 text-xs" style={{ borderColor: 'var(--border-subtle)' }}>
         <p style={{ color: 'var(--neutral-500)' }}>
-          <strong style={{ color: 'var(--neutral-700)' }}>Data Sources:</strong> Champion data and game results are verified from GSPN (Guam Sports Network), GuamPDN, and official tournament records. 
-          Results marked with a progress bar indicate partial score coverage. 
-          <Link href="/news" className="ml-1 underline">View all sources →</Link>
+          <strong style={{ color: 'var(--neutral-700)' }}>Data Sources:</strong> Champion data, article links, and recovered media are attributed to GSPN, GuamPDN, PostGuam, and official tournament records where available. Results marked with a progress bar indicate partial score coverage.
+          <Link href="/news" className="ml-1 underline">View all sources</Link>
         </p>
       </div>
     </section>

--- a/apps/web/src/app/(public)/history/page.tsx
+++ b/apps/web/src/app/(public)/history/page.tsx
@@ -1,7 +1,7 @@
 export const dynamic = 'force-dynamic'
 
 import Link from 'next/link'
-import { db } from '@/lib/db'
+import { db, withDatabaseFallback } from '@/lib/db'
 import {
   STATIC_TOURNAMENT_YEARS,
   archiveArticlesForYear,
@@ -123,7 +123,7 @@ function yearHref(path: string, tournamentId: string | null, year: number) {
 }
 
 export default async function HistoryPage() {
-  const tournaments = await db.tournament.findMany({
+  const tournaments = await withDatabaseFallback(() => db.tournament.findMany({
     orderBy: [{ year: 'desc' }, { startDate: 'desc' }],
     include: {
       articles: { select: { url: true } },
@@ -142,7 +142,7 @@ export default async function HistoryPage() {
       _count: { select: { games: true, media: true } },
     },
     take: 50,
-  })
+  }), [])
 
   const tournamentByYear = new Map(tournaments.map((t) => [t.year, t]))
   const years = Array.from(new Set([

--- a/apps/web/src/app/(public)/news/page.tsx
+++ b/apps/web/src/app/(public)/news/page.tsx
@@ -4,20 +4,14 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { db } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
+import { archiveArticlesForYear } from '@/lib/historical-archive'
+import { mergeArchiveArticles, type FeedArticle } from '@/lib/services/public-feed'
 
 export const metadata: Metadata = {
   title: 'News',
 }
 
-type NewsItem = {
-  id: string
-  source: string
-  title: string
-  imageUrl?: string | null
-  excerpt?: string | null
-  publishedAt: Date | null
-  url: string
-}
+type NewsItem = FeedArticle
 
 function ExternalLinkIcon() {
   return (
@@ -106,36 +100,40 @@ function NewsCard({ item, index }: { item: NewsItem; index: number }) {
 export default async function NewsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ tournamentId?: string; source?: string }>
+  searchParams: Promise<{ tournamentId?: string; source?: string; year?: string }>
 }) {
   const params = await searchParams
   const tournamentId = params.tournamentId ?? undefined
   const sourceFilter = params.source ?? null
+  const yearFilter = params.year ? Number(params.year) : null
 
   const tournament = tournamentId
     ? await db.tournament.findUnique({ where: { id: tournamentId } })
-    : await getActiveTournament()
+    : yearFilter
+      ? await db.tournament.findFirst({ where: { year: yearFilter } })
+      : await getActiveTournament()
 
-  const latestNews = await db.articleLink.findMany({
-    where: tournament
-      ? {
-          tournamentId: tournament.id,
-          ...(sourceFilter ? { source: sourceFilter } : {}),
-        }
-      : undefined,
-    orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
-    take: 100,
-  })
+  const displayYear = yearFilter ?? tournament?.year ?? null
 
-  const sourceRows = tournament
+  const dbNews = tournament
     ? await db.articleLink.findMany({
         where: { tournamentId: tournament.id },
-        select: { source: true },
-        distinct: ['source'],
-        orderBy: { source: 'asc' },
+        orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
+        take: 150,
       })
     : []
-  const sources = sourceRows.map(s => s.source)
+
+  const mergedNews = displayYear ? mergeArchiveArticles(dbNews, displayYear) : dbNews
+  const latestNews = sourceFilter
+    ? mergedNews.filter((item) => item.source === sourceFilter)
+    : mergedNews
+
+  const sources = displayYear
+    ? Array.from(new Set([
+        ...dbNews.map((item) => item.source),
+        ...archiveArticlesForYear(displayYear).map((item) => item.source),
+      ])).sort()
+    : []
 
   return (
     <section className="space-y-5">
@@ -146,16 +144,17 @@ export default async function NewsPage({
           News
         </h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          {tournament ? `${tournament.name} ${tournament.year}` : 'No active tournament loaded yet.'}
+          {tournament ? `${tournament.name} ${tournament.year}` : displayYear ? `FD Alumni Basketball Tournament ${displayYear}` : 'No active tournament loaded yet.'}
         </p>
         {sources.length > 1 ? (
           <div className="mt-3 flex flex-wrap items-center gap-1.5">
-            <Link href={`/news${tournamentId ? `?tournamentId=${encodeURIComponent(tournamentId)}` : ''}`} className="rounded-full px-3 py-1.5 text-xs font-semibold" style={!sourceFilter ? { background: 'var(--fd-ink)', color: '#fff' } : { background: 'var(--neutral-100)', color: 'var(--neutral-700)', border: '1px solid var(--border-subtle)' }}>
+            <Link href={`/news${tournamentId ? `?tournamentId=${encodeURIComponent(tournamentId)}` : displayYear ? `?year=${displayYear}` : ''}`} className="rounded-full px-3 py-1.5 text-xs font-semibold" style={!sourceFilter ? { background: 'var(--fd-ink)', color: '#fff' } : { background: 'var(--neutral-100)', color: 'var(--neutral-700)', border: '1px solid var(--border-subtle)' }}>
               All sources
             </Link>
             {sources.map((s) => {
               const p = new URLSearchParams()
               if (tournamentId) p.set('tournamentId', tournamentId)
+              else if (displayYear) p.set('year', String(displayYear))
               p.set('source', s)
               return (
                 <Link key={s} href={`/news?${p.toString()}`} className="rounded-full px-3 py-1.5 text-xs font-semibold" style={sourceFilter===s ? { background: 'var(--fd-maroon)', color: '#fff' } : { background: 'var(--neutral-100)', color: 'var(--neutral-700)', border: '1px solid var(--border-subtle)' }}>
@@ -178,7 +177,7 @@ export default async function NewsPage({
         </div>
       ) : (
         <div className="space-y-3">
-          {(latestNews as NewsItem[]).map((item, i) => (
+          {latestNews.map((item: NewsItem, i) => (
             <NewsCard key={item.id} item={item} index={i} />
           ))}
         </div>

--- a/apps/web/src/app/(public)/news/page.tsx
+++ b/apps/web/src/app/(public)/news/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { db } from '@/lib/db'
+import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 import { archiveArticlesForYear } from '@/lib/historical-archive'
 import { mergeArchiveArticles, type FeedArticle } from '@/lib/services/public-feed'
@@ -108,19 +108,19 @@ export default async function NewsPage({
   const yearFilter = params.year ? Number(params.year) : null
 
   const tournament = tournamentId
-    ? await db.tournament.findUnique({ where: { id: tournamentId } })
+    ? await withDatabaseFallback(() => db.tournament.findUnique({ where: { id: tournamentId } }), null)
     : yearFilter
-      ? await db.tournament.findFirst({ where: { year: yearFilter } })
+      ? await withDatabaseFallback(() => db.tournament.findFirst({ where: { year: yearFilter } }), null)
       : await getActiveTournament()
 
-  const displayYear = yearFilter ?? tournament?.year ?? null
+  const displayYear = yearFilter ?? tournament?.year ?? 2025
 
   const dbNews = tournament
-    ? await db.articleLink.findMany({
+    ? await withDatabaseFallback(() => db.articleLink.findMany({
         where: { tournamentId: tournament.id },
         orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
         take: 150,
-      })
+      }), [])
     : []
 
   const mergedNews = displayYear ? mergeArchiveArticles(dbNews, displayYear) : dbNews
@@ -144,7 +144,7 @@ export default async function NewsPage({
           News
         </h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          {tournament ? `${tournament.name} ${tournament.year}` : displayYear ? `FD Alumni Basketball Tournament ${displayYear}` : 'No active tournament loaded yet.'}
+          {tournament ? `${tournament.name} ${tournament.year}` : displayYear ? `FD Alumni Basketball Tournament ${displayYear}` : 'Tournament coverage will appear here when available.'}
         </p>
         {sources.length > 1 ? (
           <div className="mt-3 flex flex-wrap items-center gap-1.5">
@@ -172,7 +172,7 @@ export default async function NewsPage({
           style={{ borderColor: 'var(--border-subtle)', boxShadow: 'var(--shadow-card)' }}
         >
           <p className="text-sm" style={{ color: 'var(--neutral-500)' }}>
-            No news links yet. Add article links in Admin / News.
+            No coverage links are published for this filter yet. Check back for GSPN, Clutch, and tournament updates.
           </p>
         </div>
       ) : (

--- a/apps/web/src/app/(public)/news/page.tsx
+++ b/apps/web/src/app/(public)/news/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
-import { archiveArticlesForYear } from '@/lib/historical-archive'
+import { LATEST_ARCHIVE_YEAR, archiveArticlesForYear } from '@/lib/historical-archive'
 import { mergeArchiveArticles, type FeedArticle } from '@/lib/services/public-feed'
 
 export const metadata: Metadata = {
@@ -113,7 +113,7 @@ export default async function NewsPage({
       ? await withDatabaseFallback(() => db.tournament.findFirst({ where: { year: yearFilter } }), null)
       : await getActiveTournament()
 
-  const displayYear = yearFilter ?? tournament?.year ?? 2025
+  const displayYear = yearFilter ?? tournament?.year ?? LATEST_ARCHIVE_YEAR
 
   const dbNews = tournament
     ? await withDatabaseFallback(() => db.articleLink.findMany({

--- a/apps/web/src/app/(public)/news/page.tsx
+++ b/apps/web/src/app/(public)/news/page.tsx
@@ -6,6 +6,7 @@ import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 import { LATEST_ARCHIVE_YEAR, archiveArticlesForYear } from '@/lib/historical-archive'
 import { mergeArchiveArticles, type FeedArticle } from '@/lib/services/public-feed'
+import { formatGuamDate } from '@/lib/datetime'
 
 export const metadata: Metadata = {
   title: 'News',
@@ -23,7 +24,7 @@ function ExternalLinkIcon() {
 
 function NewsCard({ item, index }: { item: NewsItem; index: number }) {
   const date = item.publishedAt
-    ? new Date(item.publishedAt).toLocaleDateString('en-US', {
+    ? formatGuamDate(item.publishedAt, {
         month: 'long',
         day: 'numeric',
         year: 'numeric',

--- a/apps/web/src/app/(public)/news/page.tsx
+++ b/apps/web/src/app/(public)/news/page.tsx
@@ -106,7 +106,10 @@ export default async function NewsPage({
   const params = await searchParams
   const tournamentId = params.tournamentId ?? undefined
   const sourceFilter = params.source ?? null
-  const yearFilter = params.year ? Number(params.year) : null
+  const parsedYear = params.year ? Number(params.year) : null
+  const yearFilter = parsedYear && Number.isInteger(parsedYear) && parsedYear >= 1900 && parsedYear <= 2200
+    ? parsedYear
+    : null
 
   const tournament = tournamentId
     ? await withDatabaseFallback(() => db.tournament.findUnique({ where: { id: tournamentId } }), null)

--- a/apps/web/src/app/(public)/schedule/page.tsx
+++ b/apps/web/src/app/(public)/schedule/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getSchedule } from '@/lib/services/public-feed'
 import { DIVISIONS, getBracketCode, resolveGameDivision, getDivision } from '@/lib/divisions'
+import { formatGuamTime, guamDayLabel, isPastGuamGame } from '@/lib/datetime'
 
 export const metadata: Metadata = {
   title: 'Schedule',
@@ -25,15 +26,13 @@ type ScheduleGame = {
   awayTeam: { displayName: string; division: string | null }
 }
 
+type DisplayStatus = 'scheduled' | 'live' | 'final' | 'pending'
+
 function dayKey(date: Date) {
-  return date.toLocaleDateString('en-US', {
-    weekday: 'long',
-    month: 'long',
-    day: 'numeric',
-  })
+  return guamDayLabel(date)
 }
 
-function StatusBadge({ status }: { status: 'scheduled' | 'live' | 'final' }) {
+function StatusBadge({ status }: { status: DisplayStatus }) {
   if (status === 'live') {
     return (
       <span className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider badge-live">
@@ -46,6 +45,13 @@ function StatusBadge({ status }: { status: 'scheduled' | 'live' | 'final' }) {
     return (
       <span className="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider badge-final">
         Final
+      </span>
+    )
+  }
+  if (status === 'pending') {
+    return (
+      <span className="inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-semibold uppercase tracking-wider badge-final">
+        Result pending
       </span>
     )
   }
@@ -99,7 +105,11 @@ function ExternalIcon() {
 function GameRow({ game }: { game: ScheduleGame }) {
   const isLive = game.status === 'live'
   const isFinal = game.status === 'final'
-  const hasScore = isFinal && game.homeScore != null && game.awayScore != null
+  const hasRecordedScore = game.homeScore != null && game.awayScore != null
+  const hasScore = isFinal && hasRecordedScore
+  const displayStatus: DisplayStatus = game.status !== 'live' && !hasRecordedScore && isPastGuamGame(game.startTime)
+    ? 'pending'
+    : game.status
   const effectiveDivision = resolveGameDivision(game.division, game.homeTeam.division)
   const isFatherSon = game.bracketCode === 'FS' || /\bFS\b/i.test(game.homeTeam.displayName) || /\bFS\b/i.test(game.awayTeam.displayName)
 
@@ -115,7 +125,7 @@ function GameRow({ game }: { game: ScheduleGame }) {
         {/* Time + venue */}
         <div className="shrink-0 w-28">
           <p className="text-sm font-semibold tabular-nums" style={{ color: 'var(--neutral-700)' }}>
-            {new Date(game.startTime).toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+            {formatGuamTime(game.startTime)}
           </p>
           {game.venue && (
             <p className="text-xs mt-0.5 leading-snug" style={{ color: 'var(--neutral-400)' }}>{game.venue}</p>
@@ -147,7 +157,7 @@ function GameRow({ game }: { game: ScheduleGame }) {
               Father-Son
             </span>
           )}
-          <StatusBadge status={game.status} />
+          <StatusBadge status={displayStatus} />
           {game.streamUrl && (
             <div className="flex flex-col items-end gap-0.5">
               <Link

--- a/apps/web/src/app/(public)/schedule/page.tsx
+++ b/apps/web/src/app/(public)/schedule/page.tsx
@@ -107,7 +107,7 @@ function GameRow({ game }: { game: ScheduleGame }) {
   const isFinal = game.status === 'final'
   const hasRecordedScore = game.homeScore != null && game.awayScore != null
   const hasScore = isFinal && hasRecordedScore
-  const displayStatus: DisplayStatus = game.status !== 'live' && !hasRecordedScore && isPastGuamGame(game.startTime)
+  const displayStatus: DisplayStatus = game.status === 'scheduled' && !hasRecordedScore && isPastGuamGame(game.startTime)
     ? 'pending'
     : game.status
   const effectiveDivision = resolveGameDivision(game.division, game.homeTeam.division)
@@ -342,7 +342,7 @@ export default async function SchedulePage({
               )}
             </div>
             <p className="text-sm" style={{ color: 'var(--neutral-500)' }}>
-              {tournament ? `${tournament.name} ${tournament.year}` : 'No active tournament loaded yet.'}
+              {tournament ? `${tournament.name} ${tournament.year}` : 'Tournament schedule will appear here once published.'}
             </p>
           </div>
 
@@ -379,7 +379,7 @@ export default async function SchedulePage({
           <p className="text-sm" style={{ color: 'var(--neutral-500)' }}>
             {divisionFilter || phaseFilter
               ? `No games found for current filters${divisionFilter ? ` (${divisionFilter})` : ''}${phaseFilter ? ` (${phaseFilter})` : ''}.`
-              : 'No games yet. Seed data or add games from admin.'}
+              : 'No games are published yet. Check back for the tournament schedule.'}
           </p>
           {divisionFilter && (
             <Link

--- a/apps/web/src/app/(public)/sponsors/page.tsx
+++ b/apps/web/src/app/(public)/sponsors/page.tsx
@@ -2,7 +2,7 @@ export const dynamic = 'force-dynamic'
 
 import type { Metadata } from 'next'
 import Link from 'next/link'
-import { db } from '@/lib/db'
+import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 
 export const metadata: Metadata = {
@@ -63,10 +63,10 @@ function ExternalIcon() {
 export default async function SponsorsPage() {
   const tournament = await getActiveTournament()
   const sponsors = tournament
-    ? await db.sponsor.findMany({
+    ? await withDatabaseFallback(() => db.sponsor.findMany({
         where: { tournamentId: tournament.id, active: true },
         orderBy: [{ position: 'asc' }, { tier: 'asc' }, { name: 'asc' }],
-      })
+      }), [])
     : []
 
   const sponsorsByTier = sponsors.reduce<Record<string, typeof sponsors>>((acc, sponsor) => {

--- a/apps/web/src/app/(public)/sponsors/page.tsx
+++ b/apps/web/src/app/(public)/sponsors/page.tsx
@@ -1,10 +1,14 @@
+export const dynamic = 'force-dynamic'
+
 import type { Metadata } from 'next'
+import Link from 'next/link'
+import { db } from '@/lib/db'
+import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 
 export const metadata: Metadata = {
   title: 'Sponsors',
 }
 
-// Placeholder sponsor data until the DB tier is wired up
 const PLACEHOLDER_TIERS = [
   {
     tier: 'Presenting Sponsor',
@@ -48,21 +52,41 @@ function StarIcon() {
   )
 }
 
-export default function SponsorsPage() {
+function ExternalIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" aria-hidden="true">
+      <path d="M2 10L10 2M10 2H6M10 2V6" />
+    </svg>
+  )
+}
+
+export default async function SponsorsPage() {
+  const tournament = await getActiveTournament()
+  const sponsors = tournament
+    ? await db.sponsor.findMany({
+        where: { tournamentId: tournament.id, active: true },
+        orderBy: [{ position: 'asc' }, { tier: 'asc' }, { name: 'asc' }],
+      })
+    : []
+
+  const sponsorsByTier = sponsors.reduce<Record<string, typeof sponsors>>((acc, sponsor) => {
+    const tier = sponsor.tier || 'Community Supporter'
+    acc[tier] = acc[tier] ?? []
+    acc[tier].push(sponsor)
+    return acc
+  }, {})
+
   return (
     <section className="space-y-8">
-
-      {/* Page header */}
       <div className="animate-fade-up">
         <h1 className="text-2xl font-bold md:text-3xl" style={{ color: 'var(--fd-maroon)' }}>
           Sponsors
         </h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          Partners who make FD Alumni Basketball possible.
+          {tournament ? `${tournament.name} ${tournament.year}` : 'Partners who make FD Alumni Basketball possible.'}
         </p>
       </div>
 
-      {/* Hero strip */}
       <div
         className="relative overflow-hidden rounded-2xl p-6 md:p-8 animate-fade-up delay-75"
         style={{
@@ -84,8 +108,7 @@ export default function SponsorsPage() {
             Partner with the FD Alumni Tournament
           </h2>
           <p className="text-sm leading-relaxed mb-5" style={{ color: 'rgba(240,232,236,0.7)' }}>
-            Connect your brand with Guam basketball fans and support the alumni community. 
-            Multiple tiers available for businesses of every size.
+            Connect your brand with Guam basketball fans and support the alumni community. Multiple tiers available for businesses of every size.
           </p>
           <a
             href="mailto:info@fdalumni.com"
@@ -98,94 +121,98 @@ export default function SponsorsPage() {
         </div>
       </div>
 
-      {/* Tiers */}
-      <div className="space-y-4">
-        <h2 className="text-sm font-semibold uppercase tracking-[0.1em]" style={{ color: 'var(--neutral-500)' }}>
-          Sponsorship Tiers
-        </h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          {PLACEHOLDER_TIERS.map((t, i) => (
-            <div
-              key={t.tier}
-              className="rounded-xl border p-5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md animate-fade-up"
-              style={{
-                background: t.bg,
-                borderColor: t.border,
-                boxShadow: 'var(--shadow-card)',
-                animationDelay: `${(i + 2) * 75}ms`,
-              }}
-            >
-              {/* Tier header */}
-              <div className="flex items-center justify-between mb-3">
-                <span
-                  className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold"
-                  style={{ background: t.color, color: '#fff' }}
-                >
-                  <StarIcon />
-                  {t.tier}
-                </span>
-                <span
-                  className="text-xs font-medium"
-                  style={{ color: 'var(--neutral-500)' }}
-                >
-                  Up to {t.slots} {t.slots === 1 ? 'slot' : 'slots'}
-                </span>
-              </div>
-              <p className="text-sm leading-relaxed" style={{ color: 'var(--neutral-600)' }}>
-                {t.description}
-              </p>
+      {sponsors.length > 0 ? (
+        <div className="space-y-5">
+          {Object.entries(sponsorsByTier).map(([tier, tierSponsors], tierIndex) => (
+            <div key={tier} className="space-y-3">
+              <h2 className="text-sm font-semibold uppercase tracking-[0.1em]" style={{ color: 'var(--neutral-500)' }}>
+                {tier}
+              </h2>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {tierSponsors.map((sponsor, i) => {
+                  const card = (
+                    <article
+                      className="rounded-xl border bg-white p-5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md animate-fade-up"
+                      style={{
+                        borderColor: 'var(--border-subtle)',
+                        boxShadow: 'var(--shadow-card)',
+                        animationDelay: `${(tierIndex + i) * 60}ms`,
+                      }}
+                    >
+                      <div className="flex min-h-20 items-center justify-center rounded-lg border bg-white p-4" style={{ borderColor: 'var(--border-subtle)' }}>
+                        {sponsor.logoUrl ? (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img src={sponsor.logoUrl} alt={sponsor.name} className="max-h-16 object-contain" loading="lazy" />
+                        ) : (
+                          <span className="text-lg font-semibold" style={{ color: 'var(--fd-ink)' }}>{sponsor.name}</span>
+                        )}
+                      </div>
+                      <div className="mt-4 flex items-center justify-between gap-3">
+                        <div>
+                          <p className="font-semibold" style={{ color: 'var(--fd-ink)' }}>{sponsor.name}</p>
+                          {sponsor.tier ? <p className="text-xs" style={{ color: 'var(--neutral-500)' }}>{sponsor.tier}</p> : null}
+                        </div>
+                        {sponsor.targetUrl ? <ExternalIcon /> : null}
+                      </div>
+                    </article>
+                  )
 
-              {/* Placeholder logo grid */}
-              <div className="mt-4 flex flex-wrap gap-2">
-                {Array.from({ length: Math.min(t.slots, 3) }).map((_, j) => (
-                  <div
-                    key={j}
-                    className="flex items-center justify-center rounded-lg text-xs font-medium"
-                    style={{
-                      width: '80px',
-                      height: '40px',
-                      background: 'rgba(255,255,255,0.5)',
-                      border: `1px dashed ${t.border}`,
-                      color: 'var(--neutral-400)',
-                    }}
-                  >
-                    Your logo
-                  </div>
-                ))}
-                {t.slots > 3 && (
-                  <div
-                    className="flex items-center justify-center rounded-lg text-xs"
-                    style={{ width: '80px', height: '40px', color: 'var(--neutral-400)' }}
-                  >
-                    +{t.slots - 3} more
-                  </div>
-                )}
+                  return sponsor.targetUrl ? (
+                    <Link key={sponsor.id} href={sponsor.targetUrl} target="_blank" rel="noopener noreferrer">
+                      {card}
+                    </Link>
+                  ) : (
+                    <div key={sponsor.id}>{card}</div>
+                  )
+                })}
               </div>
             </div>
           ))}
         </div>
-      </div>
+      ) : (
+        <div className="space-y-4">
+          <h2 className="text-sm font-semibold uppercase tracking-[0.1em]" style={{ color: 'var(--neutral-500)' }}>
+            Sponsorship Tiers
+          </h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            {PLACEHOLDER_TIERS.map((t, i) => (
+              <div
+                key={t.tier}
+                className="rounded-xl border p-5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-md animate-fade-up"
+                style={{
+                  background: t.bg,
+                  borderColor: t.border,
+                  boxShadow: 'var(--shadow-card)',
+                  animationDelay: `${(i + 2) * 75}ms`,
+                }}
+              >
+                <div className="flex items-center justify-between mb-3">
+                  <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold" style={{ background: t.color, color: '#fff' }}>
+                    <StarIcon />
+                    {t.tier}
+                  </span>
+                  <span className="text-xs font-medium" style={{ color: 'var(--neutral-500)' }}>
+                    Up to {t.slots} {t.slots === 1 ? 'slot' : 'slots'}
+                  </span>
+                </div>
+                <p className="text-sm leading-relaxed" style={{ color: 'var(--neutral-600)' }}>{t.description}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
 
-      {/* Contact CTA */}
-      <div
-        className="rounded-xl border bg-white p-6 text-center animate-fade-up"
-        style={{ borderColor: 'var(--border-subtle)', boxShadow: 'var(--shadow-card)', animationDelay: '450ms' }}
-      >
+      <div className="rounded-xl border bg-white p-6 text-center animate-fade-up" style={{ borderColor: 'var(--border-subtle)', boxShadow: 'var(--shadow-card)', animationDelay: '450ms' }}>
         <p className="text-sm font-medium mb-1" style={{ color: 'var(--fd-ink)' }}>
           Interested in sponsoring?
         </p>
         <p className="text-xs mb-4" style={{ color: 'var(--neutral-500)' }}>
           Contact the tournament organizers to discuss packages and availability.
         </p>
-        <a
-          href="mailto:info@fdalumni.com"
-          className="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-200 hover:-translate-y-0.5"
-          style={{ background: 'var(--fd-maroon)', color: '#fff' }}
-        >
+        <a href="mailto:info@fdalumni.com" className="inline-flex items-center gap-2 rounded-xl px-5 py-2.5 text-sm font-semibold transition-all duration-200 hover:-translate-y-0.5" style={{ background: 'var(--fd-maroon)', color: '#fff' }}>
           Contact Us
         </a>
       </div>
-
     </section>
   )
 }

--- a/apps/web/src/app/(public)/standings/page.tsx
+++ b/apps/web/src/app/(public)/standings/page.tsx
@@ -129,7 +129,7 @@ export default async function StandingsPage({
             Standings
           </h1>
           <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-            {tournament ? `${tournament.name} ${tournament.year}` : 'No active tournament loaded yet.'}
+            {tournament ? `${tournament.name} ${tournament.year}` : 'Standings will appear here as results are confirmed.'}
             {activeDiv ? ` · ${activeDiv.label}` : ''}
           </p>
         </div>
@@ -155,7 +155,7 @@ export default async function StandingsPage({
           <p className="text-sm" style={{ color: 'var(--neutral-500)' }}>
             {divisionFilter
               ? `No standings found for the ${divisionFilter} division.`
-              : 'No standings yet. Add teams and scores from admin.'}
+              : 'Standings will appear once teams and confirmed results are published.'}
           </p>
           {divisionFilter && (
             <Link href="/standings" className="mt-3 inline-block text-xs font-medium" style={{ color: 'var(--fd-maroon)' }}>

--- a/apps/web/src/app/(public)/watch/page.tsx
+++ b/apps/web/src/app/(public)/watch/page.tsx
@@ -3,6 +3,7 @@ export const dynamic = 'force-dynamic'
 import type { Metadata } from 'next'
 import Link from 'next/link'
 import { getSchedule } from '@/lib/services/public-feed'
+import { formatGuamDate, formatGuamTime } from '@/lib/datetime'
 
 export const metadata: Metadata = {
   title: 'Watch',
@@ -36,7 +37,6 @@ function ExternalIcon() {
 function GameStreamCard({ game }: { game: WatchGame }) {
   const isLive = game.status === 'live'
   const isFinal = game.status === 'final'
-  const date = new Date(game.startTime)
 
   return (
     <div
@@ -69,9 +69,9 @@ function GameStreamCard({ game }: { game: WatchGame }) {
             </span>
           )}
           <span className="text-xs tabular-nums" style={{ color: 'var(--neutral-400)' }}>
-            {date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+            {formatGuamDate(game.startTime, { month: 'short', day: 'numeric' })}
             {' · '}
-            {date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })}
+            {formatGuamTime(game.startTime)}
           </span>
         </div>
 
@@ -204,13 +204,13 @@ export default async function WatchPage({
             <div className="flex items-center gap-2">
               <div>
                 <p className="text-sm font-semibold" style={{ color: 'var(--fd-ink)' }}>Clutch</p>
-                <p className="text-xs" style={{ color: 'var(--neutral-500)' }}>Official streaming partner</p>
+                <p className="text-xs" style={{ color: 'var(--neutral-500)' }}>Streaming partner</p>
               </div>
             </div>
             <div className="flex items-center gap-2">
               <div>
                 <p className="text-sm font-semibold" style={{ color: 'var(--fd-ink)' }}>GuamTime</p>
-                <p className="text-xs" style={{ color: 'var(--neutral-500)' }}>Official ticketing partner</p>
+                <p className="text-xs" style={{ color: 'var(--neutral-500)' }}>Ticketing partner</p>
               </div>
             </div>
           </div>

--- a/apps/web/src/app/(public)/watch/page.tsx
+++ b/apps/web/src/app/(public)/watch/page.tsx
@@ -141,7 +141,7 @@ export default async function WatchPage({
           Watch
         </h1>
         <p className="mt-1 text-sm" style={{ color: 'var(--neutral-500)' }}>
-          {tournament ? `${tournament.name} ${tournament.year}` : 'No active tournament loaded yet.'}
+          {tournament ? `${tournament.name} ${tournament.year}` : 'Stream links and replays will appear here when available.'}
         </p>
       </div>
 
@@ -154,7 +154,7 @@ export default async function WatchPage({
             <PlayIcon size={28} />
           </div>
           <p className="text-sm" style={{ color: 'var(--neutral-500)' }}>
-            No stream links yet. Add stream URLs to games from the admin panel.
+            No Clutch stream links are published yet. Check back closer to game time for live games and replays.
           </p>
         </div>
       ) : (

--- a/apps/web/src/app/admin/games/page.tsx
+++ b/apps/web/src/app/admin/games/page.tsx
@@ -70,7 +70,7 @@ export default async function AdminGamesPage() {
         </div>
       </div>
       <GameCreateForm tournamentId={tournament.id} teams={teamOptions} />
-      <GameEditor initialGames={games as any} />
+      <GameEditor initialGames={games} />
     </section>
   )
 }

--- a/apps/web/src/app/admin/links/page.tsx
+++ b/apps/web/src/app/admin/links/page.tsx
@@ -41,16 +41,16 @@ export default async function AdminLinksPage() {
         <p className="text-sm text-neutral-600 mb-3">{tournament.name} {tournament.year}</p>
         <div className="flex flex-wrap gap-4">
           <div className="rounded-lg px-3 py-2 text-sm font-medium" style={{ background: missingTicket > 0 ? '#fef2f2' : '#f0fdf4', color: missingTicket > 0 ? '#dc2626' : '#16a34a' }}>
-            🎟️ {missingTicket} games missing ticket link
+            Ticket links missing: {missingTicket}
           </div>
           <div className="rounded-lg px-3 py-2 text-sm font-medium" style={{ background: missingStream > 0 ? '#fef2f2' : '#f0fdf4', color: missingStream > 0 ? '#dc2626' : '#16a34a' }}>
-            📺 {missingStream} games missing stream link
+            Stream links missing: {missingStream}
           </div>
         </div>
         {/* Partner Integration Help */}
         <div className="mt-4 rounded-lg border p-4" style={{ borderColor: 'var(--border-subtle)', background: 'var(--neutral-50)' }}>
           <p className="text-xs font-semibold uppercase tracking-[0.08em] mb-2" style={{ color: 'var(--fd-maroon)' }}>
-            🤝 Partner Integration Quick Guide
+            Partner Integration Quick Guide
           </p>
           <ul className="text-xs space-y-1.5" style={{ color: 'var(--neutral-600)' }}>
             <li>• <strong>GuamTime (Tickets):</strong> Use Bulk Fill to apply ticket URLs by filtering a division/phase first</li>
@@ -63,7 +63,7 @@ export default async function AdminLinksPage() {
           </p>
         </div>
       </div>
-      <BulkLinkEditor initialGames={games as any} />
+      <BulkLinkEditor initialGames={games} />
     </section>
   )
 }

--- a/apps/web/src/app/admin/loading.tsx
+++ b/apps/web/src/app/admin/loading.tsx
@@ -1,14 +1,16 @@
+const navSkeletonWidths = [84, 112, 96, 124, 88, 108]
+
 export default function AdminLoading() {
   return (
     <section className="space-y-4 animate-fade-up">
       {/* Nav skeleton */}
       <div className="rounded-xl border bg-white p-1.5 shadow-sm" style={{ borderColor: 'var(--border-subtle)' }}>
         <div className="flex flex-wrap gap-1">
-          {Array.from({ length: 6 }).map((_, i) => (
+          {navSkeletonWidths.map((width, i) => (
             <div
               key={i}
               className="skeleton h-9 rounded-lg"
-              style={{ width: `${80 + Math.random() * 40}px`, animationDelay: `${i * 50}ms` }}
+              style={{ width: `${width}px`, animationDelay: `${i * 50}ms` }}
             />
           ))}
         </div>

--- a/apps/web/src/app/admin/missing-links/page.tsx
+++ b/apps/web/src/app/admin/missing-links/page.tsx
@@ -4,6 +4,7 @@ import { requireStaff } from '@/lib/authz'
 import { AdminNav } from '@/components/admin/admin-nav'
 import { getActiveTournament } from '@/lib/repositories/tournament-repo'
 import { db } from '@/lib/db'
+import { formatGuamDate } from '@/lib/datetime'
 
 export const dynamic = 'force-dynamic'
 
@@ -79,18 +80,18 @@ export default async function MissingLinksPage() {
       {/* Partner Help */}
       <div className="rounded-xl border p-4" style={{ borderColor: 'var(--fd-maroon)', borderStyle: 'dashed', background: '#fef7f7' }}>
         <p className="text-xs font-semibold uppercase tracking-[0.08em] mb-2" style={{ color: 'var(--fd-maroon)' }}>
-          📋 What Partners Need to Provide
+          What Partners Need to Provide
         </p>
         <div className="grid gap-3 sm:grid-cols-2 text-xs" style={{ color: 'var(--neutral-600)' }}>
           <div>
-            <p className="font-semibold mb-1">🎟️ GuamTime (Ticketing)</p>
+            <p className="font-semibold mb-1">GuamTime (Ticketing)</p>
             <ul className="space-y-0.5 text-[11px]">
               <li>• Ticket purchase URLs per game (or single event page)</li>
               <li>• Match by date + matchup from our CSV export</li>
             </ul>
           </div>
           <div>
-            <p className="font-semibold mb-1">📺 Clutch (Streaming)</p>
+            <p className="font-semibold mb-1">Clutch (Streaming)</p>
             <ul className="space-y-0.5 text-[11px]">
               <li>• Stream/replay URLs per game</li>
               <li>• Can be live or VOD links</li>
@@ -132,7 +133,7 @@ export default async function MissingLinksPage() {
       {hasEither.length === 0 ? (
         <div className="rounded-xl border bg-white p-8 text-center" style={{ borderColor: 'var(--border-subtle)' }}>
           <p className="text-sm font-medium" style={{ color: '#16a34a' }}>
-            ✅ All games have both ticket and stream links!
+            All games have both ticket and stream links.
           </p>
         </div>
       ) : (
@@ -150,8 +151,8 @@ export default async function MissingLinksPage() {
                   <th className="px-4 py-3">Matchup</th>
                   <th className="px-4 py-3">Div</th>
                   <th className="px-4 py-3">Phase</th>
-                  <th className="px-4 py-3 text-center">🎟️ Ticket</th>
-                  <th className="px-4 py-3 text-center">📺 Stream</th>
+                  <th className="px-4 py-3 text-center">Ticket</th>
+                  <th className="px-4 py-3 text-center">Stream</th>
                 </tr>
               </thead>
               <tbody className="divide-y" style={{ borderColor: 'var(--border-subtle)' }}>
@@ -164,7 +165,7 @@ export default async function MissingLinksPage() {
                       className="hover:bg-neutral-50 transition-colors"
                     >
                       <td className="px-4 py-3 whitespace-nowrap tabular-nums text-xs" style={{ color: 'var(--neutral-500)' }}>
-                        {new Date(g.startTime).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })}
+                        {formatGuamDate(g.startTime, { month: 'short', day: 'numeric' })}
                       </td>
                       <td className="px-4 py-3">
                         <span className="font-medium" style={{ color: 'var(--fd-ink)' }}>
@@ -182,14 +183,14 @@ export default async function MissingLinksPage() {
                       </td>
                       <td className="px-4 py-3 text-center">
                         {g.ticketUrl ? (
-                          <span style={{ color: '#16a34a' }}>✓</span>
+                          <span className="text-xs font-semibold" style={{ color: '#16a34a' }}>OK</span>
                         ) : (
                           <span className="text-xs font-semibold" style={{ color: '#dc2626' }}>Missing</span>
                         )}
                       </td>
                       <td className="px-4 py-3 text-center">
                         {g.streamUrl ? (
-                          <span style={{ color: '#16a34a' }}>✓</span>
+                          <span className="text-xs font-semibold" style={{ color: '#16a34a' }}>OK</span>
                         ) : (
                           <span className="text-xs font-semibold" style={{ color: '#dc2626' }}>Missing</span>
                         )}

--- a/apps/web/src/app/admin/news/page.tsx
+++ b/apps/web/src/app/admin/news/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminNewsPage() {
         <p className="text-sm text-neutral-600">Edit existing article links via API (UI CRUD next slice).</p>
       </div>
       <NewsCreateForm tournamentId={tournament.id} />
-      <AdminNewsList initialArticles={articles as any} />
+      <AdminNewsList initialArticles={articles} />
     </section>
   )
 }

--- a/apps/web/src/app/admin/page.tsx
+++ b/apps/web/src/app/admin/page.tsx
@@ -2,6 +2,8 @@ import { AdminNav } from '@/components/admin/admin-nav'
 import { HistoricalImportForm } from '@/components/admin/historical-import-form'
 import { DataHealthCard } from '@/components/admin/data-health-card'
 
+export const dynamic = 'force-dynamic'
+
 export default async function AdminHome() {
   return (
     <section className="space-y-4">

--- a/apps/web/src/app/admin/sponsors/page.tsx
+++ b/apps/web/src/app/admin/sponsors/page.tsx
@@ -25,7 +25,7 @@ export default async function AdminSponsorsPage() {
         <p className="text-sm text-neutral-600">Edit sponsors via API patch endpoint (full CRUD UI next slice).</p>
       </div>
       <SponsorCreateForm tournamentId={tournament.id} />
-      <AdminSponsorsList initialSponsors={sponsors as any} />
+      <AdminSponsorsList initialSponsors={sponsors} />
     </section>
   )
 }

--- a/apps/web/src/app/api/public/schedule/route.ts
+++ b/apps/web/src/app/api/public/schedule/route.ts
@@ -4,6 +4,8 @@ import { getSchedule } from '@/lib/services/public-feed'
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const tournamentId = searchParams.get('tournamentId') || undefined
-  const data = await getSchedule(tournamentId)
+  const division = searchParams.get('division') || undefined
+  const phase = searchParams.get('phase') as 'pool' | 'playoff' | 'fatherson' | null
+  const data = await getSchedule(tournamentId, division, phase)
   return NextResponse.json(data)
 }

--- a/apps/web/src/app/api/public/standings/route.ts
+++ b/apps/web/src/app/api/public/standings/route.ts
@@ -4,6 +4,7 @@ import { getStandings } from '@/lib/services/public-feed'
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const tournamentId = searchParams.get('tournamentId') || undefined
-  const data = await getStandings(tournamentId)
+  const division = searchParams.get('division') || undefined
+  const data = await getStandings(tournamentId, division)
   return NextResponse.json(data)
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -14,10 +14,10 @@ export const metadata: Metadata = {
     default: 'FD Alumni Basketball Hub',
     template: '%s — FD Alumni Hub',
   },
-  description: 'The official hub for FD Alumni Basketball. Schedule, standings, watch links, and verified updates for the tournament.',
+  description: 'A central hub for FD Alumni Basketball schedules, standings, watch links, tickets, and partner coverage.',
   openGraph: {
     title: 'FD Alumni Basketball Hub',
-    description: 'Schedule, standings, watch links, and updates for the FD Alumni Tournament.',
+    description: 'Schedule, standings, watch links, tickets, and partner coverage for the FD Alumni Tournament.',
     type: 'website',
   },
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { getHomeFeed } from '@/lib/services/public-feed'
 import { QuickCard } from '@/components/quick-card'
 import { LiveUpdates } from '@/components/live-updates'
+import { LATEST_ARCHIVE_YEAR } from '@/lib/historical-archive'
 
 function CalendarIcon() {
   return (
@@ -175,7 +176,7 @@ export default async function Home() {
                 {latestResultsTournament
                   ? `${latestResultsTournament.year} COMPLETED`
                   : isArchivePreview
-                    ? '2025 coverage'
+                    ? `${LATEST_ARCHIVE_YEAR} coverage`
                     : 'No data yet'}
               </span>
             </span>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -87,7 +87,7 @@ export default async function Home() {
               </span>
             ) : (
               <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold" style={{ background: 'rgba(217,178,111,0.15)', color: 'var(--fd-gold)', border: '1px solid rgba(217,178,111,0.25)' }}>
-                Official Tournament Hub
+                Tournament Hub
               </span>
             )}
           </div>
@@ -203,7 +203,7 @@ export default async function Home() {
       </div>
 
       {/* ── Latest updates ────────────────────────────────────── */}
-      <LiveUpdates items={latestNews as any} />
+      <LiveUpdates items={latestNews} />
 
     </section>
   )

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -48,6 +48,7 @@ export default async function Home() {
   } = await getHomeFeed()
 
   const isLive = liveGames.length > 0
+  const isArchivePreview = !tournament && latestNews.length > 0
 
   return (
     <section className="space-y-6">
@@ -87,7 +88,7 @@ export default async function Home() {
               </span>
             ) : (
               <span className="inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold" style={{ background: 'rgba(217,178,111,0.15)', color: 'var(--fd-gold)', border: '1px solid rgba(217,178,111,0.25)' }}>
-                Tournament Hub
+                {isArchivePreview ? 'Archive Preview' : 'Tournament Hub'}
               </span>
             )}
           </div>
@@ -109,7 +110,9 @@ export default async function Home() {
           >
             {tournament
               ? `${tournament.name} ${tournament.year} — schedule, standings, watch links, and verified updates.`
-              : 'Single source of truth for schedule, standings, watch links, and tournament updates.'}
+              : isArchivePreview
+                ? 'Browse researched historical coverage while live schedule data is not connected locally.'
+                : 'Single source of truth for schedule, standings, watch links, and tournament updates.'}
           </p>
 
           {/* CTA buttons */}
@@ -160,7 +163,9 @@ export default async function Home() {
               <span className="font-semibold" style={{ color: 'rgba(240,232,236,0.85)' }}>
                 {upcomingOrLiveTournament
                   ? `${upcomingOrLiveTournament.year} ${upcomingOrLiveTournament.status.toUpperCase()}`
-                  : 'None'}
+                  : isArchivePreview
+                    ? 'Archive preview'
+                    : 'None'}
               </span>
             </span>
             <span style={{ color: 'rgba(255,255,255,0.15)' }}>|</span>
@@ -169,7 +174,9 @@ export default async function Home() {
               <span className="font-semibold" style={{ color: 'rgba(240,232,236,0.85)' }}>
                 {latestResultsTournament
                   ? `${latestResultsTournament.year} COMPLETED`
-                  : 'No data yet'}
+                  : isArchivePreview
+                    ? '2025 coverage'
+                    : 'No data yet'}
               </span>
             </span>
           </div>
@@ -196,8 +203,8 @@ export default async function Home() {
         />
         <QuickCard
           title="Tournament"
-          value={tournament ? tournament.status.toUpperCase() : '—'}
-          sub={tournament ? tournament.name : 'No active tournament'}
+          value={tournament ? tournament.status.toUpperCase() : isArchivePreview ? 'ARCHIVE' : '—'}
+          sub={tournament ? tournament.name : isArchivePreview ? 'Connect DB for live data' : 'No active tournament'}
           accent="neutral"
         />
       </div>

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,6 +1,19 @@
 import { SignIn } from '@clerk/nextjs'
 
 export default function Page() {
+  if (!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
+    return (
+      <div className="mx-auto flex min-h-[60vh] max-w-md items-center justify-center">
+        <div className="rounded-xl border bg-white p-6 text-center" style={{ borderColor: 'var(--border-subtle)', boxShadow: 'var(--shadow-card)' }}>
+          <h1 className="text-lg font-semibold" style={{ color: 'var(--fd-maroon)' }}>Admin sign-in unavailable</h1>
+          <p className="mt-2 text-sm" style={{ color: 'var(--neutral-500)' }}>
+            Clerk is not configured in this environment. Add NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY to enable admin access.
+          </p>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="mx-auto flex min-h-[60vh] max-w-md items-center justify-center">
       <SignIn />

--- a/apps/web/src/components/admin/bulk-link-editor.tsx
+++ b/apps/web/src/components/admin/bulk-link-editor.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { DIVISIONS } from '@/lib/divisions'
+import { formatGuamDateTime } from '@/lib/datetime'
 import { Filter, Zap, Save, Edit3, Calendar } from 'lucide-react'
 import {
   AdminInput,
@@ -13,7 +14,6 @@ import {
   AdminMessage,
   AdminEmptyState,
   AdminBadge,
-  inputBaseClasses,
 } from './ui'
 
 function isValidUrl(value: string) {
@@ -28,7 +28,7 @@ function isValidUrl(value: string) {
 
 type GameLink = {
   id: string
-  startTime: string
+  startTime: string | Date
   division: string | null
   bracketCode: string | null
   ticketUrl: string | null
@@ -51,7 +51,7 @@ type LocalEdit = {
 
 export function BulkLinkEditor({ initialGames }: { initialGames: GameLink[] }) {
   const router = useRouter()
-  const [games, setGames] = useState<GameLink[]>(initialGames)
+  const [games] = useState<GameLink[]>(initialGames)
   const [edits, setEdits] = useState<Record<string, LocalEdit>>({})
   const [saving, setSaving] = useState(false)
   const [msg, setMsg] = useState<{ text: string; ok: boolean } | null>(null)
@@ -61,11 +61,11 @@ export function BulkLinkEditor({ initialGames }: { initialGames: GameLink[] }) {
   const [bulkTicket, setBulkTicket] = useState('')
   const [bulkStream, setBulkStream] = useState('')
 
-  const currentVal = (g: GameLink, field: 'ticketUrl' | 'streamUrl') => {
+  const currentVal = useCallback((g: GameLink, field: 'ticketUrl' | 'streamUrl') => {
     const e = edits[g.id]
     if (e && Object.prototype.hasOwnProperty.call(e, field)) return e[field] ?? ''
     return g[field] ?? ''
-  }
+  }, [edits])
 
   const updateEdit = (id: string, field: 'ticketUrl' | 'streamUrl', value: string) => {
     setEdits((prev) => ({
@@ -101,7 +101,7 @@ export function BulkLinkEditor({ initialGames }: { initialGames: GameLink[] }) {
         return false
       return true
     })
-  }, [games, edits, filters])
+  }, [games, currentVal, filters])
 
   const dirtyGames = Object.entries(edits).filter(([, e]) => e.dirty)
 
@@ -348,12 +348,7 @@ export function BulkLinkEditor({ initialGames }: { initialGames: GameLink[] }) {
                   </p>
                   <span className="flex items-center gap-1.5 text-xs text-[var(--neutral-400)]">
                     <Calendar className="h-3 w-3" />
-                    {new Date(g.startTime).toLocaleString('en-US', {
-                      month: 'short',
-                      day: 'numeric',
-                      hour: 'numeric',
-                      minute: '2-digit',
-                    })}
+                    {formatGuamDateTime(g.startTime)}
                   </span>
                   {g.division && (
                     <AdminBadge variant="default">{g.division}</AdminBadge>

--- a/apps/web/src/components/admin/game-editor.tsx
+++ b/apps/web/src/components/admin/game-editor.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { DIVISIONS, BRACKET_CODES } from '@/lib/divisions'
+import { formatGuamDateTime } from '@/lib/datetime'
 import { Calendar, Trash2, Save } from 'lucide-react'
 import {
   AdminInput,
@@ -11,7 +12,6 @@ import {
   AdminBadge,
   AdminMessage,
   AdminEmptyState,
-  inputBaseClasses,
 } from './ui'
 
 function isValidUrl(value: string) {
@@ -24,9 +24,9 @@ function isValidUrl(value: string) {
   }
 }
 
-type GameRow = {
+export type GameRow = {
   id: string
-  startTime: string
+  startTime: string | Date
   status: 'scheduled' | 'live' | 'final'
   homeScore: number | null
   awayScore: number | null
@@ -164,13 +164,7 @@ export function GameEditor({ initialGames }: { initialGames: GameRow[] }) {
 
               <span className="ml-auto flex items-center gap-1.5 text-xs text-[var(--neutral-400)]">
                 <Calendar className="h-3.5 w-3.5" />
-                {new Date(g.startTime).toLocaleString('en-US', {
-                  weekday: 'short',
-                  month: 'short',
-                  day: 'numeric',
-                  hour: 'numeric',
-                  minute: '2-digit',
-                })}
+                {formatGuamDateTime(g.startTime)}
               </span>
             </div>
 

--- a/apps/web/src/components/admin/import-historical-form.tsx
+++ b/apps/web/src/components/admin/import-historical-form.tsx
@@ -3,7 +3,7 @@
 import { useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { History } from 'lucide-react'
-import { AdminFileInput, AdminButton, AdminCard, AdminCardTitle, AdminMessage } from './ui'
+import { AdminButton, AdminCard, AdminCardTitle, AdminMessage } from './ui'
 
 export function ImportHistoricalForm() {
   const [msg, setMsg] = useState<{ text: string; ok: boolean } | null>(null)

--- a/apps/web/src/components/admin/ingest-review-list.tsx
+++ b/apps/web/src/components/admin/ingest-review-list.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { Inbox, ExternalLink, CheckCircle2, XCircle, Clock } from 'lucide-react'
+import { Inbox, ExternalLink, CheckCircle2, XCircle, Clock, FileText, Image as ImageIcon } from 'lucide-react'
 import { AdminButton, AdminEmptyState, AdminMessage, AdminBadge } from './ui'
 
 type Item = {
@@ -111,7 +111,11 @@ export function IngestReviewList({ items }: { items: Item[] }) {
                 {/* Badges */}
                 <div className="mb-2 flex flex-wrap items-center gap-2">
                   <AdminBadge variant="default">
-                    {item.kind === 'article' ? '📄 Article' : '🖼️ Media'}
+                    {item.kind === 'article' ? (
+                      <><FileText className="mr-1 h-3 w-3" /> Article</>
+                    ) : (
+                      <><ImageIcon className="mr-1 h-3 w-3" /> Media</>
+                    )}
                   </AdminBadge>
                   <AdminBadge variant="default">{item.source}</AdminBadge>
                   <span className={`flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-semibold ${status.bg} ${status.text}`}>

--- a/apps/web/src/components/admin/media-list.tsx
+++ b/apps/web/src/components/admin/media-list.tsx
@@ -2,6 +2,7 @@
 
 import { Image as ImageIcon, ExternalLink, Calendar, Tag } from 'lucide-react'
 import { AdminEmptyState, AdminBadge } from './ui'
+import { formatGuamDate } from '@/lib/datetime'
 
 type MediaItem = {
   id: string
@@ -90,7 +91,7 @@ export function AdminMediaList({ items }: { items: MediaItem[] }) {
               <span className="flex items-center gap-1.5">
                 <Calendar className="h-3.5 w-3.5" />
                 {item.takenAt
-                  ? new Date(item.takenAt).toLocaleDateString('en-US', {
+                  ? formatGuamDate(item.takenAt, {
                       month: 'short',
                       day: 'numeric',
                       year: 'numeric',

--- a/apps/web/src/components/admin/news-list.tsx
+++ b/apps/web/src/components/admin/news-list.tsx
@@ -10,7 +10,7 @@ type Article = {
   title: string
   source: string
   url?: string
-  publishedAt: string | null
+  publishedAt: string | Date | null
 }
 
 export function AdminNewsList({ initialArticles }: { initialArticles: Article[] }) {

--- a/apps/web/src/components/admin/news-list.tsx
+++ b/apps/web/src/components/admin/news-list.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { Newspaper, Calendar, Trash2, ExternalLink } from 'lucide-react'
 import { AdminButton, AdminEmptyState, AdminMessage, AdminBadge } from './ui'
+import { formatGuamDate } from '@/lib/datetime'
 
 type Article = {
   id: string
@@ -67,7 +68,7 @@ export function AdminNewsList({ initialArticles }: { initialArticles: Article[] 
                   {a.publishedAt && (
                     <span className="flex items-center gap-1.5 text-xs text-[var(--neutral-400)]">
                       <Calendar className="h-3 w-3" />
-                      {new Date(a.publishedAt).toLocaleDateString('en-US', {
+                      {formatGuamDate(a.publishedAt, {
                         month: 'short',
                         day: 'numeric',
                         year: 'numeric',

--- a/apps/web/src/components/admin/recompute-standings-button.tsx
+++ b/apps/web/src/components/admin/recompute-standings-button.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { RefreshCw } from 'lucide-react'
 import { AdminButton, AdminMessage } from './ui'
+import { formatGuamDateTime } from '@/lib/datetime'
 
 export function RecomputeStandingsButton({ tournamentId }: { tournamentId: string }) {
   const router = useRouter()
@@ -59,7 +60,7 @@ export function RecomputeStandingsButton({ tournamentId }: { tournamentId: strin
         )}
         {lastRunAt && (
           <p className="text-xs text-neutral-500">
-            Last recompute: {lastRunAt.toLocaleString()}
+            Last recompute: {formatGuamDateTime(lastRunAt)}
           </p>
         )}
       </div>

--- a/apps/web/src/components/admin/tournament-selector.tsx
+++ b/apps/web/src/components/admin/tournament-selector.tsx
@@ -39,9 +39,10 @@ export function TournamentSelector() {
     }
   }, [open])
 
-  useEffect(() => {
-    if (!open) setShowAllCompleted(false)
-  }, [open])
+  const toggleOpen = () => {
+    if (open) setShowAllCompleted(false)
+    setOpen(!open)
+  }
 
   const activeTournaments = tournaments.filter(
     (t) => t.status === 'live' || t.status === 'upcoming',
@@ -64,7 +65,7 @@ export function TournamentSelector() {
       <button
         ref={triggerRef}
         type="button"
-        onClick={() => setOpen(!open)}
+        onClick={toggleOpen}
         disabled={isLoading}
         aria-expanded={open}
         aria-haspopup="menu"

--- a/apps/web/src/components/live-updates.tsx
+++ b/apps/web/src/components/live-updates.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { formatGuamDate } from '@/lib/datetime'
 
 type UpdateItem = {
   id: string
@@ -48,7 +49,7 @@ export function LiveUpdates({ items }: { items: UpdateItem[] }) {
       {items.length === 0 ? (
         <div className="px-5 py-8 text-center">
           <p className="text-sm" style={{ color: 'var(--neutral-500)' }}>
-            No updates yet. Add article links in Admin / News to power this section.
+            No updates have been published yet. Check back for tournament coverage and partner links.
           </p>
         </div>
       ) : (
@@ -77,7 +78,7 @@ export function LiveUpdates({ items }: { items: UpdateItem[] }) {
                   </h3>
                   <p className="mt-1.5 text-xs" style={{ color: 'var(--neutral-400)' }}>
                     {item.publishedAt
-                      ? new Date(item.publishedAt).toLocaleDateString('en-US', {
+                      ? formatGuamDate(item.publishedAt, {
                           month: 'short',
                           day: 'numeric',
                           year: 'numeric',

--- a/apps/web/src/components/site-footer.tsx
+++ b/apps/web/src/components/site-footer.tsx
@@ -46,7 +46,7 @@ export function SiteFooter() {
               </div>
             </Link>
             <p className="text-xs leading-relaxed max-w-xs" style={{ color: 'rgba(240,232,236,0.45)' }}>
-              The official hub for FD Alumni Basketball. Schedule, standings, watch links, and verified updates.
+              A central hub for FD Alumni Basketball schedules, standings, watch links, tickets, and partner coverage.
             </p>
           </div>
 

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -56,6 +56,7 @@ function CloseIcon({ className }: { className?: string }) {
 
 export function SiteHeader() {
   const pathname = usePathname()
+  const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
 
@@ -64,11 +65,6 @@ export function SiteHeader() {
     window.addEventListener('scroll', handler, { passive: true })
     return () => window.removeEventListener('scroll', handler)
   }, [])
-
-  // Close drawer on route change
-  useEffect(() => {
-    setDrawerOpen(false)
-  }, [pathname])
 
   // Prevent body scroll when drawer open
   useEffect(() => {
@@ -151,29 +147,41 @@ export function SiteHeader() {
                 )
               })}
             </nav>
-            <SignedIn>
+            {clerkEnabled ? (
+              <>
+                <SignedIn>
+                  <Link
+                    href="/admin"
+                    className="rounded-md border px-2 py-1 text-xs font-semibold uppercase tracking-wide transition-colors"
+                    style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
+                    onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#fff'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.7)' }}
+                    onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'rgba(240,232,236,0.72)'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.35)' }}
+                  >
+                    Admin
+                  </Link>
+                </SignedIn>
+                <SignedOut>
+                  <SignInButton mode="modal">
+                    <button
+                      className="rounded-md border px-2 py-1 text-xs font-semibold uppercase tracking-wide transition-colors"
+                      style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
+                      onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#fff'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.7)' }}
+                      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'rgba(240,232,236,0.72)'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.35)' }}
+                    >
+                      Admin
+                    </button>
+                  </SignInButton>
+                </SignedOut>
+              </>
+            ) : (
               <Link
                 href="/admin"
                 className="rounded-md border px-2 py-1 text-xs font-semibold uppercase tracking-wide transition-colors"
                 style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
-                onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#fff'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.7)' }}
-                onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'rgba(240,232,236,0.72)'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.35)' }}
               >
                 Admin
               </Link>
-            </SignedIn>
-            <SignedOut>
-              <SignInButton mode="modal">
-                <button
-                  className="rounded-md border px-2 py-1 text-xs font-semibold uppercase tracking-wide transition-colors"
-                  style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
-                  onMouseEnter={e => { (e.currentTarget as HTMLElement).style.color = '#fff'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.7)' }}
-                  onMouseLeave={e => { (e.currentTarget as HTMLElement).style.color = 'rgba(240,232,236,0.72)'; (e.currentTarget as HTMLElement).style.borderColor = 'rgba(217,178,111,0.35)' }}
-                >
-                  Admin
-                </button>
-              </SignInButton>
-            </SignedOut>
+            )}
           </div>
 
           {/* Mobile menu button */}
@@ -226,6 +234,7 @@ export function SiteHeader() {
               <li key={href}>
                 <Link
                   href={href}
+                  onClick={() => setDrawerOpen(false)}
                   className="flex items-center gap-3 px-4 py-3.5 rounded-xl text-sm font-medium transition-all duration-150"
                   style={{
                     color: active ? '#fff' : 'rgba(240,232,236,0.7)',
@@ -247,30 +256,44 @@ export function SiteHeader() {
 
         {/* Drawer footer */}
         <div className="mt-auto pt-8 border-t" style={{ borderColor: 'rgba(255,255,255,0.08)' }}>
-          <SignedIn>
+          {clerkEnabled ? (
+            <>
+              <SignedIn>
+                <Link
+                  href="/admin"
+                  onClick={() => setDrawerOpen(false)}
+                  className="mb-3 inline-flex items-center rounded-md border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
+                  style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
+                >
+                  Admin
+                </Link>
+              </SignedIn>
+              <SignedOut>
+                <SignInButton mode="modal">
+                  <button
+                    className="mb-3 inline-flex items-center rounded-md border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
+                    style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
+                  >
+                    Admin
+                  </button>
+                </SignInButton>
+              </SignedOut>
+            </>
+          ) : (
             <Link
               href="/admin"
+              onClick={() => setDrawerOpen(false)}
               className="mb-3 inline-flex items-center rounded-md border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
               style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
             >
               Admin
             </Link>
-          </SignedIn>
-          <SignedOut>
-            <SignInButton mode="modal">
-              <button
-                className="mb-3 inline-flex items-center rounded-md border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide"
-                style={{ borderColor: 'rgba(217,178,111,0.35)', color: 'rgba(240,232,236,0.72)' }}
-              >
-                Admin
-              </button>
-            </SignInButton>
-          </SignedOut>
+          )}
           <p className="text-xs" style={{ color: 'rgba(240,232,236,0.35)' }}>
             FD Alumni Basketball Hub
           </p>
           <p className="text-xs mt-0.5" style={{ color: 'rgba(240,232,236,0.25)' }}>
-            Official tournament hub for Guam
+            Central tournament hub for Guam
           </p>
         </div>
       </nav>

--- a/apps/web/src/components/site-header.tsx
+++ b/apps/web/src/components/site-header.tsx
@@ -3,7 +3,7 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { SignInButton, SignedIn, SignedOut } from '@clerk/nextjs'
-import { useState, useEffect } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 const links = [
   { label: 'Schedule', href: '/schedule' },
@@ -59,12 +59,22 @@ export function SiteHeader() {
   const clerkEnabled = Boolean(process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY)
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
+  const previousPathname = useRef(pathname)
 
   useEffect(() => {
     const handler = () => setScrolled(window.scrollY > 20)
     window.addEventListener('scroll', handler, { passive: true })
     return () => window.removeEventListener('scroll', handler)
   }, [])
+
+  // Close the mobile drawer on every route change, including browser back/forward.
+  useEffect(() => {
+    if (previousPathname.current === pathname) return
+    previousPathname.current = pathname
+
+    const frame = requestAnimationFrame(() => setDrawerOpen(false))
+    return () => cancelAnimationFrame(frame)
+  }, [pathname])
 
   // Prevent body scroll when drawer open
   useEffect(() => {

--- a/apps/web/src/contexts/tournament-context.tsx
+++ b/apps/web/src/contexts/tournament-context.tsx
@@ -173,7 +173,7 @@ export function TournamentProvider({
     } catch {
       // localStorage may be unavailable (private mode / restricted contexts)
     }
-  }, [])
+  }, [currentTournament, initialCurrentId])
 
   const value = useMemo<TournamentContextValue>(
     () => ({

--- a/apps/web/src/lib/authz.ts
+++ b/apps/web/src/lib/authz.ts
@@ -1,7 +1,9 @@
 import { auth, currentUser } from '@clerk/nextjs/server'
-import { db } from '@/lib/db'
+import { db, isDatabaseConfigured } from '@/lib/db'
 
 export async function ensureAppUser() {
+  if (!isDatabaseConfigured || !process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY || !process.env.CLERK_SECRET_KEY) return null
+
   const { userId } = await auth()
   if (!userId) return null
 

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -1,0 +1,66 @@
+export const GUAM_TIME_ZONE = 'Pacific/Guam'
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: GUAM_TIME_ZONE,
+  month: 'short',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+export function formatGuamTime(value: Date | string) {
+  return new Date(value).toLocaleTimeString('en-US', {
+    timeZone: GUAM_TIME_ZONE,
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+export function formatGuamDate(value: Date | string, options?: Intl.DateTimeFormatOptions) {
+  return new Date(value).toLocaleDateString('en-US', {
+    timeZone: GUAM_TIME_ZONE,
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    ...options,
+  })
+}
+
+export function formatGuamDateTime(value: Date | string) {
+  const d = new Date(value)
+  return `${dateFormatter.format(d)} · ${formatGuamTime(d)}`
+}
+
+export function guamDayLabel(value: Date | string) {
+  return new Date(value).toLocaleDateString('en-US', {
+    timeZone: GUAM_TIME_ZONE,
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+export function guamDateKey(value: Date | string) {
+  const parts = new Intl.DateTimeFormat('en-CA', {
+    timeZone: GUAM_TIME_ZONE,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date(value))
+
+  const year = parts.find((p) => p.type === 'year')?.value
+  const month = parts.find((p) => p.type === 'month')?.value
+  const day = parts.find((p) => p.type === 'day')?.value
+  return `${year}-${month}-${day}`
+}
+
+export function guamDayRange(value = new Date()) {
+  const key = guamDateKey(value)
+  return {
+    start: new Date(`${key}T00:00:00+10:00`),
+    end: new Date(`${key}T23:59:59.999+10:00`),
+  }
+}
+
+export function isPastGuamGame(value: Date | string, now = new Date()) {
+  return new Date(value).getTime() < now.getTime()
+}

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -56,7 +56,7 @@ function guamOffsetMs(value: Date) {
   return sign * (hours * 60 + minutes) * 60_000
 }
 
-function guamLocalDateTimeToUtc(
+export function guamLocalDateTimeToUtc(
   year: number,
   month: number,
   day: number,
@@ -110,6 +110,11 @@ export function guamDayLabel(value: Date | string) {
 export function guamDateKey(value: Date | string) {
   const { year, month, day } = guamDateParts(value)
   return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+}
+
+export function guamDateStringToDate(dateKey: string) {
+  const [year, month, day] = dateKey.split('-').map(Number)
+  return guamLocalDateTimeToUtc(year, month, day, 0, 0, 0, 0)
 }
 
 export function guamDayRange(value = new Date()) {

--- a/apps/web/src/lib/datetime.ts
+++ b/apps/web/src/lib/datetime.ts
@@ -7,6 +7,74 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
 })
 
+const guamDatePartsFormatter = new Intl.DateTimeFormat('en-CA', {
+  timeZone: GUAM_TIME_ZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+const guamOffsetFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: GUAM_TIME_ZONE,
+  timeZoneName: 'longOffset',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+})
+
+function numericPart(parts: Intl.DateTimeFormatPart[], type: Intl.DateTimeFormatPartTypes) {
+  const value = parts.find((part) => part.type === type)?.value
+  if (!value) throw new Error(`Unable to read ${type} for ${GUAM_TIME_ZONE}`)
+  return Number(value)
+}
+
+function guamDateParts(value: Date | string) {
+  const parts = guamDatePartsFormatter.formatToParts(new Date(value))
+  return {
+    year: numericPart(parts, 'year'),
+    month: numericPart(parts, 'month'),
+    day: numericPart(parts, 'day'),
+  }
+}
+
+function guamOffsetMs(value: Date) {
+  const timeZoneName = guamOffsetFormatter
+    .formatToParts(value)
+    .find((part) => part.type === 'timeZoneName')?.value
+
+  if (!timeZoneName || timeZoneName === 'GMT' || timeZoneName === 'UTC') return 0
+
+  const match = /^GMT([+-])(\d{1,2})(?::(\d{2}))?$/.exec(timeZoneName)
+  if (!match) throw new Error(`Unable to parse ${GUAM_TIME_ZONE} offset: ${timeZoneName}`)
+
+  const sign = match[1] === '-' ? -1 : 1
+  const hours = Number(match[2])
+  const minutes = Number(match[3] ?? '0')
+  return sign * (hours * 60 + minutes) * 60_000
+}
+
+function guamLocalDateTimeToUtc(
+  year: number,
+  month: number,
+  day: number,
+  hour: number,
+  minute: number,
+  second: number,
+  millisecond: number,
+) {
+  const utcGuess = new Date(Date.UTC(year, month - 1, day, hour, minute, second, millisecond))
+  const firstOffset = guamOffsetMs(utcGuess)
+  const firstResult = new Date(utcGuess.getTime() - firstOffset)
+  const adjustedOffset = guamOffsetMs(firstResult)
+
+  return adjustedOffset === firstOffset
+    ? firstResult
+    : new Date(utcGuess.getTime() - adjustedOffset)
+}
+
 export function formatGuamTime(value: Date | string) {
   return new Date(value).toLocaleTimeString('en-US', {
     timeZone: GUAM_TIME_ZONE,
@@ -40,24 +108,16 @@ export function guamDayLabel(value: Date | string) {
 }
 
 export function guamDateKey(value: Date | string) {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: GUAM_TIME_ZONE,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(new Date(value))
-
-  const year = parts.find((p) => p.type === 'year')?.value
-  const month = parts.find((p) => p.type === 'month')?.value
-  const day = parts.find((p) => p.type === 'day')?.value
-  return `${year}-${month}-${day}`
+  const { year, month, day } = guamDateParts(value)
+  return `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
 }
 
 export function guamDayRange(value = new Date()) {
-  const key = guamDateKey(value)
+  const { year, month, day } = guamDateParts(value)
+
   return {
-    start: new Date(`${key}T00:00:00+10:00`),
-    end: new Date(`${key}T23:59:59.999+10:00`),
+    start: guamLocalDateTimeToUtc(year, month, day, 0, 0, 0, 0),
+    end: guamLocalDateTimeToUtc(year, month, day, 23, 59, 59, 999),
   }
 }
 

--- a/apps/web/src/lib/db.ts
+++ b/apps/web/src/lib/db.ts
@@ -2,6 +2,24 @@ import { PrismaClient } from '@prisma/client'
 
 const globalForPrisma = globalThis as unknown as { prisma?: PrismaClient }
 
+export const isDatabaseConfigured = Boolean(process.env.DATABASE_URL)
+
 export const db = globalForPrisma.prisma ?? new PrismaClient()
 
 if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = db
+
+export function isMissingDatabaseUrlError(error: unknown) {
+  if (!(error instanceof Error)) return false
+  return error.message.includes('Environment variable not found: DATABASE_URL')
+}
+
+export async function withDatabaseFallback<T>(operation: () => Promise<T>, fallback: T): Promise<T> {
+  if (!isDatabaseConfigured) return fallback
+
+  try {
+    return await operation()
+  } catch (error) {
+    if (isMissingDatabaseUrlError(error)) return fallback
+    throw error
+  }
+}

--- a/apps/web/src/lib/historical-archive.ts
+++ b/apps/web/src/lib/historical-archive.ts
@@ -1079,6 +1079,8 @@ export const STATIC_TOURNAMENT_YEARS = [
   2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009, 2008, 2007, 2006, 2005,
 ] as const
 
+export const LATEST_ARCHIVE_YEAR = Math.max(...STATIC_TOURNAMENT_YEARS)
+
 export function archiveArticlesForYear(year: number): ArchiveArticle[] {
   return ARCHIVE_ARTICLES.filter((article) => article.year === year)
 }

--- a/apps/web/src/lib/historical-archive.ts
+++ b/apps/web/src/lib/historical-archive.ts
@@ -1,0 +1,1112 @@
+export type ArchiveArticle = {
+  id?: number | string
+  year: number
+  publishedAt: string | null
+  source: string
+  title: string
+  url: string
+  imageUrl: string | null
+  excerpt: string | null
+}
+
+export type ArchiveMedia = {
+  year: number
+  source: string
+  title: string
+  imageUrl: string
+  articleUrl?: string | null
+  caption?: string | null
+  takenAt?: string | null
+  tags?: string | null
+}
+
+export type ChampionRecord = {
+  year: number
+  champion?: string
+  runnerUp?: string
+  score?: string
+  source: string
+  status?: 'completed' | 'cancelled' | 'unknown'
+  note?: string
+}
+
+export const ARCHIVE_ARTICLES: ArchiveArticle[] = [
+  {
+    "id": 141404,
+    "year": 2025,
+    "publishedAt": "2025-07-19",
+    "source": "GSPN",
+    "title": "’02/’04 CAPTURES 4TH FD ALUMNI CROWN",
+    "url": "https://www.guamsportsnetwork.com/2025/02-04-captures-4th-fd-alumni-crown/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2025/07/WhatsApp-Image-2025-07-19-at-9.33.15-AM-scaled.jpeg",
+    "excerpt": "Big win over 2013 to close out Brotherhood tournament"
+  },
+  {
+    "id": 141388,
+    "year": 2025,
+    "publishedAt": "2025-07-16",
+    "source": "GSPN",
+    "title": "FD ALUMNI TOURNEY COMING TO A CLOSE",
+    "url": "https://www.guamsportsnetwork.com/2025/fd-alumni-tourney-coming-to-a-close/",
+    "imageUrl": null,
+    "excerpt": "Friday night is championship night"
+  },
+  {
+    "id": 140910,
+    "year": 2025,
+    "publishedAt": "2025-07-04",
+    "source": "GSPN",
+    "title": "RESULTS FROM THIS WEEK’S FD ALUMNI HOOPS TOURNEY",
+    "url": "https://www.guamsportsnetwork.com/2025/results-from-this-weeks-fd-alumni-hoops-tourney/",
+    "imageUrl": null,
+    "excerpt": "Monday to Thursday scores"
+  },
+  {
+    "id": 140660,
+    "year": 2025,
+    "publishedAt": "2025-06-29",
+    "source": "GSPN",
+    "title": "RECAP OF FD ALUMNI BASKETBALL WEEKEND",
+    "url": "https://www.guamsportsnetwork.com/2025/recap-of-fd-alumni-basketball-weekend/",
+    "imageUrl": null,
+    "excerpt": "Scores from the opening weekend of the Brotherhood Bash"
+  },
+  {
+    "id": 140594,
+    "year": 2025,
+    "publishedAt": "2025-06-28",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS OPENS WITH A BANG",
+    "url": "https://www.guamsportsnetwork.com/2025/fd-alumni-hoops-opens-with-a-bang/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2025/06/WhatsApp-Image-2025-06-27-at-11.15.12-PM-scaled.jpeg",
+    "excerpt": "Newest alumni takes opening night stage over defending champs"
+  },
+  {
+    "id": 134079,
+    "year": 2024,
+    "publishedAt": "2024-07-20",
+    "source": "GSPN",
+    "title": "SHIMIZU ADDS INSTANT LORE TO FD ALUMNI TRADITION",
+    "url": "https://www.guamsportsnetwork.com/2024/shimizu-adds-instant-lore-to-fd-alumni-tradition/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2024/07/DSC0116-Enhanced-NR-scaled.jpg",
+    "excerpt": "Buzzer-beater bounces in for ’16/’17 championship"
+  },
+  {
+    "id": 133977,
+    "year": 2024,
+    "publishedAt": "2024-07-13",
+    "source": "GSPN",
+    "title": "JUNGLE BOYS TOURNEY PLAYOFF PREDICTIONS",
+    "url": "https://www.guamsportsnetwork.com/2024/jungle-boys-tourney-playoff-preview/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2024/06/FD-Alumni-1.jpg",
+    "excerpt": "Eddie Pelkey breaks down the playoff picture for the 2024 FD alumni tourney"
+  },
+  {
+    "id": 133934,
+    "year": 2024,
+    "publishedAt": "2024-07-08",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS HITS HALFWAY POINT",
+    "url": "https://www.guamsportsnetwork.com/2024/fd-alumni-hoops-hits-halfway-point/",
+    "imageUrl": null,
+    "excerpt": "Brotherhood gathering marches toward the playoffs"
+  },
+  {
+    "id": 133771,
+    "year": 2024,
+    "publishedAt": "2024-06-27",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS: IT’S THAT TIME AGAIN!",
+    "url": "https://www.guamsportsnetwork.com/2024/fd-alumni-hoops-its-that-time-again/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2024/06/FD-Alumni-1.jpg",
+    "excerpt": "Annual brotherhood bash ready to tip off"
+  },
+  {
+    "id": 126042,
+    "year": 2023,
+    "publishedAt": "2023-07-22",
+    "source": "GSPN",
+    "title": "CLASS OF 2013 KINGS OF FRIARFEST",
+    "url": "https://www.guamsportsnetwork.com/2023/class-of-2013-kings-of-friarfest/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2023/07/COVER-PHOTO-1-scaled.jpg",
+    "excerpt": "Sakazaki leads host class to 2nd title"
+  },
+  {
+    "id": 126016,
+    "year": 2023,
+    "publishedAt": "2023-07-17",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS PLAYOFF RECAP",
+    "url": "https://www.guamsportsnetwork.com/2023/fd-alumni-hoops-playoff-recap/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2023/06/brothers-ig.jpg",
+    "excerpt": "Weekend results"
+  },
+  {
+    "id": 125827,
+    "year": 2023,
+    "publishedAt": "2023-07-08",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS HITS THE HALFWAY MARK",
+    "url": "https://www.guamsportsnetwork.com/2023/fd-alumni-hoops-hits-the-halfway-mark/",
+    "imageUrl": null,
+    "excerpt": "Friarfest heads to final weekend before playoffs begin"
+  },
+  {
+    "id": 125667,
+    "year": 2023,
+    "publishedAt": "2023-07-03",
+    "source": "GSPN",
+    "title": "SUNDAY RECAP OF FD ALUMNI HOOPS",
+    "url": "https://www.guamsportsnetwork.com/2023/sunday-recap-of-fd-alumni-hoops/",
+    "imageUrl": null,
+    "excerpt": "Friarfest in full swing"
+  },
+  {
+    "id": 125646,
+    "year": 2023,
+    "publishedAt": "2023-06-30",
+    "source": "GSPN",
+    "title": "OPENING NIGHT OF 2023 FD BASKETBALL TOURNAMENT",
+    "url": "https://www.guamsportsnetwork.com/2023/opening-night-of-2023-fd-basketball-tournament/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2023/06/The-class-of-2016_17-huddle-together-after-a-huge-opening-night-game.-photo-by-Cam-Santos.jpg",
+    "excerpt": "FD Brotherhood get annual tournament started"
+  },
+  {
+    "id": 125618,
+    "year": 2023,
+    "publishedAt": "2023-06-27",
+    "source": "GSPN",
+    "title": "ANNUAL FRIARFEST HOOPS TOURNEY ON TAP",
+    "url": "https://www.guamsportsnetwork.com/2023/annual-friarfest-hoops-tourney-on-tap/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2023/06/brothers-ig.jpg",
+    "excerpt": "Preview of the top teams heading into the 2023 version of the FD Alumni Tournament"
+  },
+  {
+    "id": 115738,
+    "year": 2022,
+    "publishedAt": "2022-07-15",
+    "source": "GSPN",
+    "title": "’02/’04 RECLAIMS FD ALUMNI HOOPS REIGN",
+    "url": "https://www.guamsportsnetwork.com/2022/02-04-reclaims-fd-alumni-hoops-reign/",
+    "imageUrl": null,
+    "excerpt": "Perez leads the way with 25 points"
+  },
+  {
+    "id": 115692,
+    "year": 2022,
+    "publishedAt": "2022-07-14",
+    "source": "GSPN",
+    "title": "2020 BLOWS OUT ’06 IN FD SEMIFINALS",
+    "url": "https://www.guamsportsnetwork.com/2022/2020-blows-out-06-in-fd-semifinals/",
+    "imageUrl": null,
+    "excerpt": "Championship night this Friday"
+  },
+  {
+    "id": 115604,
+    "year": 2022,
+    "publishedAt": "2022-07-12",
+    "source": "GSPN",
+    "title": "PLAYOFF WEEK FOR FRIARS BASKETBALL",
+    "url": "https://www.guamsportsnetwork.com/2022/playoff-week-for-friars-basketball/",
+    "imageUrl": null,
+    "excerpt": "2020 eliminates host 12 Pack"
+  },
+  {
+    "id": 115437,
+    "year": 2022,
+    "publishedAt": "2022-07-05",
+    "source": "GSPN",
+    "title": "FD ALUMNI BASKETBALL PLAYOFFS ALL SET",
+    "url": "https://www.guamsportsnetwork.com/2022/fd-alumni-basketball-playoffs-all-set/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2022/07/FDMS-logo.png",
+    "excerpt": "Elitists tournament enters single-elimination playoffs"
+  },
+  {
+    "id": 115320,
+    "year": 2022,
+    "publishedAt": "2022-07-03",
+    "source": "GSPN",
+    "title": "’05 SHOCKS ’06 AS FD TOURNEY ROLLS ALONG",
+    "url": "https://www.guamsportsnetwork.com/2022/05-shocks-06-as-fd-tourney-rolls-along/",
+    "imageUrl": null,
+    "excerpt": "2006 drops two games in one week!"
+  },
+  {
+    "id": 115245,
+    "year": 2022,
+    "publishedAt": "2022-06-30",
+    "source": "GSPN",
+    "title": "8-TIME FD CHAMPS TAKEN DOWN",
+    "url": "https://www.guamsportsnetwork.com/2022/8-time-fd-champs-taken-down/",
+    "imageUrl": null,
+    "excerpt": "Rematch of 2021 title game"
+  },
+  {
+    "id": 115156,
+    "year": 2022,
+    "publishedAt": "2022-06-27",
+    "source": "GSPN",
+    "title": "FD ALMUNI HOOPS TOURNEY IN FULL SWING",
+    "url": "https://www.guamsportsnetwork.com/2022/fd-almuni-hoops-tourney-in-full-swing/",
+    "imageUrl": null,
+    "excerpt": "Annual brotherhood basketball festival underway"
+  },
+  {
+    "id": 107042,
+    "year": 2021,
+    "publishedAt": "2021-07-30",
+    "source": "GSPN",
+    "title": "2006 BRINGS IN EIGHTH ALUMNI TITLE IN BIG WAY",
+    "url": "https://www.guamsportsnetwork.com/2021/2006-brings-in-eighth-alumni-title-in-big-way/",
+    "imageUrl": null,
+    "excerpt": "The Class of 2006 captures their 8th FD Alumni Tournament title to close out the 2021 summer."
+  },
+  {
+    "id": 106886,
+    "year": 2021,
+    "publishedAt": "2021-07-16",
+    "source": "GSPN",
+    "title": "FRIDAY NIGHT FD ALUMNI HOOPS",
+    "url": "https://www.guamsportsnetwork.com/2021/friday-night-fd-alumni-hoops/",
+    "imageUrl": null,
+    "excerpt": "The 2021 FD Alumni Basketball Tournament is approaching the end of pool play this weekend with Monday marking the last of make-up games before the playoffs. The combined Class of 04/02 held off a comeback from the most decorated Champions of the Alumni Tourney in ’06 with Sean Perez hitting a pair of clutch buckets […]"
+  },
+  {
+    "id": 106747,
+    "year": 2021,
+    "publishedAt": "2021-07-09",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS BACK IN ACTION",
+    "url": "https://www.guamsportsnetwork.com/2021/fd-alumni-hoops-back-from-year-off/",
+    "imageUrl": null,
+    "excerpt": "After the COVID-19 Pandemic forced the FD Alumni Basketball Tournament to close it’s doors in 2020, Friday evening marked the return of the highly anticipated summer tourney for it’s return in 2021. Three rivalry games opened the evening at the FD Jungle to start the three-week long tourney. ’79/’80 – 38, ’75 – 15The sharpshooting […]"
+  },
+  {
+    "id": 93255,
+    "year": 2019,
+    "publishedAt": "2019-07-12",
+    "source": "GSPN",
+    "title": "2006 CAPTURES SEVENTH FD ALUMNI TITLE",
+    "url": "https://www.guamsportsnetwork.com/2019/2006-captures-seventh-fd-alumni-title/",
+    "imageUrl": null,
+    "excerpt": "The Class of 2006 have added yet another basketball title to their seemingly ever-growing collection as they defeated the Class of 2009, the tournament’s host, 49-46 at The Jungle Friday evening in the Maroon Division."
+  },
+  {
+    "id": 93021,
+    "year": 2019,
+    "publishedAt": "2019-07-08",
+    "source": "GSPN",
+    "title": "WEEKEND ROUND-UP OF ALUMNI TOURNAMENT PLAYOFFS",
+    "url": "https://www.guamsportsnetwork.com/2019/weekend-round-alumni-tournament-playoffs/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2019/07/IMG-6076.jpg",
+    "excerpt": "The first round of the playoffs in the FD Alumni summer basketball tournament continued this Saturday and with the quarterfinals happening Sunday."
+  },
+  {
+    "id": 92309,
+    "year": 2019,
+    "publishedAt": "2019-06-21",
+    "source": "GSPN",
+    "title": "2006 BEATS 2016 AS ALUMNI TOURNEY TIPS OFF",
+    "url": "https://www.guamsportsnetwork.com/2019/2006-beats-2016-alumni-tourney-tips-off/",
+    "imageUrl": null,
+    "excerpt": "No event quite fills the FD Jungle like opening night in FD Alumni Basketball Tournament."
+  },
+  {
+    "id": 78795,
+    "year": 2018,
+    "publishedAt": "2018-07-13",
+    "source": "GSPN",
+    "title": "2002/04 REPEAT AS FD ALUMNI CHAMPIONS",
+    "url": "https://www.guamsportsnetwork.com/2018/live-video-fd-alumni-tournament-finals/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2018/07/2018-FD-Alumni-Tournament-Finals-13.jpg",
+    "excerpt": "Repeat Champions!"
+  },
+  {
+    "id": 78653,
+    "year": 2018,
+    "publishedAt": "2018-07-09",
+    "source": "GSPN",
+    "title": "430-5, 06 PICK UP WEEKEND PLAYOFF WINS IN FD TOURNEY",
+    "url": "https://www.guamsportsnetwork.com/2018/430-5-06-pick-weekend-playoff-wins-fd-tourney/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2018/07/IMG_2771.jpg",
+    "excerpt": "Playoff action picked up Sunday afternoon in the FD Alumni Basketball Tournament. Class 430-5 knocked off the oldest class of 75 while 06 and the host class 2008 picked up wins."
+  },
+  {
+    "id": 78398,
+    "year": 2018,
+    "publishedAt": "2018-06-30",
+    "source": "GSPN",
+    "title": "UPPER CLASSES TAKE FD ALUMNI TOURNEY WINS",
+    "url": "https://www.guamsportsnetwork.com/2018/upper-classes-take-fd-alumni-tourney-wins/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2018/06/2018-FD-Alumni-Tournament-02.jpg",
+    "excerpt": "The upper classes had the upper hand Saturday in the morning games as the vets dished out some lessons for the FD Alumni Tournament’s youngest teams."
+  },
+  {
+    "id": 78263,
+    "year": 2018,
+    "publishedAt": "2018-06-25",
+    "source": "GSPN",
+    "title": "FD ALUMNI SUNDAY SCORES",
+    "url": "https://www.guamsportsnetwork.com/2018/fd-alumni-sunday-scores/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2018/06/20180624_200020.jpg",
+    "excerpt": "The FD Alumni Tournament wrapped up opening their weekend with seven more games on Sunday. Pool play continues throughout the week with the playoffs set to begin on July 6th!"
+  },
+  {
+    "id": 69033,
+    "year": 2017,
+    "publishedAt": "2017-07-15",
+    "source": "GSPN",
+    "title": "ESTELLA HITS GAME WINNER TO GIVE 02/04 FD ALUMNI TITLE",
+    "url": "https://www.guamsportsnetwork.com/2017/estella-hits-game-winner-give-0204-fd-alumni-title/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2017/07/IMG_6539.jpg",
+    "excerpt": "It was built as the ‘Super Team’ vs ‘The Dynasty’. The combined Class of 02/04 had to go through the second most winningest Alumni Tourney Class of 2006 in one epic showdown to conclude the 2017 FD Alumni Basketball Tournament Friday night."
+  },
+  {
+    "id": 68813,
+    "year": 2017,
+    "publishedAt": "2017-07-09",
+    "source": "GSPN",
+    "title": "TEAMS MAKE EXITS IN SUNDAY’S FD ALUMNI PLAYOFFS",
+    "url": "https://www.guamsportsnetwork.com/2017/teams-make-exits-sundays-fd-alumni-playoffs/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2017/06/logo-3.png",
+    "excerpt": "The annual FD Alumni Basketball Tournament is rendering it’s single-elimination playoffs, separating the title contenders from the pretenders. Sunday’s action involved a handful of lopsided games with the usual suspects moving on to the final week of play. Scores 2006 – 53, 91 – 32 Steve Sablan and AJ Reyes scored 13 each as the […]"
+  },
+  {
+    "id": 68662,
+    "year": 2017,
+    "publishedAt": "2017-06-28",
+    "source": "GSPN",
+    "title": "PAULINO SINKS GAME WINNER FOR RIVAL WIN OVER 2013",
+    "url": "https://www.guamsportsnetwork.com/2017/paulino-sinks-game-winner-rival-win-2013/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2017/06/IMG_3301.jpg",
+    "excerpt": "Late-game heroics in FD Alumni hoops."
+  },
+  {
+    "id": 68649,
+    "year": 2017,
+    "publishedAt": "2017-06-28",
+    "source": "GSPN",
+    "title": "FD ALUMNI BASKETBALL: TUESDAY SCORES",
+    "url": "https://www.guamsportsnetwork.com/2017/fd-alumni-basketball-tuesday-scores/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2017/06/logo-3.png",
+    "excerpt": "Get the latest scores from Tuesday nights FD Alumni Basketball Tourney."
+  },
+  {
+    "id": 68582,
+    "year": 2017,
+    "publishedAt": "2017-06-24",
+    "source": "GSPN",
+    "title": "FD ALUMNI BASKETBALL TIP-OFF WEEKEND",
+    "url": "https://www.guamsportsnetwork.com/2017/fd-alumni-basketball-tip-off-weekend/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2017/06/IMG_3238.jpg",
+    "excerpt": "The 2017 FD Alumni Tournament, hosted by the class of 2007, has officially tipped off!"
+  },
+  {
+    "id": 64918,
+    "year": 2017,
+    "publishedAt": "2017-01-31",
+    "source": "GSPN",
+    "title": "FRIARS RETIRE SIX BASKETBALL JERESEYS",
+    "url": "https://www.guamsportsnetwork.com/2017/friars-retire-six-basketball-jereseys/",
+    "imageUrl": null,
+    "excerpt": "Six jerseys numbers will be worn in FD Basketball history ever again. This past Sunday, the FD Friar Alumni Association hosted its first ever retirement ceremony at the Phoenix Center for the likes of six legendary ballers who suited up in maroon and gold. Retired Jerseys Ricardo Eusebio #33 (1972) Eduardo ‘Champ’ Calvo #10 (1974) […]"
+  },
+  {
+    "id": 56906,
+    "year": 2015,
+    "publishedAt": "2015-06-29",
+    "source": "GSPN",
+    "title": "2015 FD ALUMNI TOURNEY: VIDEO RECAP",
+    "url": "https://www.guamsportsnetwork.com/2015/2015-fd-alumni-tourney-video-recap/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/Screen-Shot-2015-06-29-at-6.19.49-PM.png",
+    "excerpt": "The men of Father Duenas once again put together a memorable summer event in the 2015 FD Alumni Basketball Tournament with the Class of 2013 claiming their first ever title in just their third run in the tourney. Led by John Baza and Guam’s National Basketball player Mike Sakazaki, the Class of ’13 overcame a […]"
+  },
+  {
+    "id": 56809,
+    "year": 2015,
+    "publishedAt": "2015-06-27",
+    "source": "GSPN",
+    "title": "2013 WINS FIRST EVER FD ALUMNI TOURNEY",
+    "url": "https://www.guamsportsnetwork.com/2015/2013-wins-first-ever-fd-alumni-tourney/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/fd-champs-10.jpg",
+    "excerpt": "The Class of 2013 earned a lot more than just respect Friday night, they won the FD Alumni Basketball title over the defending champion’s in Class of 2004 at the packed FD Jungle behind a big showing from guard John Baza."
+  },
+  {
+    "id": 56761,
+    "year": 2015,
+    "publishedAt": "2015-06-25",
+    "source": "GSPN",
+    "title": "2004 TO FACE 2013 IN FD HOOPS FINALS",
+    "url": "https://www.guamsportsnetwork.com/2015/2004-to-face-2013-in-fd-hoops-finals/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/Alumni-41.jpg",
+    "excerpt": "The Class of 2004 will get a chance to defend their FD Alumni Basketball title after defeating the Class of 2008 in the semis. They will meet the Class of 2013, who had to get through a gritty bunch of five-time Alumni champs in 2006."
+  },
+  {
+    "id": 56687,
+    "year": 2015,
+    "publishedAt": "2015-06-24",
+    "source": "GSPN",
+    "title": "FINAL FOUR SET IN FD HOOPS",
+    "url": "https://www.guamsportsnetwork.com/2015/final-four-set-in-fd-hoops/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/BBall-112.jpg",
+    "excerpt": "The Class of 2013 and 2010 put on an awesome display of FD Alumni Basketball in the best game of the tournament with 2013 claiming victors. 2006 defeated 1999 to make it to the semifinals Wednesday night to play 2013 while 2004 will play the Class of 2008."
+  },
+  {
+    "id": 56658,
+    "year": 2015,
+    "publishedAt": "2015-06-21",
+    "source": "GSPN",
+    "title": "FATHER’S DAY BUCKETS IN ALUMNI PLAYOFFS",
+    "url": "https://www.guamsportsnetwork.com/2015/fathers-day-buckets-in-alumni-playoffs/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/IMG_0093.jpg",
+    "excerpt": "The FD Alumni Basketball Tournament continued on Father’s Day with several single elimination playoff games at played at the “Jungle”. Teams are moving on and classes are getting knocked off, but see who’s still in the run as the tourney is set to wrap up Friday evening."
+  },
+  {
+    "id": 56590,
+    "year": 2015,
+    "publishedAt": "2015-06-21",
+    "source": "GSPN",
+    "title": "THE EUSEBIOS: ALUMNI BASKETBALL",
+    "url": "https://www.guamsportsnetwork.com/2015/the-eusebios-alumni-basketball/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/IMG_2544.jpg",
+    "excerpt": "Dr. Andrew Eusebio and his three sons have a lot of things in common. All are members of the Father Duenas family and all of them have suited up for the Friars basketball squad. Get to know the men and how basketball, being an FD Friar, and family bind them together on this Father’s Day special!"
+  },
+  {
+    "id": 56536,
+    "year": 2015,
+    "publishedAt": "2015-06-19",
+    "source": "GSPN",
+    "title": "PLAYOFF ACTION UNDERWAY FOR FD HOOPS",
+    "url": "https://www.guamsportsnetwork.com/2015/playoff-action-underway-for-fd-hoops/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/BBall-13.jpg",
+    "excerpt": "Playoffs have just started in the FD Alumni tournament and things are already heating up with classes bringing in the competitiveness showing how much they want to win. Tuesday night’s game came with two close games that brought the people in the Jungle in the edge of their seats."
+  },
+  {
+    "id": 56178,
+    "year": 2015,
+    "publishedAt": "2015-06-14",
+    "source": "GSPN",
+    "title": "FD ALUMNI BASKETBALL TOURNEY SCOREBOARD",
+    "url": "https://www.guamsportsnetwork.com/2015/fd-alumni-basketball-tourney-scoreboard/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/website-logo-copy.jpg",
+    "excerpt": "Get all the scores from every game all FD Friars Alumni tourney long here with Guam Sports Network!"
+  },
+  {
+    "id": 56409,
+    "year": 2015,
+    "publishedAt": "2015-06-13",
+    "source": "GSPN",
+    "title": "ONE WEEK DONE IN FD ALUMNI HOOPS",
+    "url": "https://www.guamsportsnetwork.com/2015/one-week-done-in-alumni-hoops/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2015/06/IMG_0086.jpg",
+    "excerpt": "The FD Alumni Tournament wrapped up one week of play Friday with the playoffs soon to follow. Pool play is heating up at the jungle!"
+  },
+  {
+    "id": 45029,
+    "year": 2014,
+    "publishedAt": "2014-07-21",
+    "source": "GSPN",
+    "title": "BROTHERHOOD EXEMPLIFIED AMONG ALUMNI",
+    "url": "https://www.guamsportsnetwork.com/2014/brotherhood-exemplified-among-fd-alumni/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/FD-logo1.jpg",
+    "excerpt": "Exciting games and lots of food. Another year in the books for the traditional Father Duenas Alumni Basketball Tournament."
+  },
+  {
+    "id": 44948,
+    "year": 2014,
+    "publishedAt": "2014-07-19",
+    "source": "GSPN",
+    "title": "2004 WINS COVETED FD ALUMNI TITLE",
+    "url": "https://www.guamsportsnetwork.com/2014/2004-wins-coveted-fd-alumni-title/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_2409.jpg",
+    "excerpt": "Since joining the FD Alumni Tournament 10 years ago, the men of 2004 capped off a memorable year by not only hosting the tourney, but also beating the Class of 2012 in the finals to capture their first Alumni title."
+  },
+  {
+    "id": 44870,
+    "year": 2014,
+    "publishedAt": "2014-07-18",
+    "source": "GSPN",
+    "title": "2004 TO PLAY 2012 IN ALUMNI FINALS",
+    "url": "https://www.guamsportsnetwork.com/2014/2004-to-play-2012-in-alumni-finals/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_1968.jpg",
+    "excerpt": "Then there were two. The host Class of 2004 and upstart Class of 2012 will lay it all on the line Friday night in this summers finale of the FD Alumni Tournament after getting big wins in the semifinals Thursday night."
+  },
+  {
+    "id": 44834,
+    "year": 2014,
+    "publishedAt": "2014-07-17",
+    "source": "GSPN",
+    "title": "79/80 OLDIES MOVE ON TO FD SEMIFINALS",
+    "url": "https://www.guamsportsnetwork.com/2014/fd-alumni-tourney-heading-into-semis/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_1816.jpg",
+    "excerpt": "Although the 2014 FD Alumni Basketball Tournament nears its end, the excitement and unexpected upsets seem to get better and better as the final days approach. In the quarterfinal games on Wednesday night, a pair of upsets took place with last minute clutch shots and shocking come from behind wins."
+  },
+  {
+    "id": 44793,
+    "year": 2014,
+    "publishedAt": "2014-07-16",
+    "source": "GSPN",
+    "title": "2006 DENIED SIXTH TITLE BY 2013",
+    "url": "https://www.guamsportsnetwork.com/2014/2006-denied-sixth-title-by-2013/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/04/GSPN-Homepage.jpg",
+    "excerpt": "Class of 2013 just accomplished something no team has been able to do for the past five years which is knock the Class of 2006 out of the playoffs, more importantly denying them a chance at repeating as FD Alumni Tournament champs for the sixth straight year."
+  },
+  {
+    "id": 44752,
+    "year": 2014,
+    "publishedAt": "2014-07-15",
+    "source": "GSPN",
+    "title": "ALUMNI TOURNEY PLAYOFFS HEATING UP",
+    "url": "https://www.guamsportsnetwork.com/2014/alumni-tourney-playoffs-heating-up/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_5501.jpg",
+    "excerpt": "The Class of 2012 proved Monday night that they’re a legitimate threat to take the 2014 FD Alumni Basketball title after narrowly defeating the tough Class of 2010 in a thrilling down to the wire game while 1991/98 managed to hold off the Class of 2007’s late rally."
+  },
+  {
+    "id": 44725,
+    "year": 2014,
+    "publishedAt": "2014-07-14",
+    "source": "GSPN",
+    "title": "BUZZER BEATER SENDS 02/03 PACKING",
+    "url": "https://www.guamsportsnetwork.com/2014/buzzer-beater-sends-0203-packing/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_5106.jpg",
+    "excerpt": "Classes started falling during the second day of the single elimination playoffs in the annual FD Alumni Basketball Tournament with the night ending in dramatic fashion as 2009 knocked off the power house class of 2002/03 with a last second shot."
+  },
+  {
+    "id": 44690,
+    "year": 2014,
+    "publishedAt": "2014-07-13",
+    "source": "GSPN",
+    "title": "FD ALUMNI ENTERS PLAYOFF STRETCH",
+    "url": "https://www.guamsportsnetwork.com/2014/fd-alumni-enters-playoff-stretch/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_4999.jpg",
+    "excerpt": "The FD Alumni Tournament featured two playoff games Saturday night, as well as the final day of pool play, as the Class of 2008 and 2000/01 got first round wins to stay alive for the weekend."
+  },
+  {
+    "id": 44681,
+    "year": 2014,
+    "publishedAt": "2014-07-12",
+    "source": "GSPN",
+    "title": "STORM CAN’T STOP FD ALUMNI TOURNEY",
+    "url": "https://www.guamsportsnetwork.com/2014/storm-cant-stop-fd-alumni-tourney/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_4964.jpg",
+    "excerpt": "Not even the possibility of a tropical storm could keep the FD Alumni Tournament from rolling on Friday night featuring three games, but an even bigger crowd."
+  },
+  {
+    "id": 44462,
+    "year": 2014,
+    "publishedAt": "2014-07-07",
+    "source": "GSPN",
+    "title": "FD ALUMNI: STINNETT DROPS 38 ON 2010",
+    "url": "https://www.guamsportsnetwork.com/2014/fd-alumni-stinnett-drops-38-on-2010/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_4885.jpg",
+    "excerpt": "William Stinnett had a monstrous night scoring 38 points, while getting a late heroic performance from Chris Santos and Napoleon Finch, to give the FD Alumni Tournament host class of 2004 a big win over the Class of 2010 Monday night."
+  },
+  {
+    "id": 44378,
+    "year": 2014,
+    "publishedAt": "2014-07-06",
+    "source": "GSPN",
+    "title": "FD ALUMNI: 2006 RECOVERS FROM FIRST LOSS",
+    "url": "https://www.guamsportsnetwork.com/2014/fd-alumni-2006-recovers-from-first-loss/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_4843.jpg",
+    "excerpt": "The FD Jungle continued to have its court rocking as the annual Alumni Tournament finished its third day of action all day Saturday."
+  },
+  {
+    "id": 44341,
+    "year": 2014,
+    "publishedAt": "2014-07-05",
+    "source": "GSPN",
+    "title": "FD ALUMNI TOURNAMENT DAY 2",
+    "url": "https://www.guamsportsnetwork.com/2014/fd-alumni-tournament-day-2/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_0293.jpg",
+    "excerpt": "The FD Alumni Tournament rolled through the July 4th National Holiday with a slew of games, including a couple of close matches between rival classes."
+  },
+  {
+    "id": 44354,
+    "year": 2014,
+    "publishedAt": "2014-07-03",
+    "source": "GSPN",
+    "title": "FD ALUMNI TOURNAMENT SCOREBOARD",
+    "url": "https://www.guamsportsnetwork.com/2014/fd-alumni-basketball-tournament-scoreboard/",
+    "imageUrl": "https://www.guamsportsnetwork.com/wp-content/uploads/2014/07/IMG_4843.jpg",
+    "excerpt": "Day 1 1996/97 – 46, 1999 – 44 (shootout) 2003 – 56, 2006 – 46 1981/82 – 46, 1988 – 36 Day 2 2007 – 43, 2008 – 37 1995 – 63, 2000/01 – 57 2010 – 62, 2014 – 53 1979 – 48, 1975 – 23 1970/75 – 21, 1960 – 16 1991/98 – […]"
+  },
+  {
+    "id": 30318,
+    "year": 2013,
+    "publishedAt": "2013-07-23",
+    "source": "GSPN",
+    "title": "FD ’06 ON TETRAVALENT STREAK",
+    "url": "https://www.guamsportsnetwork.com/2013/fd-06-on-tetravalent-streak/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Patrick Lujan The Class of 2006 is in the midst of building a basketball dynasty. Just seven years removed from graduating from Father Duenas, 06 captured their fifth FD Alumni Basketball Tournament championship Tuesday night with a 63-49 win over 2004 in the title game. It is their fourth championship in a row […]"
+  },
+  {
+    "id": 30112,
+    "year": 2013,
+    "publishedAt": "2013-07-20",
+    "source": "GSPN",
+    "title": "2006 KNOCKS OUT 2010",
+    "url": "https://www.guamsportsnetwork.com/2013/2006-knocks-out-2010/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia Two of the most entertaining teams to watch all tournament faced off once more in the FD Alumni Tournament with 2006 keeping their title defend hopes alive by taking out the young guns of 2010, 60-54. Julius Yu led ’06 in scoring with 11 points but key offensive rebounds from teammate […]"
+  },
+  {
+    "id": 30096,
+    "year": 2013,
+    "publishedAt": "2013-07-20",
+    "source": "GSPN",
+    "title": "TOURNEY FRESHMEN MOVING ON",
+    "url": "https://www.guamsportsnetwork.com/2013/tourney-freshman-moving-on/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Colin Leon Guerrero The Class of 2013 pulled off an impressive playoff victory, defeating Class of 2009 48-44 Friday night in the FD Alumni Basketball Tournament at the Jungle. ’13 came out very aggressive as John Baza, Jon Onedera, and Anthony Olchondra used their fresh legs to cut between defenders and get to […]"
+  },
+  {
+    "id": 30052,
+    "year": 2013,
+    "publishedAt": "2013-07-17",
+    "source": "GSPN",
+    "title": "FD ALUMNI MASTERS ROUND",
+    "url": "https://www.guamsportsnetwork.com/2013/fd-alumni-masters-round/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia 1991 – 71, 1970 – 52 Chief Justice Robert Torres led the eldest class in the tournament with 24 points but the Class of ’91 hit 12 three pointers which helped them advance to the quarter finals in the FD Alumni Tournament. The Class of ’70 were also playing with the […]"
+  },
+  {
+    "id": 30011,
+    "year": 2013,
+    "publishedAt": "2013-07-16",
+    "source": "GSPN",
+    "title": "MARTINEZ SINKS GAME WINNER",
+    "url": "https://www.guamsportsnetwork.com/2013/martinez-sinks-game-winner/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] Robert Balajadia 2007 – 53, 2000/05 – 51 The fate of 2007’s FD Alumni Basketball Tournament lives came down to two plays, on offense and defense, where ’07’s Jude Martinez and Brandon Duenas delivered while overcoming 2000/’05’s Nick Santos’ 27 points. With the game tied at 51, Martinez looked at the clock and noticed […]"
+  },
+  {
+    "id": 29984,
+    "year": 2013,
+    "publishedAt": "2013-07-15",
+    "source": "GSPN",
+    "title": "FD PLAYOFF ACTION UNDERWAY",
+    "url": "https://www.guamsportsnetwork.com/2013/fd-playoff-action-underway/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Colin Leon Guerrero “It was like playing our little brothers tonight, so we have to treat them like little brothers,” said Earvin Jose after his Class of 2010 defeated the Class of 2012 46-43 in a tense playoff game at the FD Alumni Basketball Tournament Monday night at The Jungle. Knowing that the […]"
+  },
+  {
+    "id": 29487,
+    "year": 2013,
+    "publishedAt": "2013-07-14",
+    "source": "GSPN",
+    "title": "’06 TO START TITLE DEFENSE",
+    "url": "https://www.guamsportsnetwork.com/2013/06-to-start-title-defense/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia 2006 – 72, 2007 – 61 The Class of 2006 finished pool play in the FD Alumni Tournament undefeated as they got past a hot start from 2007. Julius Yu led ’06 with 18 points while Jude Martinez finished with 24 points and teammate Brandon Duenas had 20. ’07 managed to […]"
+  },
+  {
+    "id": 29468,
+    "year": 2013,
+    "publishedAt": "2013-07-13",
+    "source": "GSPN",
+    "title": "FD ALUMNI FRIDAY NIGHT",
+    "url": "https://www.guamsportsnetwork.com/2013/fd-alumni-friday-night/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Colin Leon Guerrero In Day 8 of the FD Alumni Basketball Tournament, Class of 1999 showed that they are still in their prime after defeating the combined team of 2000 and 2005, 53-35 Friday night at the Jungle. 99’s Johnny Holbrom got things going for his class scoring the first five buckets within […]"
+  },
+  {
+    "id": 29378,
+    "year": 2013,
+    "publishedAt": "2013-07-11",
+    "source": "GSPN",
+    "title": "UNBEATEN STREAKS CONTINUE",
+    "url": "https://www.guamsportsnetwork.com/2013/unbeaten-streaks-continue/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia 1996/97 – 61, 1995 – 49 Longtime FD Friar basketball head coach Eddie Pelkey dropped 19 points for Class of ’96/97 to move his team past their rivals of 1995 on Day 6 of the FD Alumni Basketball Tournament. Chris Ogo had a big game for ’96/97 as well finishing with […]"
+  },
+  {
+    "id": 29192,
+    "year": 2013,
+    "publishedAt": "2013-07-07",
+    "source": "GSPN",
+    "title": "FD ALUMNI BASKETBALL SCOREBOARD",
+    "url": "https://www.guamsportsnetwork.com/2013/fd-alumni-basketball-scoreboard/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] PLAYOFFS: Day 6 2006 – 60, 2010 – 54 2006 – 70, 2002 – 56 1999 – 51, 1991 – 29 2004 – 51, 430 – 29 PLAYOFFS: Day 5 2013 – 48, 2009 – 44 PLAYOFFS: Day 4 2001 – 43, 2008 – 40 2002 – 65, 2011 – 41 430 def. 2007 […]"
+  },
+  {
+    "id": 29146,
+    "year": 2013,
+    "publishedAt": "2013-07-06",
+    "source": "GSPN",
+    "title": "FD TOURNEY OPENING WEEKEND",
+    "url": "https://www.guamsportsnetwork.com/2013/fd-tourney-opening-weekend/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia 2000/2005 – 46, 1976/2001 – 39 Neil Espino finished with 12 points to lead the class combination of 2000 and 2005 over the other combined class of 1976 and 2001 with a final score of 46-39 on day two of the FD Alumni Tournament. Frank Perez of ’76/’01 led all scorers […]"
+  },
+  {
+    "id": 29097,
+    "year": 2013,
+    "publishedAt": "2013-07-05",
+    "source": "GSPN",
+    "title": "THE FD ALUMNI REIGN OF ’06",
+    "url": "https://www.guamsportsnetwork.com/2013/the-fd-alumni-reign-of-06/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia The last time the Father Duenas Friars won a IIAAG Basketball championship was back in 2006. That same class has ruled the FD Alumni Basketball tournament for the past few years winning two back-to-back titles since coming out of high school and are now in contention for their fifth. The four […]"
+  },
+  {
+    "id": 13800,
+    "year": 2012,
+    "publishedAt": "2012-07-22",
+    "source": "GSPN",
+    "title": "’06 THREE-PEAT CHAMPS",
+    "url": "https://www.guamsportsnetwork.com/2012/06-three-peat-champs/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Robert Balajadia For the third straight year, the Father Duenas Friars Class of 2006 was the last team standing as they defeated the Class of 2002 Sunday night 55-52 to conclude the FD Alumni Tournament. ’06 has now won four of their last five championships since joining the tournament as freshmen. The hosting […]"
+  },
+  {
+    "id": 13686,
+    "year": 2012,
+    "publishedAt": "2012-07-19",
+    "source": "GSPN",
+    "title": "CLASS OF ’89 OUSTS ’88",
+    "url": "https://www.guamsportsnetwork.com/2012/89-ousts-88/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Errol “DynamiX” Alegre Jr. The Class of ’89 remain alive in the single-elimination playoffs of the Father Duenas Alumni Basketball Tournament after defeating Class of ’88, 28-22, at the FD “Jungle” Gym Wednesday night. Both teams executed half court offense for majority of the game, but with a few fast break spurts led […]"
+  },
+  {
+    "id": 13422,
+    "year": 2012,
+    "publishedAt": "2012-07-12",
+    "source": "GSPN",
+    "title": "‘96-‘97 TAKE NAIL-BITING WIN",
+    "url": "https://www.guamsportsnetwork.com/2012/96-97-take-nail-biting-win/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Errol “DynamiX” Alegre Jr. In a game where every second counted, Jake Leon Guerrero made sure to utilize whatever time he had left to lift his Class of 1996-1997 to a close 68-67 win over Class of 1995 Wednesday night in the FD Alumni Basketball Tournament. With just four seconds remaining on the […]"
+  },
+  {
+    "id": 13399,
+    "year": 2012,
+    "publishedAt": "2012-07-10",
+    "source": "GSPN",
+    "title": "FD ALUMNI HOOPS",
+    "url": "https://www.guamsportsnetwork.com/2012/fd-alumni-hoops/",
+    "imageUrl": null,
+    "excerpt": "Monday July 9 Game 1 Class of ’75 def. Class of ’70 27-26 Game 2 Class of ’74/’98 def. ’95 64-53 Tuesday July 10 Game 1 Class of ’84-’82 def. Class of ’88 30-25 Game 2 Class of ’85-’87 def. Class of ’89 33-32 Game 3 Team 430 def. Class of ’92 69-45 […]"
+  },
+  {
+    "id": 13212,
+    "year": 2012,
+    "publishedAt": "2012-07-06",
+    "source": "GSPN",
+    "title": "2012 SLIPS PAST ’79-’80",
+    "url": "https://www.guamsportsnetwork.com/2012/2012-slips-past-79-and-80/",
+    "imageUrl": null,
+    "excerpt": "[sixcol_five_last] By Regina Shiroma Class of 2012 slipped by class of ’79 and ‘80, 55-54 with just 22 seconds left in the second half in the opening game of the FD alumni basketball tournament. The older alumni were given a 20 point lead at the start of the game to even the playing field, as […]"
+  },
+  {
+    "id": 13141,
+    "year": 2012,
+    "publishedAt": "2012-07-06",
+    "source": "GSPN",
+    "title": "HISTORY OF THE FD ALUMNI TOURNAMENT",
+    "url": "https://www.guamsportsnetwork.com/2012/history-of-the-fd-alumni-basketball-tournament/",
+    "imageUrl": null,
+    "excerpt": "1985…Memorial Day Weekend…10 Teams. What started as a simple idea after missing a high school reunion, the Father Duenas Alumni Association’s (FDAA) annual basketball tournament is ready to gear up for its 27th consecutive year! “I missed my 10-year reunion with my class. They had a nice get together at a beach, took a class […]"
+  },
+  {
+    "year": 2016,
+    "publishedAt": "2016-06-19",
+    "source": "PostGuam",
+    "title": "2009 drops 2016 in FD alumni game",
+    "url": "https://www.postguam.com/sports/local/2009-drops-2016-in-fd-alumni-game/article_1100757a-3618-11e6-97fe-971d35d25d69.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/7/0e/70e89cb6-3617-11e6-9cf7-4b3a01bb31dc/57668cc2c055c.image.jpg?crop=1134%2C595%2C0%2C102",
+    "excerpt": "The 2016 FD Alumni Basketball Tournament had its soft opening Friday night with the classes of 2016 and 2009 battling it out for the right to play in the tournaments"
+  },
+  {
+    "year": 2015,
+    "publishedAt": "2015-06-09",
+    "source": "PostGuam",
+    "title": "FD alumni holds basketball tournament",
+    "url": "https://www.postguam.com/sports/local/fd-alumni-holds-basketball-tournament/article_adaaadbb-076e-5200-9c91-f8ee3652371e.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/custom/image/f433efec-b17a-11eb-bb56-6f9f445e39b2.jpg?resize=600%2C336",
+    "excerpt": "(GSPN) – The Father Duenas Memorial School alumni kicked off its basketball tournament over the weekend, providing much excitement to those present at the FD gym known as “The Jungle.”"
+  },
+  {
+    "year": 2015,
+    "publishedAt": "2015-06-21",
+    "source": "PostGuam",
+    "title": "Playoff action underway for FD Alumni Tournament",
+    "url": "https://www.postguam.com/sports/local/playoff-action-underway-for-fd-alumni-tournament/article_fda729c7-dca5-5a37-91f3-dd4127386b4e.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/e/9f/e9fd3d89-3084-5a4a-ba64-faa6055c91e6/566b023052baf.image.jpg?crop=250%2C250%2C63%2C0&resize=200%2C200&order=crop%2Cresize",
+    "excerpt": "PLAYOFFS have just started in the FD Alumni Tournament and things are already heating up with classes bringing in the competitiveness showing how much they want to win."
+  },
+  {
+    "year": 2015,
+    "publishedAt": "2015-06-15",
+    "source": "PostGuam",
+    "title": "One week done in FD alumni hoops",
+    "url": "https://www.postguam.com/sports/local/one-week-done-in-fd-alumni-hoops/article_e43a2a44-005d-5361-89c4-16b3566e1bfc.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/c/9d/c9d24c56-cab8-580c-8b48-a727e3a33aab/566b01b8eba64.image.jpg?resize=200%2C200",
+    "excerpt": "FRIDAY, June 12 represented the one week mark for the 2015 Father Duenas Alumni Tournament and this past week was only the start of barbecue, brotherhood, and basketball."
+  },
+  {
+    "year": 2015,
+    "publishedAt": "2015-06-28",
+    "source": "PostGuam",
+    "title": "Class of 2013 wins first FD Alumni Basketball tourney",
+    "url": "https://www.postguam.com/sports/local/class-of-2013-wins-first-fd-alumni-basketball-tourney/article_8a8f0516-605b-57a7-9855-a28b287c8570.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/9/f7/9f7a3457-736d-526b-9e5d-7dc37f355768/566b01920b57e.image.jpg?crop=250%2C250%2C63%2C0&resize=200%2C200&order=crop%2Cresize",
+    "excerpt": "THE 30th annual Father Duenas Alumni Basketball has come to a close and a packed FD gym known as the “jungle” witnessed a competitive game featuring the defending champion class"
+  },
+  {
+    "year": 2022,
+    "publishedAt": "2022-07-16",
+    "source": "PostGuam",
+    "title": "Estella, Perez, Stinnett lead 02/04 to 5th FD Alumni basketball title",
+    "url": "https://www.postguam.com/sports/local/estella-perez-stinnett-lead-02-04-to-5th-fd-alumni-basketball-title/article_42dae3f0-0484-11ed-a886-ff9d4c4c7fe5.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/a/59/a59021e4-0485-11ed-bdfc-6f8007f30b71/62d1dcf54eeb1.image.png?crop=1053%2C553%2C0%2C106",
+    "excerpt": "Despite a career night form Christian Leon Guerrero, where the class-of-2020 sharpshooter drained an unprecedented six three-pointers in the first half, the class of 2002/2004 claimed their fifth Father Duenas"
+  },
+  {
+    "year": 2025,
+    "publishedAt": "2025-07-15",
+    "source": "PostGuam",
+    "title": "FDMS alumni return to the jungle for hoops, memories, and giving back",
+    "url": "https://www.postguam.com/forum/letter_to_the_editor/fdms-alumni-return-to-the-jungle-for-hoops-memories-and-giving-back/article_f1cdf2e6-e095-4ffb-ac30-c1d07d3b15d9.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/d/5c/d5c009bc-410c-4c39-aca0-812023ec494a/686d099a56c60.image.jpg?crop=1763%2C926%2C0%2C124&resize=1200%2C630&order=crop%2Cresize",
+    "excerpt": "Summer is here and on Guam that means BBQs, basketball and reconnecting with old friends. Over the last few weeks, alumni from the island’s only private boys' school made their"
+  },
+  {
+    "year": 2014,
+    "publishedAt": "2014-07-18",
+    "source": "PostGuam",
+    "title": "Class of '65 scores upset in Father Duenas tournament",
+    "url": "https://www.postguam.com/sports/local/class-of-65-scores-upset-in-father-duenas-tournament/article_9eed1e68-3acd-54f5-b5bb-ec8ed0af6c55.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/d/fe/dfe271b2-9192-5f40-bde5-0fdbf52837c2/566b006750bd0.image.jpg?crop=250%2C250%2C63%2C0&resize=200%2C200&order=crop%2Cresize",
+    "excerpt": "FATHER Duenas Alumni basketball teams battled their way through the FD Tournament single game elimination playoffs that began on Sunday."
+  },
+  {
+    "year": 2014,
+    "publishedAt": "2014-07-21",
+    "source": "PostGuam",
+    "title": "Class of 1974 wins Father Duenas milestone basketball game",
+    "url": "https://www.postguam.com/sports/local/class-of-1974-wins-father-duenas-milestone-basketball-game/article_5064f09e-150d-5370-a554-f664c43c3c7d.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/custom/image/f433efec-b17a-11eb-bb56-6f9f445e39b2.jpg?resize=600%2C336",
+    "excerpt": "WITH the score tied 36-36 in the closing 30 seconds of the Father Duenas Alumni basketball Milestone Game, which was a friendly grudge match between the Class of 1974 and"
+  },
+  {
+    "year": 2008,
+    "publishedAt": "2008-07-10",
+    "source": "PostGuam",
+    "title": "FDMS Alumni Basketball Tournament begins tomorrow",
+    "url": "https://www.postguam.com/sports/local/fdms-alumni-basketball-tournament-begins-tomorrow/article_9aeccdf9-1071-52c5-b595-4bb65084c9de.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/custom/image/f433efec-b17a-11eb-bb56-6f9f445e39b2.jpg?resize=600%2C336",
+    "excerpt": "THE FATHER Duenas Memorial School Class of 1998 is proud to announce the commencement of the 2008 FDMS Alumni Basketball Tournament, which is set to begin bright and early tomorrow"
+  },
+  {
+    "year": 2008,
+    "publishedAt": "2008-07-16",
+    "source": "PostGuam",
+    "title": "’99/’97 survives against ’01, 49-43",
+    "url": "https://www.postguam.com/sports/local/99-97-survives-against-01-49-43/article_da3c3bf6-dd59-5811-bd64-0509848c6384.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/8/20/820424c6-7606-5cf7-b3db-c398c1f1eb01/566af8add32af.image.jpg?crop=225%2C225%2C0%2C37&resize=200%2C200&order=crop%2Cresize",
+    "excerpt": "DAY five of the 2008 Father Duenas Memorial School Alumni Basketball Tournament went down last night at “the Jungle” in Mangilao with another triple header."
+  },
+  {
+    "year": 2008,
+    "publishedAt": "2008-07-29",
+    "source": "PostGuam",
+    "title": "’99/’97 downs ’02, 44-35: ’95 set to challenge ’99/’97 for title",
+    "url": "https://www.postguam.com/sports/local/99-97-downs-02-44-35-95-set-to-challenge-99-97-for-title/article_d0c41798-5f84-5448-97d0-5d8c7aa60330.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/a/61/a61a1885-3de9-5c50-b6ec-b6e91d1b7e6f/566af90c47e04.image.jpg?crop=231%2C231%2C34%2C0&resize=200%2C200&order=crop%2Cresize",
+    "excerpt": "AFTER weeks of fast paced action in the 2008 Father Duenas Memorial School Alumni Basketball Tournament, it all came down to the final four squads as intense semifinal action unfolded"
+  },
+  {
+    "year": 2025,
+    "publishedAt": "2025-07-19",
+    "source": "GuamPDN",
+    "title": "Team '02/'04 earns 4th FD alumni crown after win against class of 2013",
+    "url": "https://www.guampdn.com/sports/team-02-04-earns-4th-fd-alumni-crown-after-win-against-class-of-2013/article_d994f2ca-fc6e-4d76-974f-4b6716c4d7ea.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/2/5a/25acebb0-e7dc-4cbe-a956-c484a3c268a0/687b2870ee699.image.png?crop=1024%2C538%2C0%2C72",
+    "excerpt": "The combined classes of 2002 & 2004 defeated the class of 2013 to win their fourth Father Dueñas Alumni Basketball championship as a group."
+  },
+  {
+    "year": 2025,
+    "publishedAt": "2025-07-17",
+    "source": "GuamPDN",
+    "title": "FD alumni basketball tournament coming to a close",
+    "url": "https://www.guampdn.com/sports/fd-alumni-basketball-tournament-coming-to-a-close/article_20910fef-aa5c-4870-b0fc-766167e38dba.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/8/66/866be33e-3dae-11ef-88c3-033c4112810d/668cc12e0f317.image.png?crop=1193%2C626%2C0%2C84",
+    "excerpt": "Summer is here and on Guam, that means BBQs, basketball, and reconnecting with old friends."
+  },
+  {
+    "year": 2025,
+    "publishedAt": "2025-06-30",
+    "source": "GuamPDN",
+    "title": "FD alumni basketball tournament opens with a bang",
+    "url": "https://www.guampdn.com/sports/fd-alumni-basketball-tournament-opens-with-a-bang/article_f5598b72-ddd2-44b4-83fa-b0864fde94ed.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/6/00/600744c0-c2b1-46d6-9760-fc55af61c589/68621e440d2dc.image.png?crop=1191%2C625%2C0%2C82",
+    "excerpt": "The Father Duenas Memorial School Alumni Tournament kicked off on Friday night with a not too surprising upset."
+  },
+  {
+    "year": 2024,
+    "publishedAt": "2024-07-20",
+    "source": "GuamPDN",
+    "title": "Shimizu sinks game winner, 16/17 wins FD alumni tournament",
+    "url": "https://www.guampdn.com/sports/shimizu-sinks-game-winner-16-17-wins-fd-alumni-tournament/article_33f3a928-462a-11ef-b1e2-6f95570cec09.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/6/a7/6a7d1ad2-462b-11ef-b009-0f73a37c4a48/669afeaf91248.image.png?crop=1763%2C926%2C0%2C124&resize=1200%2C630&order=crop%2Cresize",
+    "excerpt": "Add Leon Shimizu to the legends list of the heralded FD Alumni Basketball Tournament."
+  },
+  {
+    "year": 2022,
+    "publishedAt": "2022-06-16",
+    "source": "GuamPDN",
+    "title": "FD Alumni Basketball Tournament kicks off June 24",
+    "url": "https://www.guampdn.com/sports/fd-alumni-basketball-tournament-kicks-off-june-24/article_ce5e5730-ed33-11ec-80be-a3074b11137d.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/1/c2/1c26d158-ed3a-11ec-8310-9bc7c5a7fda4/62aac8bc8744c.image.jpg?crop=1200%2C630%2C0%2C58",
+    "excerpt": "The Father Dueñas Memorial School class of 2006 will attempt to defend, and win an unprecedented ninth title at the annual FD Alumni Basketball Tournament, scheduled to start June 24"
+  },
+  {
+    "year": 2017,
+    "publishedAt": "2017-07-12",
+    "source": "GuamPDN",
+    "title": "2006 to square off with 2002/4 at FD Alumni basketball tournament finals",
+    "url": "https://www.guampdn.com/sports/2006-to-square-off-with-2002-4-at-fd-alumni-basketball-tournament-finals/article_cffcb7ee-7630-5e80-88c6-639fa2efb1b7.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/custom/image/d1d0565a-bcb2-11eb-8535-ab06d41ce483.jpg?resize=600%2C315",
+    "excerpt": "The 2017 FDAA Basketball tournament championship game is set, as the 6-time champs of 2006 will square off against the new combined powerhouse of 2002/2004. The championship is scheduled for"
+  },
+  {
+    "year": 2023,
+    "publishedAt": "2023-07-19",
+    "source": "GuamPDN",
+    "title": "FD Friars Alumni Tournament in final days",
+    "url": "https://www.guampdn.com/sports/fd-friars-alumni-tournament-in-final-days/article_39cf3a9c-25ec-11ee-8915-f31eed85791b.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/5/5d/55d5ef64-25ed-11ee-9026-9f03c985eb90/64b7677940773.image.jpg?crop=1589%2C834%2C0%2C234&resize=1200%2C630&order=crop%2Cresize",
+    "excerpt": "After weeks of barbecue, beverages, brotherhood and yes, basketball, the FDMS Alumni Summer Tournament is coming to a close, following its penultimate set of games on Wednesday night."
+  },
+  {
+    "year": 2023,
+    "publishedAt": "2023-07-17",
+    "source": "GuamPDN",
+    "title": "FD alumni hoops playoff recap",
+    "url": "https://www.guampdn.com/sports/fd-alumni-hoops-playoff-recap/article_c80ab5e0-2473-11ee-aa53-eb117b27b1ec.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/d/68/d68c36f4-fa83-11ec-a417-c3566bd738ca/62c112f4d93b9.image.jpg?crop=1548%2C813%2C0%2C263&resize=1200%2C630&order=crop%2Cresize",
+    "excerpt": "Playoff weekend has begun for the 2023 FD Alumni Tournament. More than half of the competition was knocked over the weekend, and the climactic championship is fast approaching."
+  },
+  {
+    "year": 2024,
+    "publishedAt": "2024-07-10",
+    "source": "GuamPDN",
+    "title": "FD alumni basketball hits halfway point",
+    "url": "https://www.guampdn.com/sports/fd-alumni-basketball-hits-halfway-point/article_16e92774-3dae-11ef-a703-3b80c0bd0c0c.html",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/guampdn.com/content/tncms/assets/v3/editorial/d/18/d183e9fc-3dae-11ef-bdb1-c7aa51df61e4/668cc1ac0be40.image.png?crop=1058%2C555%2C0%2C74",
+    "excerpt": "The annual FD Basketball Alumni Tournament has hit the halfway mark with games going on nightly and a slew of action on the weekends."
+  }
+]
+
+export const EXTRA_ARCHIVE_MEDIA: ArchiveMedia[] = [
+  {
+    "year": 2022,
+    "source": "PostGuam",
+    "title": "2022 FD Alumni Championship photo 1",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/a/59/a59021e4-0485-11ed-bdfc-6f8007f30b71/62d1dcf54eeb1.image.png?resize=687%2C500",
+    "articleUrl": "https://www.postguam.com/sports/local/estella-perez-stinnett-lead-02-04-to-5th-fd-alumni-basketball-title/article_42dae3f0-0484-11ed-a886-ff9d4c4c7fe5.html",
+    "caption": "02/04 defeated 2020 62-52 in the 2022 FD Alumni Basketball Tournament championship. Photos credited in source to Matua Salas/GSPN.",
+    "takenAt": "2022-07-15"
+  },
+  {
+    "year": 2022,
+    "source": "PostGuam",
+    "title": "2022 FD Alumni Championship photo 2",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/b/a1/ba150030-0485-11ed-9ca2-4b1a6cf1038d/62d1dd17b6bff.image.png?resize=814%2C500",
+    "articleUrl": "https://www.postguam.com/sports/local/estella-perez-stinnett-lead-02-04-to-5th-fd-alumni-basketball-title/article_42dae3f0-0484-11ed-a886-ff9d4c4c7fe5.html",
+    "caption": "02/04 defeated 2020 62-52 in the 2022 FD Alumni Basketball Tournament championship. Photos credited in source to Matua Salas/GSPN.",
+    "takenAt": "2022-07-15"
+  },
+  {
+    "year": 2022,
+    "source": "PostGuam",
+    "title": "2022 FD Alumni Championship photo 3",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/9/f2/9f2b01ac-0485-11ed-ab9b-6318ec52cda5/62d1dcea9113d.image.png?resize=884%2C500",
+    "articleUrl": "https://www.postguam.com/sports/local/estella-perez-stinnett-lead-02-04-to-5th-fd-alumni-basketball-title/article_42dae3f0-0484-11ed-a886-ff9d4c4c7fe5.html",
+    "caption": "02/04 defeated 2020 62-52 in the 2022 FD Alumni Basketball Tournament championship. Photos credited in source to Matua Salas/GSPN.",
+    "takenAt": "2022-07-15"
+  },
+  {
+    "year": 2022,
+    "source": "PostGuam",
+    "title": "2022 FD Alumni Championship photo 4",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/a/b3/ab303f26-0485-11ed-a6c7-033be20f89c0/62d1dcfeb9dfb.image.png?resize=839%2C500",
+    "articleUrl": "https://www.postguam.com/sports/local/estella-perez-stinnett-lead-02-04-to-5th-fd-alumni-basketball-title/article_42dae3f0-0484-11ed-a886-ff9d4c4c7fe5.html",
+    "caption": "02/04 defeated 2020 62-52 in the 2022 FD Alumni Basketball Tournament championship. Photos credited in source to Matua Salas/GSPN.",
+    "takenAt": "2022-07-15"
+  },
+  {
+    "year": 2022,
+    "source": "PostGuam",
+    "title": "2022 FD Alumni Championship photo 5",
+    "imageUrl": "https://bloximages.newyork1.vip.townnews.com/postguam.com/content/tncms/assets/v3/editorial/b/22/b2246eb0-0485-11ed-b643-fb57f8261281/62d1dd0a68877.image.png?resize=892%2C500",
+    "articleUrl": "https://www.postguam.com/sports/local/estella-perez-stinnett-lead-02-04-to-5th-fd-alumni-basketball-title/article_42dae3f0-0484-11ed-a886-ff9d4c4c7fe5.html",
+    "caption": "02/04 defeated 2020 62-52 in the 2022 FD Alumni Basketball Tournament championship. Photos credited in source to Matua Salas/GSPN.",
+    "takenAt": "2022-07-15"
+  }
+]
+
+
+export const CHAMPION_RECORDS: ChampionRecord[] = [
+  { year: 2025, champion: 'Class of 2002/04', runnerUp: 'Class of 2013', score: '50-44', source: 'GSPN / GuamPDN' },
+  { year: 2024, champion: 'Class of 2016/17', runnerUp: 'Class of 2013', score: '58-56', source: 'GSPN / GuamPDN' },
+  { year: 2023, champion: 'Class of 2013', source: 'GSPN' },
+  { year: 2022, champion: 'Class of 2002/04', runnerUp: 'Class of 2020', score: '62-52', source: 'GSPN / PostGuam' },
+  { year: 2021, champion: 'Class of 2006', runnerUp: 'Class of 2002/04', score: '58-38', source: 'GSPN' },
+  { year: 2020, status: 'cancelled', source: 'COVID-19', note: 'Tournament cancelled during COVID-19 period.' },
+  { year: 2019, champion: 'Class of 2006', runnerUp: 'Class of 2009', score: '49-46', source: 'GSPN' },
+  { year: 2018, champion: 'Class of 2002/04', runnerUp: 'Class of 2011/12', source: 'GSPN' },
+  { year: 2017, champion: 'Class of 2002/04', runnerUp: 'Class of 2006', score: '48-46', source: 'GSPN' },
+  { year: 2016, status: 'unknown', source: 'PostGuam', note: 'Tournament existed; only partial public online records recovered so far.' },
+  { year: 2015, champion: 'Class of 2013', runnerUp: 'Class of 2004', score: '60-48', source: 'GSPN / PostGuam' },
+  { year: 2014, champion: 'Class of 2004', source: 'GSPN' },
+  { year: 2013, champion: 'Class of 2006', source: 'GSPN / historical champions list' },
+  { year: 2012, champion: 'Class of 2006', source: 'GSPN / historical champions list' },
+  { year: 2011, champion: 'Class of 2006', source: 'Historical champions list' },
+  { year: 2010, champion: 'Class of 2006', source: 'Historical champions list' },
+  { year: 2009, champion: 'Class of 2002', source: 'Historical champions list' },
+  { year: 2008, champion: 'Class of 1995', source: 'PostGuam / historical champions list' },
+  { year: 2007, champion: 'Class of 2006', source: 'Historical champions list' },
+  { year: 2006, champion: 'Class of 2002/03', source: 'Historical champions list' },
+  { year: 2005, champion: 'Class of 1991', source: 'Historical champions list' },
+]
+
+export const STATIC_TOURNAMENT_YEARS = [
+  2025, 2024, 2023, 2022, 2021, 2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013, 2012, 2011, 2010, 2009, 2008, 2007, 2006, 2005,
+] as const
+
+export function archiveArticlesForYear(year: number): ArchiveArticle[] {
+  return ARCHIVE_ARTICLES.filter((article) => article.year === year)
+}
+
+export function archiveMediaForYear(year: number): ArchiveMedia[] {
+  const articleMedia = ARCHIVE_ARTICLES
+    .filter((article) => article.year === year && article.imageUrl)
+    .map((article) => ({
+      year: article.year,
+      source: article.source,
+      title: article.title,
+      imageUrl: article.imageUrl!,
+      articleUrl: article.url,
+      caption: article.excerpt,
+      takenAt: article.publishedAt,
+      tags: article.title.toLowerCase().includes('champ') || article.title.toLowerCase().includes('crown') || article.title.toLowerCase().includes('title') ? 'featured' : null,
+    }))
+
+  return [...articleMedia, ...EXTRA_ARCHIVE_MEDIA.filter((item) => item.year === year)]
+}
+
+export function championForYear(year: number): ChampionRecord | undefined {
+  return CHAMPION_RECORDS.find((record) => record.year === year)
+}
+
+export function allArchiveSourcesForYear(year: number): string[] {
+  return Array.from(new Set([
+    ...archiveArticlesForYear(year).map((item) => item.source),
+    ...archiveMediaForYear(year).map((item) => item.source),
+  ])).sort()
+}

--- a/apps/web/src/lib/repositories/tournament-repo.ts
+++ b/apps/web/src/lib/repositories/tournament-repo.ts
@@ -1,30 +1,35 @@
-import { db } from '@/lib/db'
+import { db, withDatabaseFallback } from '@/lib/db'
 
 export async function getHomeTournamentContext() {
-  const [upcomingOrLive, latestCompletedWithGames] = await Promise.all([
-    db.tournament.findFirst({
-      where: { status: { in: ['live', 'upcoming'] } },
-      orderBy: [{ year: 'desc' }],
-    }),
-    db.tournament.findFirst({
-      where: {
-        status: 'completed',
-        games: { some: {} },
-      },
-      orderBy: [{ year: 'desc' }],
-    }),
-  ])
+  return withDatabaseFallback(async () => {
+    const [upcomingOrLive, latestCompletedWithGames] = await Promise.all([
+      db.tournament.findFirst({
+        where: { status: { in: ['live', 'upcoming'] } },
+        orderBy: [{ year: 'desc' }],
+      }),
+      db.tournament.findFirst({
+        where: {
+          status: 'completed',
+          games: { some: {} },
+        },
+        orderBy: [{ year: 'desc' }],
+      }),
+    ])
 
-  return { upcomingOrLive, latestCompletedWithGames }
+    return { upcomingOrLive, latestCompletedWithGames }
+  }, { upcomingOrLive: null, latestCompletedWithGames: null })
 }
 
 export async function getActiveTournament() {
   const { upcomingOrLive, latestCompletedWithGames } = await getHomeTournamentContext()
 
   const upcomingOrLiveWithGames = upcomingOrLive
-    ? await db.tournament.findFirst({
-        where: { id: upcomingOrLive.id, games: { some: {} } },
-      })
+    ? await withDatabaseFallback(
+        () => db.tournament.findFirst({
+          where: { id: upcomingOrLive.id, games: { some: {} } },
+        }),
+        null,
+      )
     : null
 
   if (upcomingOrLiveWithGames) return upcomingOrLiveWithGames
@@ -33,5 +38,5 @@ export async function getActiveTournament() {
 }
 
 export async function getTournamentByYear(year: number) {
-  return db.tournament.findFirst({ where: { year } })
+  return withDatabaseFallback(() => db.tournament.findFirst({ where: { year } }), null)
 }

--- a/apps/web/src/lib/services/public-feed.ts
+++ b/apps/web/src/lib/services/public-feed.ts
@@ -2,7 +2,7 @@ import type { Prisma } from '@prisma/client'
 import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament, getHomeTournamentContext } from '@/lib/repositories/tournament-repo'
 import { resolveGameDivision } from '@/lib/divisions'
-import { archiveArticlesForYear } from '@/lib/historical-archive'
+import { LATEST_ARCHIVE_YEAR, archiveArticlesForYear } from '@/lib/historical-archive'
 import { guamDateStringToDate, guamDayRange } from '@/lib/datetime'
 
 export type FeedArticle = {
@@ -71,7 +71,7 @@ export async function getHomeFeed(): Promise<HomeFeed> {
       latestResultsTournament: context.latestCompletedWithGames,
       todayGames: [] as HomeFeed['todayGames'],
       liveGames: [] as HomeFeed['liveGames'],
-      latestNews: mergeArchiveArticles([], 2025, 5),
+      latestNews: mergeArchiveArticles([], LATEST_ARCHIVE_YEAR, 5),
     }
   }
 

--- a/apps/web/src/lib/services/public-feed.ts
+++ b/apps/web/src/lib/services/public-feed.ts
@@ -1,6 +1,21 @@
+import type { Prisma } from '@prisma/client'
 import { db } from '@/lib/db'
 import { getActiveTournament, getHomeTournamentContext } from '@/lib/repositories/tournament-repo'
 import { resolveGameDivision } from '@/lib/divisions'
+import { archiveArticlesForYear } from '@/lib/historical-archive'
+import { guamDayRange } from '@/lib/datetime'
+
+export type FeedArticle = {
+  id: string
+  tournamentId?: string
+  title: string
+  source: string
+  url: string
+  imageUrl?: string | null
+  excerpt?: string | null
+  publishedAt: Date | null
+  createdAt?: Date
+}
 
 type HomeFeed = {
   tournament: Awaited<ReturnType<typeof getActiveTournament>>
@@ -8,7 +23,39 @@ type HomeFeed = {
   latestResultsTournament: Awaited<ReturnType<typeof getHomeTournamentContext>>['latestCompletedWithGames']
   todayGames: Awaited<ReturnType<typeof db.game.findMany>>
   liveGames: Awaited<ReturnType<typeof db.game.findMany>>
-  latestNews: Awaited<ReturnType<typeof db.articleLink.findMany>>
+  latestNews: FeedArticle[]
+}
+
+export function mergeArchiveArticles(dbArticles: FeedArticle[], year: number, take?: number): FeedArticle[] {
+  const seen = new Set<string>()
+  const merged: FeedArticle[] = []
+
+  for (const item of dbArticles) {
+    seen.add(item.url)
+    merged.push(item)
+  }
+
+  for (const item of archiveArticlesForYear(year)) {
+    if (seen.has(item.url)) continue
+    seen.add(item.url)
+    merged.push({
+      id: `archive:${item.url}`,
+      title: item.title,
+      source: item.source,
+      url: item.url,
+      imageUrl: item.imageUrl,
+      excerpt: item.excerpt,
+      publishedAt: item.publishedAt ? new Date(`${item.publishedAt}T00:00:00+10:00`) : null,
+    })
+  }
+
+  merged.sort((a, b) => {
+    const aTime = a.publishedAt?.getTime() ?? a.createdAt?.getTime() ?? 0
+    const bTime = b.publishedAt?.getTime() ?? b.createdAt?.getTime() ?? 0
+    return bTime - aTime
+  })
+
+  return typeof take === 'number' ? merged.slice(0, take) : merged
 }
 
 export async function getHomeFeed(): Promise<HomeFeed> {
@@ -24,15 +71,11 @@ export async function getHomeFeed(): Promise<HomeFeed> {
       latestResultsTournament: context.latestCompletedWithGames,
       todayGames: [] as HomeFeed['todayGames'],
       liveGames: [] as HomeFeed['liveGames'],
-      latestNews: [] as HomeFeed['latestNews'],
+      latestNews: [],
     }
   }
 
-  const now = new Date()
-  const start = new Date(now)
-  start.setHours(0, 0, 0, 0)
-  const end = new Date(now)
-  end.setHours(23, 59, 59, 999)
+  const { start, end } = guamDayRange()
 
   const [todayGames, liveGames, latestNews] = await Promise.all([
     db.game.findMany({
@@ -50,7 +93,7 @@ export async function getHomeFeed(): Promise<HomeFeed> {
     db.articleLink.findMany({
       where: { tournamentId: tournament.id },
       orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
-      take: 5,
+      take: 25,
     }),
   ])
 
@@ -60,7 +103,7 @@ export async function getHomeFeed(): Promise<HomeFeed> {
     latestResultsTournament: context.latestCompletedWithGames,
     todayGames,
     liveGames,
-    latestNews,
+    latestNews: mergeArchiveArticles(latestNews, tournament.year, 5),
   }
 }
 
@@ -102,8 +145,8 @@ export async function getSchedule(
   if (!tournament) return { tournament: null, games: [], divisions: [], phases: [] }
 
   // Build where clause
-  const where: any = { tournamentId: tournament.id }
-  const andFilters: any[] = []
+  const where: Prisma.GameWhereInput = { tournamentId: tournament.id }
+  const andFilters: Prisma.GameWhereInput[] = []
 
   if (divisionFilter) {
     // Match games where game.division = filter OR (game.division is null AND homeTeam.division = filter)
@@ -212,7 +255,7 @@ export async function getStandings(
   }
 
   // Apply filter: if divisionFilter set, filter teams by division
-  const teamWhere: any = { tournamentId: tournament.id }
+  const teamWhere: Prisma.TeamWhereInput = { tournamentId: tournament.id }
   if (divisionFilter) teamWhere.division = divisionFilter
 
   const [standings, totalGames, scoredGames] = await Promise.all([

--- a/apps/web/src/lib/services/public-feed.ts
+++ b/apps/web/src/lib/services/public-feed.ts
@@ -3,7 +3,7 @@ import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament, getHomeTournamentContext } from '@/lib/repositories/tournament-repo'
 import { resolveGameDivision } from '@/lib/divisions'
 import { archiveArticlesForYear } from '@/lib/historical-archive'
-import { guamDayRange } from '@/lib/datetime'
+import { guamDateStringToDate, guamDayRange } from '@/lib/datetime'
 
 export type FeedArticle = {
   id: string
@@ -45,7 +45,7 @@ export function mergeArchiveArticles(dbArticles: FeedArticle[], year: number, ta
       url: item.url,
       imageUrl: item.imageUrl,
       excerpt: item.excerpt,
-      publishedAt: item.publishedAt ? new Date(`${item.publishedAt}T00:00:00+10:00`) : null,
+      publishedAt: item.publishedAt ? guamDateStringToDate(item.publishedAt) : null,
     })
   }
 

--- a/apps/web/src/lib/services/public-feed.ts
+++ b/apps/web/src/lib/services/public-feed.ts
@@ -1,5 +1,5 @@
 import type { Prisma } from '@prisma/client'
-import { db } from '@/lib/db'
+import { db, withDatabaseFallback } from '@/lib/db'
 import { getActiveTournament, getHomeTournamentContext } from '@/lib/repositories/tournament-repo'
 import { resolveGameDivision } from '@/lib/divisions'
 import { archiveArticlesForYear } from '@/lib/historical-archive'
@@ -71,13 +71,13 @@ export async function getHomeFeed(): Promise<HomeFeed> {
       latestResultsTournament: context.latestCompletedWithGames,
       todayGames: [] as HomeFeed['todayGames'],
       liveGames: [] as HomeFeed['liveGames'],
-      latestNews: [],
+      latestNews: mergeArchiveArticles([], 2025, 5),
     }
   }
 
   const { start, end } = guamDayRange()
 
-  const [todayGames, liveGames, latestNews] = await Promise.all([
+  const [todayGames, liveGames, latestNews] = await withDatabaseFallback(() => Promise.all([
     db.game.findMany({
       where: { tournamentId: tournament.id, startTime: { gte: start, lte: end } },
       include: { homeTeam: true, awayTeam: true },
@@ -95,7 +95,7 @@ export async function getHomeFeed(): Promise<HomeFeed> {
       orderBy: [{ publishedAt: 'desc' }, { createdAt: 'desc' }],
       take: 25,
     }),
-  ])
+  ]), [[], [], []] as const)
 
   return {
     tournament,
@@ -140,7 +140,7 @@ export async function getSchedule(
   phaseFilter?: 'pool' | 'playoff' | 'fatherson' | null,
 ): Promise<ScheduleFeed> {
   const tournament = tournamentId
-    ? await db.tournament.findUnique({ where: { id: tournamentId } })
+    ? await withDatabaseFallback(() => db.tournament.findUnique({ where: { id: tournamentId } }), null)
     : await getActiveTournament()
   if (!tournament) return { tournament: null, games: [], divisions: [], phases: [] }
 
@@ -172,19 +172,19 @@ export async function getSchedule(
 
   if (andFilters.length > 0) where.AND = andFilters
 
-  const games = await db.game.findMany({
+  const games = await withDatabaseFallback(() => db.game.findMany({
     where,
     include: { homeTeam: true, awayTeam: true },
     orderBy: { startTime: 'asc' },
     take: 500,
-  })
+  }), [] as ScheduleGame[])
 
   // Collect distinct divisions from this tournament's games
   const allGames = divisionFilter
-    ? await db.game.findMany({
+    ? await withDatabaseFallback(() => db.game.findMany({
         where: { tournamentId: tournament.id },
         select: { division: true, homeTeam: { select: { division: true } } },
-      })
+      }), [])
     : games.map(g => ({ division: g.division, homeTeam: { division: g.homeTeam.division } }))
 
   const divSet = new Set<string>()
@@ -194,10 +194,10 @@ export async function getSchedule(
     if (resolved) divSet.add(resolved)
   }
 
-  const phaseRows = await db.game.findMany({
+  const phaseRows = await withDatabaseFallback(() => db.game.findMany({
     where: { tournamentId: tournament.id },
     select: { notes: true, bracketCode: true, homeTeam: { select: { displayName: true } }, awayTeam: { select: { displayName: true } } },
-  })
+  }), [])
   for (const g of phaseRows) {
     if (g.notes?.includes('phase=pool')) phaseSet.add('pool')
     if (g.notes?.includes('phase=playoff')) phaseSet.add('playoff')
@@ -235,7 +235,7 @@ export async function getStandings(
   divisionFilter?: string | null,
 ): Promise<StandingsFeed> {
   const tournament = tournamentId
-    ? await db.tournament.findUnique({ where: { id: tournamentId } })
+    ? await withDatabaseFallback(() => db.tournament.findUnique({ where: { id: tournamentId } }), null)
     : await getActiveTournament()
   if (!tournament) return {
     tournament: null,
@@ -245,10 +245,10 @@ export async function getStandings(
   }
 
   // Get all teams' divisions for the tab list
-  const allTeams = await db.team.findMany({
+  const allTeams = await withDatabaseFallback(() => db.team.findMany({
     where: { tournamentId: tournament.id },
     select: { division: true },
-  })
+  }), [])
   const divSet = new Set<string>()
   for (const t of allTeams) {
     if (t.division) divSet.add(t.division)
@@ -258,7 +258,7 @@ export async function getStandings(
   const teamWhere: Prisma.TeamWhereInput = { tournamentId: tournament.id }
   if (divisionFilter) teamWhere.division = divisionFilter
 
-  const [standings, totalGames, scoredGames] = await Promise.all([
+  const [standings, totalGames, scoredGames] = await withDatabaseFallback(() => Promise.all([
     db.standing.findMany({
       where: {
         tournamentId: tournament.id,
@@ -276,7 +276,7 @@ export async function getStandings(
         awayScore: { not: null },
       },
     }),
-  ])
+  ]), [[], 0, 0] as const)
 
   const percent = totalGames ? Math.round((scoredGames / totalGames) * 1000) / 10 : 0
 

--- a/docs/PROJECT-STATUS-2026-03-04.md
+++ b/docs/PROJECT-STATUS-2026-03-04.md
@@ -10,7 +10,18 @@ The hub is now in a strong **functional beta** state for 2025 replay/testing:
 - Historical content ingest is 96% complete
 - Champion data verified for 2014-2025 (excluding 2016)
 
-Current 2025 score coverage: **14 / 93 games (15.1%)**
+Current 2025 score coverage in the historical docs was **14 / 93 games (15.1%)** before the June 2026 refresh.
+
+## Update — 2026-06-11
+
+- Added a static researched archive layer in `apps/web/src/lib/historical-archive.ts` so the public site can show historical articles, media, and champion records before the database is backfilled.
+- Added `npm --workspace @fd/web run import:archive-content` to materialize that archive into the database when `DATABASE_URL` is available.
+- Added GSPN opening-weekend 2025 results to `apps/web/scripts/import-2025-gspn-scores.ts`.
+- Fixed Guam timezone formatting and past-game status display in public/admin schedule views.
+- Added `apps/web/.env.example` and made `build` run `prisma generate` before `next build`.
+- Production database imports/migrations were not run from the local harness because production secrets were unavailable.
+
+See `docs/research/public-archive-refresh-2026-06-11.md` for source notes and remaining gaps.
 
 ---
 

--- a/docs/research/public-archive-refresh-2026-06-11.md
+++ b/docs/research/public-archive-refresh-2026-06-11.md
@@ -1,0 +1,46 @@
+# FD Alumni public archive refresh — 2026-06-11
+
+## Scope
+
+Reviewed public tournament context and added a static archive layer for historical coverage that can be rendered immediately and optionally imported into the database.
+
+## Sources reviewed
+
+- GSPN / Guam Sports Network public article pages and WordPress REST responses
+- PostGuam and GuamPDN public coverage references where available
+- Existing repo ingest reports and partner/readiness docs
+- Brain-Dump FD Alumni tournament runbook
+
+## Added to app
+
+- Static archive articles and media in `apps/web/src/lib/historical-archive.ts`
+- Champion/runner-up records where publicly confirmed
+- Runtime merges so `/`, `/news`, `/gallery`, and `/history` can show researched archive content even before the DB is backfilled
+- Optional DB import script: `npm --workspace @fd/web run import:archive-content`
+
+## Confirmed champions/results now represented
+
+| Year | Champion | Runner-up | Score | Source context |
+|---|---|---|---:|---|
+| 2025 | 2002/04 | 2013 | 50–44 | GSPN championship recap |
+| 2024 | 2016/17 | 2013 | 58–56 | GSPN championship recap |
+| 2022 | 2002/04 | 2020 | 62–52 | GSPN championship recap |
+| 2021 | 2006 | 2002/04 | 58–38 | GSPN / public recap context |
+| 2019 | 2006 | 2009 | 49–46 | GSPN championship recap |
+| 2017 | 2002/04 | 2006 | 48–46 | GSPN championship recap |
+| 2015 | 2013 | 2004 | 60–48 | GSPN championship recap |
+| 2020 | Cancelled | — | — | COVID-era tournament cancellation marker |
+
+## 2025 score data added to import script
+
+Added opening-weekend GSPN recap scores to `apps/web/scripts/import-2025-gspn-scores.ts`, covering June 28–29 games that were previously absent from the scripted score import.
+
+## Not completed
+
+Production database migrations/imports were not run from this environment because the production `DATABASE_URL` and app secrets were not available locally.
+
+## Remaining data gaps
+
+- 2026 schedule, tickets, streams, sponsors, and organizer-approved wording are still pending partner/organizer coordination.
+- Some historic years still only have partial article/media coverage.
+- Remaining `npm audit --omit=dev` output is limited to 3 moderate PostCSS/Next transitive findings with no currently available non-forced fix in the resolved dependency set.

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,12 +15,12 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1001.0",
         "@aws-sdk/s3-presigned-post": "^3.1001.0",
-        "@clerk/nextjs": "^6.39.0",
+        "@clerk/nextjs": "^6.39.5",
         "@netlify/plugin-nextjs": "^5.8.1",
-        "@prisma/client": "^6.16.2",
+        "@prisma/client": "^6.19.3",
         "csv-parse": "^6.1.0",
         "lucide-react": "^0.577.0",
-        "next": "16.1.6",
+        "next": "^16.2.9",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "zod": "^4.3.6"
@@ -31,8 +31,8 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "16.1.6",
-        "prisma": "^6.16.2",
+        "eslint-config-next": "^16.2.9",
+        "prisma": "^6.19.3",
         "tailwindcss": "^4",
         "tsx": "^4.21.0",
         "typescript": "^5"
@@ -48,560 +48,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "apps/web/node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "js-tokens": "^4.0.0",
-        "picocolors": "^1.1.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/core": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/remapping": "^2.3.5",
-        "convert-source-map": "^2.0.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.3",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "apps/web/node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
-        "@jridgewell/gen-mapping": "^0.3.12",
-        "@jridgewell/trace-mapping": "^0.3.28",
-        "jsesc": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^5.1.1",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "apps/web/node_modules/@babel/template": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@babel/types": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
-    },
-    "apps/web/node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/@eslint-community/regexpp": {
-      "version": "4.12.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
-    },
-    "apps/web/node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
-        "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "apps/web/node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "apps/web/node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "apps/web/node_modules/@eslint/eslintrc": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.3",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/@eslint/js": {
-      "version": "9.39.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      }
-    },
-    "apps/web/node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "apps/web/node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@eslint/core": "^0.17.0",
-        "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "apps/web/node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "apps/web/node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@humanfs/core": "^0.19.1",
-        "@humanwhocodes/retry": "^0.4.0"
-      },
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
-    "apps/web/node_modules/@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=12.22"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "apps/web/node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/nzakas"
-      }
-    },
-    "apps/web/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "apps/web/node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "apps/web/node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "apps/web/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.1.0",
-        "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "apps/web/node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-glob": "3.3.1"
-      }
-    },
-    "apps/web/node_modules/@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "apps/web/node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "apps/web/node_modules/@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "apps/web/node_modules/@nolyfill/is-core-module": {
-      "version": "1.0.39",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.4.0"
-      }
-    },
-    "apps/web/node_modules/@prisma/client": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.16.2.tgz",
-      "integrity": "sha512-E00PxBcalMfYO/TWnXobBVUai6eW/g5OsifWQsQDzJYm7yaY+IRLo7ZLsaefi0QkTpxfuhFcQ/w180i6kX3iJw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18"
-      },
-      "peerDependencies": {
-        "prisma": "*",
-        "typescript": ">=5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "prisma": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@prisma/config": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.16.2.tgz",
-      "integrity": "sha512-mKXSUrcqXj0LXWPmJsK2s3p9PN+aoAbyMx7m5E1v1FufofR1ZpPoIArjjzOIm+bJRLLvYftoNYLx1tbHgF9/yg==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "c12": "3.1.0",
-        "deepmerge-ts": "7.1.5",
-        "effect": "3.16.12",
-        "empathic": "2.0.0"
-      }
-    },
-    "apps/web/node_modules/@prisma/debug": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.16.2.tgz",
-      "integrity": "sha512-bo4/gA/HVV6u8YK2uY6glhNsJ7r+k/i5iQ9ny/3q5bt9ijCj7WMPUwfTKPvtEgLP+/r26Z686ly11hhcLiQ8zA==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "apps/web/node_modules/@prisma/engines": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.16.2.tgz",
-      "integrity": "sha512-7yf3AjfPUgsg/l7JSu1iEhsmZZ/YE00yURPjTikqm2z4btM0bCl2coFtTGfeSOWbQMmq45Jab+53yGUIAT1sjA==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.16.2",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/fetch-engine": "6.16.2",
-        "@prisma/get-platform": "6.16.2"
-      }
-    },
-    "apps/web/node_modules/@prisma/engines-version": {
-      "version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43.tgz",
-      "integrity": "sha512-ThvlDaKIVrnrv97ujNFDYiQbeMQpLa0O86HFA2mNoip4mtFqM7U5GSz2ie1i2xByZtvPztJlNRgPsXGeM/kqAA==",
-      "devOptional": true,
-      "license": "Apache-2.0"
-    },
-    "apps/web/node_modules/@prisma/fetch-engine": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.16.2.tgz",
-      "integrity": "sha512-wPnZ8DMRqpgzye758ZvfAMiNJRuYpz+rhgEBZi60ZqDIgOU2694oJxiuu3GKFeYeR/hXxso4/2oBC243t/whxQ==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.16.2",
-        "@prisma/engines-version": "6.16.0-7.1c57fdcd7e44b29b9313256c76699e91c3ac3c43",
-        "@prisma/get-platform": "6.16.2"
-      }
-    },
-    "apps/web/node_modules/@prisma/get-platform": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.16.2.tgz",
-      "integrity": "sha512-U/P36Uke5wS7r1+omtAgJpEB94tlT4SdlgaeTc6HVTTT93pXj7zZ+B/cZnmnvjcNPfWddgoDx8RLjmQwqGDYyA==",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/debug": "6.16.2"
-      }
-    },
-    "apps/web/node_modules/@rtsao/scc": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT"
     },
     "apps/web/node_modules/@tailwindcss/node": {
       "version": "4.2.1",
@@ -666,21 +112,6 @@
         "tailwindcss": "4.2.1"
       }
     },
-    "apps/web/node_modules/@types/estree": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/@types/json5": {
-      "version": "0.0.29",
-      "dev": true,
-      "license": "MIT"
-    },
     "apps/web/node_modules/@types/node": {
       "version": "20.19.35",
       "dev": true,
@@ -697,830 +128,6 @@
         "@types/react": "^19.2.0"
       }
     },
-    "apps/web/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/type-utils": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
-        "ignore": "^7.0.5",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.56.1",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/parser": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/project-service": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.56.1",
-        "@typescript-eslint/types": "^8.56.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1",
-        "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/types": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.56.1",
-        "@typescript-eslint/tsconfig-utils": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/visitor-keys": "8.56.1",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.4",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "apps/web/node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/@unrs/resolver-binding-darwin-arm64": {
-      "version": "1.11.1",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "apps/web/node_modules/acorn": {
-      "version": "8.16.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "apps/web/node_modules/acorn-jsx": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "apps/web/node_modules/ajv": {
-      "version": "6.14.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "apps/web/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "apps/web/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "apps/web/node_modules/aria-query": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/array-buffer-byte-length": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "is-array-buffer": "^3.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/array-includes": {
-      "version": "3.1.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.0",
-        "es-object-atoms": "^1.1.1",
-        "get-intrinsic": "^1.3.0",
-        "is-string": "^1.1.1",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/array.prototype.findlast": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/array.prototype.findlastindex": {
-      "version": "1.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-shim-unscopables": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/array.prototype.flat": {
-      "version": "1.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/array.prototype.flatmap": {
-      "version": "1.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/array.prototype.tosorted": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3",
-        "es-errors": "^1.3.0",
-        "es-shim-unscopables": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/arraybuffer.prototype.slice": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.1",
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "is-array-buffer": "^3.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/ast-types-flow": {
-      "version": "0.0.8",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/async-function": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/available-typed-arrays": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "possible-typed-array-names": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/axe-core": {
-      "version": "4.11.1",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "apps/web/node_modules/axobject-query": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/balanced-match": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "apps/web/node_modules/braces": {
-      "version": "3.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "apps/web/node_modules/browserslist": {
-      "version": "4.28.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
-    "apps/web/node_modules/call-bind": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.0",
-        "es-define-property": "^1.0.0",
-        "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/call-bind-apply-helpers": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/call-bound": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "get-intrinsic": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/callsites": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/web/node_modules/chalk": {
-      "version": "4.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "apps/web/node_modules/color-convert": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "apps/web/node_modules/color-name": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/concat-map": {
-      "version": "0.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/convert-source-map": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/damerau-levenshtein": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "apps/web/node_modules/data-view-buffer": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/data-view-byte-length": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/inspect-js"
-      }
-    },
-    "apps/web/node_modules/data-view-byte-offset": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-data-view": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/debug": {
-      "version": "4.4.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/deep-is": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/define-data-property": {
-      "version": "1.1.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/define-properties": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/doctrine": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/dunder-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "gopd": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/effect": {
-      "version": "3.16.12",
-      "resolved": "https://registry.npmjs.org/effect/-/effect-3.16.12.tgz",
-      "integrity": "sha512-N39iBk0K71F9nb442TLbTkjl24FLUzuvx2i1I2RsEAQsdAdUTuUoW0vlfUXgkMTUOnYqKnWcFfqw4hK4Pw27hg==",
-      "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0",
-        "fast-check": "^3.23.1"
-      }
-    },
-    "apps/web/node_modules/electron-to-chromium": {
-      "version": "1.5.302",
-      "dev": true,
-      "license": "ISC"
-    },
-    "apps/web/node_modules/emoji-regex": {
-      "version": "9.2.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "apps/web/node_modules/enhanced-resolve": {
       "version": "5.20.0",
       "dev": true,
@@ -1531,1463 +138,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "apps/web/node_modules/es-abstract": {
-      "version": "1.24.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.2",
-        "arraybuffer.prototype.slice": "^1.0.4",
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "data-view-buffer": "^1.0.2",
-        "data-view-byte-length": "^1.0.2",
-        "data-view-byte-offset": "^1.0.1",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "es-set-tostringtag": "^2.1.0",
-        "es-to-primitive": "^1.3.0",
-        "function.prototype.name": "^1.1.8",
-        "get-intrinsic": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "get-symbol-description": "^1.1.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "internal-slot": "^1.1.0",
-        "is-array-buffer": "^3.0.5",
-        "is-callable": "^1.2.7",
-        "is-data-view": "^1.0.2",
-        "is-negative-zero": "^2.0.3",
-        "is-regex": "^1.2.1",
-        "is-set": "^2.0.3",
-        "is-shared-array-buffer": "^1.0.4",
-        "is-string": "^1.1.1",
-        "is-typed-array": "^1.1.15",
-        "is-weakref": "^1.1.1",
-        "math-intrinsics": "^1.1.0",
-        "object-inspect": "^1.13.4",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.7",
-        "own-keys": "^1.0.1",
-        "regexp.prototype.flags": "^1.5.4",
-        "safe-array-concat": "^1.1.3",
-        "safe-push-apply": "^1.0.0",
-        "safe-regex-test": "^1.1.0",
-        "set-proto": "^1.0.0",
-        "stop-iteration-iterator": "^1.1.0",
-        "string.prototype.trim": "^1.2.10",
-        "string.prototype.trimend": "^1.0.9",
-        "string.prototype.trimstart": "^1.0.8",
-        "typed-array-buffer": "^1.0.3",
-        "typed-array-byte-length": "^1.0.3",
-        "typed-array-byte-offset": "^1.0.4",
-        "typed-array-length": "^1.0.7",
-        "unbox-primitive": "^1.1.0",
-        "which-typed-array": "^1.1.19"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/es-define-property": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/es-errors": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/es-iterator-helpers": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.24.1",
-        "es-errors": "^1.3.0",
-        "es-set-tostringtag": "^2.1.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.3.0",
-        "globalthis": "^1.0.4",
-        "gopd": "^1.2.0",
-        "has-property-descriptors": "^1.0.2",
-        "has-proto": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "iterator.prototype": "^1.1.5",
-        "safe-array-concat": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/es-set-tostringtag": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/es-shim-unscopables": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/es-to-primitive": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7",
-        "is-date-object": "^1.0.5",
-        "is-symbol": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/escalade": {
-      "version": "3.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/web/node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/eslint": {
-      "version": "9.39.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.39.3",
-        "@eslint/plugin-kit": "^0.4.1",
-        "@humanfs/node": "^0.16.6",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@humanwhocodes/retry": "^0.4.2",
-        "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.6",
-        "debug": "^4.3.2",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^8.0.0",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3"
-      },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "jiti": "*"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/eslint-config-next": {
-      "version": "16.1.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@next/eslint-plugin-next": "16.1.6",
-        "eslint-import-resolver-node": "^0.3.6",
-        "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jsx-a11y": "^6.10.0",
-        "eslint-plugin-react": "^7.37.0",
-        "eslint-plugin-react-hooks": "^7.0.0",
-        "globals": "16.4.0",
-        "typescript-eslint": "^8.46.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9.0.0",
-        "typescript": ">=3.3.1"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/eslint-config-next/node_modules/globals": {
-      "version": "16.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
-      }
-    },
-    "apps/web/node_modules/eslint-import-resolver-node/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "apps/web/node_modules/eslint-import-resolver-typescript": {
-      "version": "3.10.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "@nolyfill/is-core-module": "1.0.39",
-        "debug": "^4.4.0",
-        "get-tsconfig": "^4.10.0",
-        "is-bun-module": "^2.0.0",
-        "stable-hash": "^0.0.5",
-        "tinyglobby": "^0.2.13",
-        "unrs-resolver": "^1.6.2"
-      },
-      "engines": {
-        "node": "^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint-import-resolver-typescript"
-      },
-      "peerDependencies": {
-        "eslint": "*",
-        "eslint-plugin-import": "*",
-        "eslint-plugin-import-x": "*"
-      },
-      "peerDependenciesMeta": {
-        "eslint-plugin-import": {
-          "optional": true
-        },
-        "eslint-plugin-import-x": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/eslint-module-utils": {
-      "version": "2.12.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^3.2.7"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/eslint-module-utils/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "apps/web/node_modules/eslint-plugin-import": {
-      "version": "2.32.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.9",
-        "array.prototype.findlastindex": "^1.2.6",
-        "array.prototype.flat": "^1.3.3",
-        "array.prototype.flatmap": "^1.3.3",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.1",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.16.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.1",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.9",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
-      }
-    },
-    "apps/web/node_modules/eslint-plugin-import/node_modules/debug": {
-      "version": "3.2.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
-    "apps/web/node_modules/eslint-plugin-jsx-a11y": {
-      "version": "6.10.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "aria-query": "^5.3.2",
-        "array-includes": "^3.1.8",
-        "array.prototype.flatmap": "^1.3.2",
-        "ast-types-flow": "^0.0.8",
-        "axe-core": "^4.10.0",
-        "axobject-query": "^4.1.0",
-        "damerau-levenshtein": "^1.0.8",
-        "emoji-regex": "^9.2.2",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^3.3.5",
-        "language-tags": "^1.0.9",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "safe-regex-test": "^1.0.3",
-        "string.prototype.includes": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
-      }
-    },
-    "apps/web/node_modules/eslint-plugin-react": {
-      "version": "7.37.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.8",
-        "array.prototype.findlast": "^1.2.5",
-        "array.prototype.flatmap": "^1.3.3",
-        "array.prototype.tosorted": "^1.1.4",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.2.1",
-        "estraverse": "^5.3.0",
-        "hasown": "^2.0.2",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.9",
-        "object.fromentries": "^2.0.8",
-        "object.values": "^1.2.1",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.5",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.12",
-        "string.prototype.repeat": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
-      }
-    },
-    "apps/web/node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.24.4",
-        "@babel/parser": "^7.24.4",
-        "hermes-parser": "^0.25.1",
-        "zod": "^3.25.0 || ^4.0.0",
-        "zod-validation-error": "^3.5.0 || ^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
-      }
-    },
-    "apps/web/node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "node-exports-info": "^1.6.0",
-        "object-keys": "^1.1.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/espree": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "apps/web/node_modules/esquery": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "estraverse": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "apps/web/node_modules/esrecurse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "apps/web/node_modules/estraverse": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "apps/web/node_modules/esutils": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/fast-glob": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "apps/web/node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "apps/web/node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/fast-levenshtein": {
-      "version": "2.0.6",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/fastq": {
-      "version": "1.20.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "apps/web/node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flat-cache": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "apps/web/node_modules/fill-range": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "apps/web/node_modules/find-up": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/flat-cache": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.4"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "apps/web/node_modules/flatted": {
-      "version": "3.3.4",
-      "dev": true,
-      "license": "ISC"
-    },
-    "apps/web/node_modules/for-each": {
-      "version": "0.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/function-bind": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/function.prototype.name": {
-      "version": "1.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "functions-have-names": "^1.2.3",
-        "hasown": "^2.0.2",
-        "is-callable": "^1.2.7"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/functions-have-names": {
-      "version": "1.2.3",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/generator-function": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "apps/web/node_modules/get-intrinsic": {
-      "version": "1.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind-apply-helpers": "^1.0.2",
-        "es-define-property": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.1.1",
-        "function-bind": "^1.1.2",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "hasown": "^2.0.2",
-        "math-intrinsics": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/get-proto": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/get-symbol-description": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "apps/web/node_modules/globals": {
-      "version": "14.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/globalthis": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.2.1",
-        "gopd": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/gopd": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/has-bigints": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/has-flag": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "apps/web/node_modules/has-property-descriptors": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-define-property": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/has-proto": {
-      "version": "1.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/has-symbols": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/has-tostringtag": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-symbols": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/hasown": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/hermes-estree": {
-      "version": "0.25.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hermes-estree": "0.25.1"
-      }
-    },
-    "apps/web/node_modules/ignore": {
-      "version": "5.3.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "apps/web/node_modules/import-fresh": {
-      "version": "3.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/imurmurhash": {
-      "version": "0.1.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.19"
-      }
-    },
-    "apps/web/node_modules/internal-slot": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "hasown": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/is-array-buffer": {
-      "version": "3.0.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-async-function": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async-function": "^1.0.0",
-        "call-bound": "^1.0.3",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-bigint": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-bigints": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-boolean-object": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-bun-module": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.7.1"
-      }
-    },
-    "apps/web/node_modules/is-bun-module/node_modules/semver": {
-      "version": "7.7.4",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "apps/web/node_modules/is-callable": {
-      "version": "1.2.7",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-core-module": {
-      "version": "2.16.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-data-view": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "is-typed-array": "^1.1.13"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-date-object": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-extglob": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/is-finalizationregistry": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-generator-function": {
-      "version": "1.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.4",
-        "generator-function": "^2.0.0",
-        "get-proto": "^1.0.1",
-        "has-tostringtag": "^1.0.2",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-extglob": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/is-map": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-negative-zero": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-number": {
-      "version": "7.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
-      }
-    },
-    "apps/web/node_modules/is-number-object": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-regex": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2",
-        "hasown": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-set": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-shared-array-buffer": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-string": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-symbol": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "safe-regex-test": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-typed-array": {
-      "version": "1.1.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-weakmap": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-weakref": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/is-weakset": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "get-intrinsic": "^1.2.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/isarray": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/iterator.prototype": {
-      "version": "1.1.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "get-proto": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/js-tokens": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "apps/web/node_modules/jsesc": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/web/node_modules/json-buffer": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/json5": {
-      "version": "2.2.3",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/web/node_modules/jsx-ast-utils": {
-      "version": "3.3.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flat": "^1.3.1",
-        "object.assign": "^4.1.4",
-        "object.values": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "apps/web/node_modules/keyv": {
-      "version": "4.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
-    },
-    "apps/web/node_modules/language-subtag-registry": {
-      "version": "0.3.23",
-      "dev": true,
-      "license": "CC0-1.0"
-    },
-    "apps/web/node_modules/language-tags": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "language-subtag-registry": "^0.3.20"
-      },
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "apps/web/node_modules/levn": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
       }
     },
     "apps/web/node_modules/lightningcss": {
@@ -3037,44 +187,6 @@
         "url": "https://opencollective.com/parcel"
       }
     },
-    "apps/web/node_modules/locate-path": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/loose-envify": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
-    },
-    "apps/web/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
     "apps/web/node_modules/magic-string": {
       "version": "0.30.21",
       "dev": true,
@@ -3083,311 +195,10 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "apps/web/node_modules/math-intrinsics": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/merge2": {
-      "version": "1.4.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "apps/web/node_modules/micromatch": {
-      "version": "4.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "apps/web/node_modules/minimatch": {
-      "version": "3.1.5",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "apps/web/node_modules/minimist": {
-      "version": "1.2.8",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/ms": {
-      "version": "2.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/napi-postinstall": {
-      "version": "0.3.4",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "napi-postinstall": "lib/cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/napi-postinstall"
-      }
-    },
-    "apps/web/node_modules/natural-compare": {
-      "version": "1.4.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/node-exports-info": {
-      "version": "1.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array.prototype.flatmap": "^1.3.3",
-        "es-errors": "^1.3.0",
-        "object.entries": "^1.1.9",
-        "semver": "^6.3.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/node-releases": {
-      "version": "2.0.27",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/object-assign": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/object-inspect": {
-      "version": "1.13.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/object-keys": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/object.assign": {
-      "version": "4.1.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0",
-        "has-symbols": "^1.1.0",
-        "object-keys": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/object.entries": {
-      "version": "1.1.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/object.fromentries": {
-      "version": "2.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/object.groupby": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/object.values": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/optionator": {
-      "version": "0.9.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0",
-        "word-wrap": "^1.2.5"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "apps/web/node_modules/own-keys": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-intrinsic": "^1.2.6",
-        "object-keys": "^1.1.1",
-        "safe-push-apply": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/p-locate": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/parent-module": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/web/node_modules/path-exists": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "apps/web/node_modules/path-parse": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/picomatch": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "apps/web/node_modules/possible-typed-array-names": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "apps/web/node_modules/postcss": {
-      "version": "8.5.6",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -3405,513 +216,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "apps/web/node_modules/prelude-ls": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "apps/web/node_modules/prisma": {
-      "version": "6.16.2",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.16.2.tgz",
-      "integrity": "sha512-aRvldGE5UUJTtVmFiH3WfNFNiqFlAtePUxcI0UEGlnXCX7DqhiMT5TRYwncHFeA/Reca5W6ToXXyCMTeFPdSXA==",
-      "devOptional": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@prisma/config": "6.16.2",
-        "@prisma/engines": "6.16.2"
-      },
-      "bin": {
-        "prisma": "build/index.js"
-      },
-      "engines": {
-        "node": ">=18.18"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.1.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/prop-types": {
-      "version": "15.8.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "apps/web/node_modules/punycode": {
-      "version": "2.3.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "apps/web/node_modules/queue-microtask": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
-    "apps/web/node_modules/react-is": {
-      "version": "16.13.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/reflect.getprototypeof": {
-      "version": "1.0.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.9",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.7",
-        "get-proto": "^1.0.1",
-        "which-builtin-type": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/regexp.prototype.flags": {
-      "version": "1.5.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "define-properties": "^1.2.1",
-        "es-errors": "^1.3.0",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "set-function-name": "^2.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/resolve": {
-      "version": "1.22.11",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "apps/web/node_modules/reusify": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "iojs": ">=1.0.0",
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/run-parallel": {
-      "version": "1.2.0",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "apps/web/node_modules/safe-array-concat": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "get-intrinsic": "^1.2.6",
-        "has-symbols": "^1.1.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">=0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/safe-push-apply": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "isarray": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/safe-regex-test": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "is-regex": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
-    "apps/web/node_modules/set-function-length": {
-      "version": "1.2.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.4",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/set-function-name": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-data-property": "^1.1.4",
-        "es-errors": "^1.3.0",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/set-proto": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "dunder-proto": "^1.0.1",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/side-channel": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
-        "side-channel-map": "^1.0.1",
-        "side-channel-weakmap": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/side-channel-map": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/side-channel-weakmap": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "es-errors": "^1.3.0",
-        "get-intrinsic": "^1.2.5",
-        "object-inspect": "^1.13.3",
-        "side-channel-map": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/stable-hash": {
-      "version": "0.0.5",
-      "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/stop-iteration-iterator": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "internal-slot": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/string.prototype.includes": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/string.prototype.matchall": {
-      "version": "4.0.12",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.6",
-        "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
-        "get-intrinsic": "^1.2.6",
-        "gopd": "^1.2.0",
-        "has-symbols": "^1.1.0",
-        "internal-slot": "^1.1.0",
-        "regexp.prototype.flags": "^1.5.3",
-        "set-function-name": "^2.0.2",
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/string.prototype.repeat": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
-      }
-    },
-    "apps/web/node_modules/string.prototype.trim": {
-      "version": "1.2.10",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-data-property": "^1.1.4",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.23.5",
-        "es-object-atoms": "^1.0.0",
-        "has-property-descriptors": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/string.prototype.trimend": {
-      "version": "1.0.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/string.prototype.trimstart": {
-      "version": "1.0.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/strip-bom": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "apps/web/node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/supports-color": {
-      "version": "7.2.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "apps/web/node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "apps/web/node_modules/tailwindcss": {
@@ -3931,176 +241,9 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "apps/web/node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "apps/web/node_modules/tinyglobby/node_modules/fdir": {
-      "version": "6.5.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "apps/web/node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
-    "apps/web/node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
-      }
-    },
-    "apps/web/node_modules/tsconfig-paths": {
-      "version": "3.15.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "apps/web/node_modules/tsconfig-paths/node_modules/json5": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.0"
-      },
-      "bin": {
-        "json5": "lib/cli.js"
-      }
-    },
-    "apps/web/node_modules/type-check": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prelude-ls": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "apps/web/node_modules/typed-array-buffer": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "es-errors": "^1.3.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
-    "apps/web/node_modules/typed-array-byte-length": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.14"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/typed-array-byte-offset": {
-      "version": "1.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "for-each": "^0.3.3",
-        "gopd": "^1.2.0",
-        "has-proto": "^1.2.0",
-        "is-typed-array": "^1.1.15",
-        "reflect.getprototypeof": "^1.0.9"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/typed-array-length": {
-      "version": "1.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bind": "^1.0.7",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "is-typed-array": "^1.1.13",
-        "possible-typed-array-names": "^1.0.0",
-        "reflect.getprototypeof": "^1.0.6"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/web/node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -4110,235 +253,10 @@
         "node": ">=14.17"
       }
     },
-    "apps/web/node_modules/typescript-eslint": {
-      "version": "8.56.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.56.1",
-        "@typescript-eslint/parser": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1",
-        "@typescript-eslint/utils": "8.56.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "apps/web/node_modules/unbox-primitive": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.3",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.1.0",
-        "which-boxed-primitive": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "apps/web/node_modules/undici-types": {
       "version": "6.21.0",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/web/node_modules/unrs-resolver": {
-      "version": "1.11.1",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "dependencies": {
-        "napi-postinstall": "^0.3.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/unrs-resolver"
-      },
-      "optionalDependencies": {
-        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-        "@unrs/resolver-binding-android-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-        "@unrs/resolver-binding-darwin-x64": "1.11.1",
-        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
-      }
-    },
-    "apps/web/node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
-      "peerDependencies": {
-        "browserslist": ">= 4.21.0"
-      }
-    },
-    "apps/web/node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "apps/web/node_modules/which-boxed-primitive": {
-      "version": "1.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-bigint": "^1.1.0",
-        "is-boolean-object": "^1.2.1",
-        "is-number-object": "^1.1.1",
-        "is-string": "^1.1.1",
-        "is-symbol": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/which-builtin-type": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "call-bound": "^1.0.2",
-        "function.prototype.name": "^1.1.6",
-        "has-tostringtag": "^1.0.2",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.1.0",
-        "is-finalizationregistry": "^1.1.0",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.2.1",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.1.0",
-        "which-collection": "^1.0.2",
-        "which-typed-array": "^1.1.16"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/which-collection": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-map": "^2.0.3",
-        "is-set": "^2.0.3",
-        "is-weakmap": "^2.0.2",
-        "is-weakset": "^2.0.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/which-typed-array": {
-      "version": "1.1.20",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "available-typed-arrays": "^1.0.7",
-        "call-bind": "^1.0.8",
-        "call-bound": "^1.0.4",
-        "for-each": "^0.3.5",
-        "get-proto": "^1.0.1",
-        "gopd": "^1.2.0",
-        "has-tostringtag": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/word-wrap": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "apps/web/node_modules/yallist": {
-      "version": "3.1.1",
-      "dev": true,
-      "license": "ISC"
-    },
-    "apps/web/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/zod-validation-error": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      }
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
@@ -5202,13 +1120,13 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.9.tgz",
-      "integrity": "sha512-ItnlMgSqkPrUfJs7EsvU/01zw5UeIb2tNPhD09LBLHbg+g+HDiKibSLwpkuz/ZIlz4F2IMn+5XgE4AK/pfPuog==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.29.tgz",
+      "integrity": "sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.13.0",
-        "fast-xml-parser": "5.4.1",
+        "@smithy/types": "^4.14.3",
+        "fast-xml-parser": "5.7.3",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -5224,14 +1142,274 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@clerk/backend": {
-      "version": "2.33.0",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.0.tgz",
-      "integrity": "sha512-sVR214TlJ5vsRprDE9EiZpqeNq/YVhCQLtAZ19ugjNf1C9xMX28JoMyodI/dU5FLBelmgSyjBAjodPULjIeF+w==",
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2",
-        "@clerk/types": "^4.101.20",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@clerk/backend": {
+      "version": "2.33.5",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.33.5.tgz",
+      "integrity": "sha512-YOzUYJfb1d4w+0rKKm+LnnNpkJGQ+NI/g7qmF3mgaSN9X9huteuwCZyufdsI7z2DDkwy/yGRgb9eUWV96t7xLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -5240,12 +1418,12 @@
       }
     },
     "node_modules/@clerk/clerk-react": {
-      "version": "5.61.3",
-      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.3.tgz",
-      "integrity": "sha512-W21aNEeHtqh3xJLuW5g2ydben/1D5pSnxsl/kCnv0IY1zma7lO+aIJ7Br2bR4FKKkiu695mPnjtY+fvkQmCXBg==",
+      "version": "5.61.8",
+      "resolved": "https://registry.npmjs.org/@clerk/clerk-react/-/clerk-react-5.61.8.tgz",
+      "integrity": "sha512-n+k3q3xeyDkIPGTVA1J4Pd0+6MbS9Ia04qNlecOztTHwFfcirO5hy4TpOXrpGnO+GzYBuUMp7pYc3//ybMdEfg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2",
+        "@clerk/shared": "^3.47.7",
         "tslib": "2.8.1"
       },
       "engines": {
@@ -5257,15 +1435,15 @@
       }
     },
     "node_modules/@clerk/nextjs": {
-      "version": "6.39.0",
-      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.0.tgz",
-      "integrity": "sha512-T9LS/C0lly5eHmyH79RFi1afF45IHWZw7CZkudRK2zsJaxn7SjrHURYDNp6O5Cdcm/OmjYrND0PC0eKZh/jfRA==",
+      "version": "6.39.5",
+      "resolved": "https://registry.npmjs.org/@clerk/nextjs/-/nextjs-6.39.5.tgz",
+      "integrity": "sha512-hvdvpiuHXPhlx3iaNfoXO1joZkNP4Lzw83teUNPrzsbOX0rT9QE0uSxS2J/UEAeqoPK6JhNK7dZGvZ9knsB/mg==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/backend": "^2.33.0",
-        "@clerk/clerk-react": "^5.61.3",
-        "@clerk/shared": "^3.47.2",
-        "@clerk/types": "^4.101.20",
+        "@clerk/backend": "^2.33.5",
+        "@clerk/clerk-react": "^5.61.8",
+        "@clerk/shared": "^3.47.7",
+        "@clerk/types": "^4.101.25",
         "server-only": "0.0.1",
         "tslib": "2.8.1"
       },
@@ -5279,16 +1457,16 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.47.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.2.tgz",
-      "integrity": "sha512-dwUT27DKq3Gr9vn9lAfc/LSe79P1rKIib8/mTWA7ZEzY7XX2Yq5UnDMCMznYrI8oVLdJrCT4ypFXRgnH306Oew==",
+      "version": "3.47.7",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.47.7.tgz",
+      "integrity": "sha512-9Yv4MJFEaC7BzV0whxa4txQ4SoMu/3j1LBnI85EBykb5CcfXxIKvNX/9sjMUUySHlTOjsj7XZa5i3W5Dx02K/Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "3.1.3",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
-        "js-cookie": "3.0.5",
+        "js-cookie": "3.0.7",
         "std-env": "^3.9.0",
         "swr": "2.3.4"
       },
@@ -5309,21 +1487,44 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.101.20",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.20.tgz",
-      "integrity": "sha512-MHvr1tGL5lwxD6zdzzixkHICbbZz/S1LChONKR52Qeu0yRGChZomPknsgqBMG9J3yNeyhaj0SWa5phQgQUk0lg==",
+      "version": "4.101.25",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.101.25.tgz",
+      "integrity": "sha512-gPxm3hlBkP7B9EfKyp3/UDonNOjg7Z0UvqfrMj5u8gA8nyzvC1UFYtSTTmTfgSY82+5Yo38YV0DYu9vNf6t9CQ==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.47.2"
+        "@clerk/shared": "^3.47.7"
       },
       "engines": {
         "node": ">=18.17.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5772,9 +1973,219 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/@fd/web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
     },
     "node_modules/@img/colour": {
       "version": "1.1.0",
@@ -6242,6 +2653,75 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
     "node_modules/@netlify/plugin-nextjs": {
       "version": "5.15.8",
       "resolved": "https://registry.npmjs.org/@netlify/plugin-nextjs/-/plugin-nextjs-5.15.8.tgz",
@@ -6252,15 +2732,25 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
-      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
       "license": "MIT"
     },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.9.tgz",
+      "integrity": "sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
-      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
       "cpu": [
         "arm64"
       ],
@@ -6274,9 +2764,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
-      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
       "cpu": [
         "x64"
       ],
@@ -6290,9 +2780,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
-      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
       "cpu": [
         "arm64"
       ],
@@ -6306,9 +2796,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
-      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
       ],
@@ -6322,9 +2812,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
-      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
       "cpu": [
         "x64"
       ],
@@ -6338,9 +2828,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
-      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
       ],
@@ -6354,9 +2844,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
-      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
       "cpu": [
         "arm64"
       ],
@@ -6370,9 +2860,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
-      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
       "cpu": [
         "x64"
       ],
@@ -6384,6 +2874,158 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@prisma/client": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.19.3.tgz",
+      "integrity": "sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@prisma/config": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.19.3.tgz",
+      "integrity": "sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "c12": "3.1.0",
+        "deepmerge-ts": "7.1.5",
+        "effect": "3.21.0",
+        "empathic": "2.0.0"
+      }
+    },
+    "node_modules/@prisma/debug": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.19.3.tgz",
+      "integrity": "sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/engines": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.19.3.tgz",
+      "integrity": "sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/fetch-engine": "6.19.3",
+        "@prisma/get-platform": "6.19.3"
+      }
+    },
+    "node_modules/@prisma/engines-version": {
+      "version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7.tgz",
+      "integrity": "sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==",
+      "devOptional": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@prisma/fetch-engine": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.19.3.tgz",
+      "integrity": "sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3",
+        "@prisma/engines-version": "7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7",
+        "@prisma/get-platform": "6.19.3"
+      }
+    },
+    "node_modules/@prisma/get-platform": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.19.3.tgz",
+      "integrity": "sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/debug": "6.19.3"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.10",
@@ -6873,9 +3515,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.0.tgz",
-      "integrity": "sha512-COuLsZILbbQsdrwKQpkkpyep7lCsByxwj7m0Mg5v66/ZTyenlfBc40/QFQ5chO0YN/PNEH1Bi3fGtfXPnYNeDw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.3.tgz",
+      "integrity": "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -7139,6 +3781,38 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -7156,10 +3830,910 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.61.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.61.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anynum": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.0.tgz",
+      "integrity": "sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -7173,6 +4747,64 @@
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
     },
     "node_modules/c12": {
       "version": "3.1.0",
@@ -7203,10 +4835,70 @@
         }
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001775",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001775.tgz",
-      "integrity": "sha512-s3Qv7Lht9zbVKE9XoTyRG6wVDCKdtOFIjBGg3+Yhn6JaytuNKPIjBMTMIY1AnOH3seL5mvF+x33oGAyK3hVt3A==",
+      "version": "1.0.30001797",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
+      "integrity": "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==",
       "funding": [
         {
           "type": "opencollective",
@@ -7222,6 +4914,23 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -7255,6 +4964,33 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/confbox": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
@@ -7271,6 +5007,13 @@
       "engines": {
         "node": "^14.18.0 || >=16.10.0"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -7299,6 +5042,92 @@
       "integrity": "sha512-CEE+jwpgLn+MmtCpVcPtiCZpVtB6Z2OKPTr34pycYYoL7sxdOkXDdQ4lRiw6ioC0q6BLqhc6cKweCVvral8yhw==",
       "license": "MIT"
     },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deepmerge-ts": {
       "version": "7.1.5",
       "resolved": "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-7.1.5.tgz",
@@ -7309,10 +5138,46 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/defu": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "devOptional": true,
       "license": "MIT"
     },
@@ -7342,6 +5207,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -7355,6 +5233,46 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/effect": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-3.21.0.tgz",
+      "integrity": "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "fast-check": "^3.23.1"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/empathic": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.0.tgz",
@@ -7363,6 +5281,183 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
+      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/esbuild": {
@@ -7407,6 +5502,455 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.9.tgz",
+      "integrity": "sha512-olGtBrs07bQchpaJWeqbk9GaMoU0oGmN/pYNEBXSbfgKngb5uHnPe37X6tVeh6DJfaWFQildvinGEOrolo5fmw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "16.2.9",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.32.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.13.0.tgz",
+      "integrity": "sha512-bLohSkT6469rRs8czj0tLTD8vaeIS/whvPRJVjDr7IuoTT1k5DYDERlNycjDj/HkOlvQdYurmfZ/g3fG5bgeLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
@@ -7437,6 +5981,57 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -7444,21 +6039,9 @@
       "license": "Unlicense"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.0.0.tgz",
-      "integrity": "sha512-fpZuDogrAgnyt9oDDz+5DBz0zgPdPZz6D4IR7iESxRXElrlGTRkHJ9eEt+SACRJwT0FNFrt71DFQIUFBJfX/uQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/fast-xml-parser": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.4.1.tgz",
-      "integrity": "sha512-BQ30U1mKkvXQXXkAGcuyUA/GA26oEB7NzOtsxCDtyu62sjGw5QraKFhx2Em3WQNjPw9PG6MQ9yuIIgkSDfGu5A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "funding": [
         {
           "type": "github",
@@ -7467,11 +6050,119 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "fast-xml-builder": "^1.0.0",
-        "strnum": "^2.1.2"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
+      "integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.7",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/fsevents": {
@@ -7487,6 +6178,124 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-tsconfig": {
@@ -7520,11 +6329,67 @@
         "giget": "dist/cli.mjs"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/glob-to-regexp": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
@@ -7533,12 +6398,602 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
@@ -7551,12 +7006,195 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/lucide-react": {
@@ -7568,10 +7206,74 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7586,15 +7288,38 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/next": {
-      "version": "16.1.6",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
-      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.6",
+        "@next/env": "16.2.9",
         "@swc/helpers": "0.5.15",
-        "baseline-browser-mapping": "^2.8.3",
+        "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
         "postcss": "8.4.31",
         "styled-jsx": "5.1.6"
@@ -7606,15 +7331,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.6",
-        "@next/swc-darwin-x64": "16.1.6",
-        "@next/swc-linux-arm64-gnu": "16.1.6",
-        "@next/swc-linux-arm64-musl": "16.1.6",
-        "@next/swc-linux-x64-gnu": "16.1.6",
-        "@next/swc-linux-x64-musl": "16.1.6",
-        "@next/swc-win32-arm64-msvc": "16.1.6",
-        "@next/swc-win32-x64-msvc": "16.1.6",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.9",
+        "@next/swc-darwin-x64": "16.2.9",
+        "@next/swc-linux-arm64-gnu": "16.2.9",
+        "@next/swc-linux-arm64-musl": "16.2.9",
+        "@next/swc-linux-x64-gnu": "16.2.9",
+        "@next/swc-linux-x64-musl": "16.2.9",
+        "@next/swc-win32-arm64-msvc": "16.2.9",
+        "@next/swc-win32-x64-msvc": "16.2.9",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7639,6 +7364,35 @@
         }
       }
     },
+    "node_modules/node-exports-info": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.0.tgz",
+      "integrity": "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
@@ -7646,16 +7400,26 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/node-releases": {
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/nypm": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.5.tgz",
-      "integrity": "sha512-K6AJy1GMVyfyMXRVB88700BJqNUkByijGJM8kEHpLdcAt+vSQAVfkWWHYzuRXHSY6xA2sNc5RjTj0p9rE2izVQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
+      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "citty": "^0.2.0",
+        "citty": "^0.2.2",
         "pathe": "^2.0.3",
-        "tinyexec": "^1.0.2"
+        "tinyexec": "^1.1.1"
       },
       "bin": {
         "nypm": "dist/cli.mjs"
@@ -7665,11 +7429,134 @@
       }
     },
     "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.1.tgz",
-      "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
+      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/ohash": {
       "version": "2.0.11",
@@ -7677,6 +7564,112 @@
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/path-key": {
       "version": "3.1.1",
@@ -7687,6 +7680,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -7708,16 +7708,39 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/pkg-types": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.0.tgz",
-      "integrity": "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-2.3.1.tgz",
+      "integrity": "sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
-        "confbox": "^0.2.2",
-        "exsolve": "^1.0.7",
+        "confbox": "^0.2.4",
+        "exsolve": "^1.0.8",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/postcss": {
@@ -7748,6 +7771,64 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prisma": {
+      "version": "6.19.3",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.19.3.tgz",
+      "integrity": "sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==",
+      "devOptional": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@prisma/config": "6.19.3",
+        "@prisma/engines": "6.19.3"
+      },
+      "bin": {
+        "prisma": "build/index.js"
+      },
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -7761,6 +7842,27 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
         }
       ],
       "license": "MIT"
@@ -7797,6 +7899,13 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -7811,6 +7920,84 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
@@ -7819,6 +8006,96 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/scheduler": {
@@ -7831,8 +8108,8 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7845,6 +8122,55 @@
       "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
       "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
       "license": "MIT"
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -7914,6 +8240,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7922,6 +8324,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",
@@ -7939,17 +8348,171 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "license": "MIT"
     },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/strnum": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.0.tgz",
-      "integrity": "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.0.tgz",
+      "integrity": "sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.0"
+      }
     },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
@@ -7974,6 +8537,32 @@
         }
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/swr": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.4.tgz",
@@ -7988,13 +8577,113 @@
       }
     },
     "node_modules/tinyexec": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
-      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
       "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/tslib": {
@@ -8023,6 +8712,234 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -8048,6 +8965,140 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/zod": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
@@ -8055,6 +9106,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "apps/*"
   ],
   "scripts": {
-    "dev": "npm --workspace @fd/web run dev",
-    "build": "npm --workspace @fd/web run build",
+    "dev": "node scripts/with-env.mjs npm --workspace @fd/web run dev",
+    "build": "node scripts/with-env.mjs npm --workspace @fd/web run build",
     "lint": "npm --workspace @fd/web run lint"
   }
 }

--- a/scripts/with-env.mjs
+++ b/scripts/with-env.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const appRoot = resolve(repoRoot, 'apps/web')
+const mode = process.env.NODE_ENV || 'development'
+
+function parseDotenv(content) {
+  const env = {}
+
+  for (const rawLine of content.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    const match = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/.exec(line)
+    if (!match) continue
+
+    const [, key, rawValue] = match
+    let value = rawValue.trim()
+
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+      value = value.slice(1, -1)
+    } else {
+      const commentIndex = value.indexOf(' #')
+      if (commentIndex >= 0) value = value.slice(0, commentIndex).trim()
+    }
+
+    env[key] = value
+  }
+
+  return env
+}
+
+function loadEnvFile(path, target) {
+  if (!existsSync(path)) return
+  Object.assign(target, parseDotenv(readFileSync(path, 'utf8')))
+}
+
+const loaded = {}
+for (const root of [repoRoot, appRoot]) {
+  loadEnvFile(resolve(root, '.env'), loaded)
+  loadEnvFile(resolve(root, `.env.${mode}`), loaded)
+  if (mode !== 'test') loadEnvFile(resolve(root, '.env.local'), loaded)
+  loadEnvFile(resolve(root, `.env.${mode}.local`), loaded)
+}
+
+const env = { ...loaded, ...process.env }
+const args = process.argv.slice(2)
+
+if (args.length === 0) {
+  console.error('Usage: node scripts/with-env.mjs <command> [...args]')
+  process.exit(1)
+}
+
+const result = spawnSync(args[0], args.slice(1), {
+  cwd: process.cwd(),
+  env,
+  stdio: 'inherit',
+  shell: process.platform === 'win32',
+})
+
+if (result.error) {
+  console.error(result.error)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 0)


### PR DESCRIPTION
## Summary
- Added researched static historical archive/champion/media layer plus an optional DB import script for archive backfill.
- Fixed Guam timezone formatting and past-game pending status across public/admin schedule surfaces.
- Added 2025 GSPN opening-weekend score rows to the score import script.
- Improved news/gallery/history/sponsors public pages and removed emoji/over-official wording from app UI.
- Added env example/setup docs, reproducible Prisma generate in build, Clerk-unconfigured build fallback, and dependency security updates.

## Validation
- npm --workspace @fd/web run lint
- npm --workspace @fd/web run build
- npm audit --omit=dev (remaining: 3 moderate PostCSS/Next transitive findings, no fix currently available)

## Notes
- Production DB migrations/imports were not run because DATABASE_URL and production secrets were not available in this harness.
- See docs/research/public-archive-refresh-2026-06-11.md for source notes and remaining data gaps.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a broad readiness and data-refresh pass: it wires a static historical archive into the public pages, adds a graceful `withDatabaseFallback` pattern throughout public-feed/schedule/standings, fixes Guam timezone formatting across the admin and public surfaces, and adds Clerk-unconfigured build fallbacks so the app renders without secrets.

- **`withDatabaseFallback` + `isDatabaseConfigured`** — new helpers in `db.ts` are applied consistently to every public Prisma query in `public-feed.ts`, `tournament-repo.ts`, and the sponsors page; archive articles are merged in when the DB is absent.
- **`datetime.ts`** — replaces ad-hoc local-timezone date math with `Intl`-derived Guam-aware helpers; `guamDayRange` now derives the UTC+10 offset dynamically via `guamOffsetMs` rather than hardcoding it.
- **Static archive + import script** — `historical-archive.ts` bakes in researched article/media/champion records going back to 2005; `import-archive-content.ts` can materialize them into the live DB.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all previously flagged issues have been addressed and no new correctness problems were found.

Every concern raised in the prior review round has been resolved: `withDatabaseFallback` is now applied to the sponsors page, the import script's ternary correctly writes 'cancelled' when appropriate, the schedule page's `pending` heuristic is guarded to `scheduled`-only games, the Guam timezone offset is derived dynamically rather than hardcoded, and the site-header drawer now closes on browser back/forward via pathname tracking. The new static archive layer and fallback plumbing are logically sound and no new defects were introduced.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/web/src/lib/db.ts | Adds `isDatabaseConfigured`, `isMissingDatabaseUrlError`, and `withDatabaseFallback`; the fallback helper correctly re-throws non-DATABASE_URL errors and only swallows the missing-env case. |
| apps/web/src/lib/datetime.ts | New file introducing `Intl`-derived Guam timezone helpers; `guamOffsetMs` dynamically parses the UTC offset rather than hardcoding +10:00, addressing a prior review concern. |
| apps/web/src/lib/services/public-feed.ts | All Prisma queries are now wrapped with `withDatabaseFallback`; `mergeArchiveArticles` correctly deduplicates by URL and slices to the requested take count. |
| apps/web/src/lib/historical-archive.ts | Large static data file containing researched articles, media, and champion records from 2005-2025; export helpers are straightforward filter functions with no logic issues. |
| apps/web/scripts/import-archive-content.ts | Import script uses correct ternary for both `create` and `update` paths; properly upserts by URL/imageUrl. |
| apps/web/src/lib/authz.ts | Guards `ensureAppUser` to return null immediately when DB or Clerk are unconfigured — fail-closed behavior. |
| apps/web/src/app/(public)/schedule/page.tsx | Pending status override now correctly guards on `game.status === 'scheduled'`, so admin-marked `final` games are unaffected by the past-game heuristic. |
| apps/web/src/app/(public)/sponsors/page.tsx | Now wraps `db.sponsor.findMany` with `withDatabaseFallback`, addressing the previously flagged crash-on-missing-DATABASE_URL path. |
| apps/web/src/contexts/tournament-context.tsx | The `reconciledRef.current` guard ensures the once-on-mount localStorage reconciliation runs only once; deps are harmless due to the guard. |
| apps/web/src/components/site-header.tsx | Drawer close now uses `requestAnimationFrame` on pathname change to handle browser back/forward; Clerk-absent fallback shows a plain Admin link. |
| apps/web/src/app/api/public/schedule/route.ts | Adds `division` and `phase` passthrough from query params; safe behavior on invalid phase values. |
| apps/web/prisma/migrations/0008_add_cancelled_tournament_status/migration.sql | Adds `cancelled` to the `TournamentStatus` enum using `IF NOT EXISTS` — idempotent and safe. |

</details>

</details>

<sub>Reviews (8): Last reviewed commit: ["Guard archive year query params"](https://github.com/shimizu-technology/fd-alumni-hub/commit/0ce832cb81fcbe9a9235993d5ca6ef5bbb7662af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36885601)</sub>

<!-- /greptile_comment -->