### PR TITLE
Add Next to Rails data migration pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules/
 !web/.env.example
 .next/
 dist/
+tmp/
 .DS_Store
 
 # Local Netlify folder

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ api/       Rails API foundation plus public/admin JSON endpoints
 web/       Side-by-side React/Vite frontend being validated before cutover
 ```
 
-See `docs/RAILS-REACT-MIGRATION.md` for the migration rationale, phases, go/no-go criteria, and route mapping.
+See `docs/RAILS-REACT-MIGRATION.md` for the migration rationale, phases, go/no-go criteria, and route mapping. See `docs/RAILS-DATA-MIGRATION-RUNBOOK.md` for the operator-run Next/Prisma → Rails data migration path.
 
 ## App Scaffold
 - Next.js app lives in `apps/web`

--- a/api/README.md
+++ b/api/README.md
@@ -101,6 +101,14 @@ Authorization: Bearer dev_token_you@example.com
 - `PATCH /api/v1/admin/links/bulk`
 - `GET /api/v1/admin/missing-links`
 
-## Data safety
+## Data migration + safety
 
-Do not point this Rails API at the existing Next/Prisma production database. Phase 1 is intended for a Rails-owned local DB or Neon branch/new DB. Production data import/cutover must be an explicit operator-run step.
+Do not point this Rails API at the existing Next/Prisma production database. Rails should use a Rails-owned local DB or Neon branch/new DB.
+
+Use the operator-run migration path in `docs/RAILS-DATA-MIGRATION-RUNBOOK.md`:
+
+- export Next/Prisma data to an ignored JSON snapshot
+- import that snapshot into Rails with `bin/rails fd:migration:import_next_snapshot[...]`
+- validate with `bin/rails fd:migration:validate_next_snapshot[...]`
+
+Production data import/cutover must remain an explicit operator-run step.

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -47,6 +47,7 @@ class Game < ApplicationRecord
       notes: notes,
       division: division,
       bracketCode: bracket_code,
+      placeholder: placeholder,
       createdAt: created_at&.iso8601,
       updatedAt: updated_at&.iso8601
     }
@@ -74,13 +75,9 @@ class Game < ApplicationRecord
 
   def teams_are_distinct
     return if home_team_id.blank? || away_team_id.blank? || home_team_id != away_team_id
-    return if scheduled_unscored_placeholder?
+    return if placeholder?
 
     errors.add(:away_team_id, "must be different from home team")
-  end
-
-  def scheduled_unscored_placeholder?
-    status == "scheduled" && home_score.nil? && away_score.nil?
   end
 
   def teams_belong_to_tournament

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -74,8 +74,13 @@ class Game < ApplicationRecord
 
   def teams_are_distinct
     return if home_team_id.blank? || away_team_id.blank? || home_team_id != away_team_id
+    return if scheduled_unscored_placeholder?
 
     errors.add(:away_team_id, "must be different from home team")
+  end
+
+  def scheduled_unscored_placeholder?
+    status == "scheduled" && home_score.nil? && away_score.nil?
   end
 
   def teams_belong_to_tournament

--- a/api/app/models/media_asset.rb
+++ b/api/app/models/media_asset.rb
@@ -2,7 +2,6 @@ class MediaAsset < ApplicationRecord
   belongs_to :tournament
 
   validates :source, :title, :image_url, presence: true
-  validates :image_url, uniqueness: { scope: :tournament_id }
 
   scope :latest, -> { order(taken_at: :desc, created_at: :desc, id: :desc) }
 

--- a/api/app/services/data_migration/next_prisma_snapshot/import.rb
+++ b/api/app/services/data_migration/next_prisma_snapshot/import.rb
@@ -4,6 +4,18 @@ module DataMigration
   module NextPrismaSnapshot
     class Import
       FORMAT = "fd-alumni-hub-next-prisma-export"
+      TABLES = {
+        "tournaments" => Tournament,
+        "teams" => Team,
+        "games" => Game,
+        "standings" => Standing,
+        "articleLinks" => ArticleLink,
+        "mediaAssets" => MediaAsset,
+        "sponsors" => Sponsor,
+        "contentIngestItems" => ContentIngestItem,
+        "adminWhitelists" => AdminWhitelist,
+        "appUsers" => User
+      }.freeze
 
       attr_reader :path, :snapshot, :records, :id_maps
 
@@ -46,11 +58,19 @@ module DataMigration
       end
 
       def result
+        source_counts = records.transform_values(&:length)
+        rails_counts = TABLES.to_h do |record_key, model|
+          legacy_ids = records.fetch(record_key, []).filter_map { |record| record["id"] }
+          [ record_key, model.where(legacy_id: legacy_ids).count ]
+        end
+
         {
           path: path,
           importedAt: Time.current.iso8601,
           sourceExportedAt: snapshot["exportedAt"],
-          counts: records.transform_values(&:length)
+          sourceCounts: source_counts,
+          railsCounts: rails_counts,
+          counts: rails_counts
         }
       end
 
@@ -271,8 +291,18 @@ module DataMigration
         if source["kind"] == "article"
           ArticleLink.find_by(tournament_id: tournament_id, url: source["url"])
         else
-          MediaAsset.find_by(tournament_id: tournament_id, image_url: source["imageUrl"])
+          infer_media_import(source, tournament_id)
         end
+      end
+
+      def infer_media_import(source, tournament_id)
+        candidates = MediaAsset.where(tournament_id: tournament_id, image_url: source["imageUrl"])
+        return candidates.first if candidates.one?
+
+        title_matches = candidates.where(title: source["title"])
+        return title_matches.first if title_matches.one?
+
+        nil
       end
 
       def placeholder_game?(source)

--- a/api/app/services/data_migration/next_prisma_snapshot/import.rb
+++ b/api/app/services/data_migration/next_prisma_snapshot/import.rb
@@ -110,7 +110,8 @@ module DataMigration
             ticket_url: blank_to_nil(source["ticketUrl"]),
             notes: blank_to_nil(source["notes"]),
             division: blank_to_nil(source["division"]),
-            bracket_code: blank_to_nil(source["bracketCode"])
+            bracket_code: blank_to_nil(source["bracketCode"]),
+            placeholder: placeholder_game?(source)
           })
           id_maps[:games][source.fetch("id")] = game.id
         end
@@ -274,6 +275,13 @@ module DataMigration
         end
       end
 
+      def placeholder_game?(source)
+        source["homeTeamId"] == source["awayTeamId"] &&
+          source["status"] == "scheduled" &&
+          source["homeScore"].nil? &&
+          source["awayScore"].nil?
+      end
+
       def each_record(key, &block)
         records.fetch(key, []).each(&block)
       end
@@ -290,7 +298,7 @@ module DataMigration
         created_at = parse_time(source["createdAt"])
         updated_at = parse_time(source["updatedAt"]) || created_at
 
-        record.assign_attributes(attrs.compact)
+        record.assign_attributes(attrs)
         record.created_at = created_at if created_at && record.new_record?
         record.save!
 

--- a/api/app/services/data_migration/next_prisma_snapshot/import.rb
+++ b/api/app/services/data_migration/next_prisma_snapshot/import.rb
@@ -1,0 +1,322 @@
+require "json"
+
+module DataMigration
+  module NextPrismaSnapshot
+    class Import
+      FORMAT = "fd-alumni-hub-next-prisma-export"
+
+      attr_reader :path, :snapshot, :records, :id_maps
+
+      def self.call(path)
+        new(path).call
+      end
+
+      def initialize(path)
+        @path = path
+        @snapshot = JSON.parse(File.read(path))
+        @records = snapshot.fetch("records")
+        @id_maps = Hash.new { |hash, key| hash[key] = {} }
+      end
+
+      def call
+        validate_format!
+
+        ActiveRecord::Base.transaction do
+          import_tournaments
+          import_teams
+          import_games
+          import_standings
+          import_article_links
+          import_media_assets
+          import_sponsors
+          import_content_ingest_items
+          import_admin_whitelists
+          import_users
+        end
+
+        result
+      end
+
+      private
+
+      def validate_format!
+        return if snapshot["format"] == FORMAT && snapshot["version"].to_i == 1
+
+        raise ArgumentError, "Unsupported snapshot format/version"
+      end
+
+      def result
+        {
+          path: path,
+          importedAt: Time.current.iso8601,
+          sourceExportedAt: snapshot["exportedAt"],
+          counts: records.transform_values(&:length)
+        }
+      end
+
+      def import_tournaments
+        each_record("tournaments") do |source|
+          tournament = find_by_legacy(Tournament, source) || Tournament.find_or_initialize_by(year: source.fetch("year"), name: source.fetch("name"))
+          persist!(tournament, source, {
+            legacy_id: source.fetch("id"),
+            name: source.fetch("name"),
+            year: source.fetch("year"),
+            start_date: parse_date(source.fetch("startDate")),
+            end_date: parse_date(source.fetch("endDate")),
+            status: source.fetch("status")
+          })
+          id_maps[:tournaments][source.fetch("id")] = tournament.id
+        end
+      end
+
+      def import_teams
+        each_record("teams") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "team", source.fetch("id"))
+          team = find_by_legacy(Team, source) || Team.find_or_initialize_by(tournament_id: tournament_id, display_name: source.fetch("displayName"))
+          persist!(team, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            class_year_label: source.fetch("classYearLabel"),
+            display_name: source.fetch("displayName"),
+            division: blank_to_nil(source["division"])
+          })
+          id_maps[:teams][source.fetch("id")] = team.id
+        end
+      end
+
+      def import_games
+        each_record("games") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "game", source.fetch("id"))
+          home_team_id = mapped_id!(:teams, source.fetch("homeTeamId"), "game", source.fetch("id"))
+          away_team_id = mapped_id!(:teams, source.fetch("awayTeamId"), "game", source.fetch("id"))
+          game = find_by_legacy(Game, source) || Game.find_or_initialize_by(
+            tournament_id: tournament_id,
+            home_team_id: home_team_id,
+            away_team_id: away_team_id,
+            start_time: parse_time(source.fetch("startTime"))
+          )
+
+          persist!(game, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            home_team_id: home_team_id,
+            away_team_id: away_team_id,
+            start_time: parse_time(source.fetch("startTime")),
+            venue: blank_to_nil(source["venue"]),
+            status: source.fetch("status"),
+            home_score: source["homeScore"],
+            away_score: source["awayScore"],
+            stream_url: blank_to_nil(source["streamUrl"]),
+            ticket_url: blank_to_nil(source["ticketUrl"]),
+            notes: blank_to_nil(source["notes"]),
+            division: blank_to_nil(source["division"]),
+            bracket_code: blank_to_nil(source["bracketCode"])
+          })
+          id_maps[:games][source.fetch("id")] = game.id
+        end
+      end
+
+      def import_standings
+        each_record("standings") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "standing", source.fetch("id"))
+          team_id = mapped_id!(:teams, source.fetch("teamId"), "standing", source.fetch("id"))
+          standing = find_by_legacy(Standing, source) || Standing.find_or_initialize_by(tournament_id: tournament_id, team_id: team_id)
+          persist!(standing, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            team_id: team_id,
+            wins: source.fetch("wins"),
+            losses: source.fetch("losses"),
+            points_for: source.fetch("pointsFor"),
+            points_against: source.fetch("pointsAgainst")
+          })
+          id_maps[:standings][source.fetch("id")] = standing.id
+        end
+      end
+
+      def import_article_links
+        each_record("articleLinks") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "article", source.fetch("id"))
+          article = find_by_legacy(ArticleLink, source) || ArticleLink.find_or_initialize_by(tournament_id: tournament_id, url: source.fetch("url"))
+          persist!(article, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            title: source.fetch("title"),
+            source: source.fetch("source"),
+            url: source.fetch("url"),
+            published_at: parse_time(source["publishedAt"]),
+            image_url: blank_to_nil(source["imageUrl"]),
+            excerpt: blank_to_nil(source["excerpt"])
+          })
+          id_maps[:article_links][source.fetch("id")] = article.id
+        end
+      end
+
+      def import_media_assets
+        each_record("mediaAssets") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "media", source.fetch("id"))
+          media = find_by_legacy(MediaAsset, source) || MediaAsset.new
+          persist!(media, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            source: source.fetch("source"),
+            title: source.fetch("title"),
+            image_url: source.fetch("imageUrl"),
+            article_url: blank_to_nil(source["articleUrl"]),
+            caption: blank_to_nil(source["caption"]),
+            tags: blank_to_nil(source["tags"]),
+            taken_at: parse_time(source["takenAt"])
+          })
+          id_maps[:media_assets][source.fetch("id")] = media.id
+        end
+      end
+
+      def import_sponsors
+        each_record("sponsors") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "sponsor", source.fetch("id"))
+          sponsor = find_by_legacy(Sponsor, source) || Sponsor.find_or_initialize_by(tournament_id: tournament_id, name: source.fetch("name"))
+          persist!(sponsor, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            name: source.fetch("name"),
+            logo_url: blank_to_nil(source["logoUrl"]),
+            target_url: blank_to_nil(source["targetUrl"]),
+            tier: blank_to_nil(source["tier"]),
+            active: source.fetch("active"),
+            position: source.fetch("position")
+          })
+          id_maps[:sponsors][source.fetch("id")] = sponsor.id
+        end
+      end
+
+      def import_content_ingest_items
+        each_record("contentIngestItems") do |source|
+          tournament_id = mapped_id!(:tournaments, source.fetch("tournamentId"), "ingest item", source.fetch("id"))
+          item = find_by_legacy(ContentIngestItem, source) || ContentIngestItem.find_or_initialize_by(tournament_id: tournament_id, url: source.fetch("url"))
+          imported_to_id = mapped_imported_to_id(source, tournament_id)
+          persist!(item, source, {
+            legacy_id: source.fetch("id"),
+            tournament_id: tournament_id,
+            kind: source.fetch("kind"),
+            status: migrated_ingest_status(source, imported_to_id),
+            source: source.fetch("source"),
+            title: source.fetch("title"),
+            url: source.fetch("url"),
+            image_url: blank_to_nil(source["imageUrl"]),
+            excerpt: blank_to_nil(source["excerpt"]),
+            confidence: blank_to_nil(source["confidence"]),
+            notes: migrated_ingest_notes(source, imported_to_id),
+            imported_to_id: imported_to_id
+          })
+          id_maps[:content_ingest_items][source.fetch("id")] = item.id
+        end
+      end
+
+      def import_admin_whitelists
+        each_record("adminWhitelists") do |source|
+          whitelist = find_by_legacy(AdminWhitelist, source) || AdminWhitelist.find_or_initialize_by(email: source.fetch("email").to_s.downcase)
+          persist!(whitelist, source, {
+            legacy_id: source.fetch("id"),
+            email: source.fetch("email"),
+            role: source.fetch("role"),
+            active: source.fetch("isActive"),
+            notes: blank_to_nil(source["notes"])
+          })
+          id_maps[:admin_whitelists][source.fetch("id")] = whitelist.id
+        end
+      end
+
+      def import_users
+        each_record("appUsers") do |source|
+          user = find_by_legacy(User, source) || User.find_or_initialize_by(email: source.fetch("email").to_s.downcase)
+          persist!(user, source, {
+            legacy_id: source.fetch("id"),
+            clerk_id: blank_to_nil(source["clerkId"]),
+            email: source.fetch("email"),
+            role: source.fetch("role"),
+            active: source.fetch("isActive")
+          })
+          id_maps[:users][source.fetch("id")] = user.id
+        end
+      end
+
+      def migrated_ingest_status(source, imported_to_id)
+        return "pending" if source["status"] == "approved" && imported_to_id.blank?
+
+        source.fetch("status")
+      end
+
+      def migrated_ingest_notes(source, imported_to_id)
+        notes = blank_to_nil(source["notes"])
+        return notes unless source["status"] == "approved" && imported_to_id.blank?
+
+        [ notes, "Migration note: source snapshot marked this item approved without an imported record; reset to pending for review." ].compact.join("\n")
+      end
+
+      def mapped_imported_to_id(source, tournament_id)
+        legacy_imported_id = blank_to_nil(source["importedToId"])
+        mapped_id = if source["kind"] == "article"
+          id_maps[:article_links][legacy_imported_id]
+        else
+          id_maps[:media_assets][legacy_imported_id]
+        end
+        return mapped_id.to_s if mapped_id
+        return nil unless source["status"] == "approved"
+
+        inferred_import_for(source, tournament_id)&.id&.to_s
+      end
+
+      def inferred_import_for(source, tournament_id)
+        if source["kind"] == "article"
+          ArticleLink.find_by(tournament_id: tournament_id, url: source["url"])
+        else
+          MediaAsset.find_by(tournament_id: tournament_id, image_url: source["imageUrl"])
+        end
+      end
+
+      def each_record(key, &block)
+        records.fetch(key, []).each(&block)
+      end
+
+      def find_by_legacy(model, source)
+        model.find_by(legacy_id: source.fetch("id"))
+      end
+
+      def mapped_id!(map_key, legacy_id, record_type, record_id)
+        id_maps[map_key][legacy_id] || raise(ArgumentError, "Missing #{map_key.to_s.singularize} #{legacy_id} for #{record_type} #{record_id}")
+      end
+
+      def persist!(record, source, attrs)
+        created_at = parse_time(source["createdAt"])
+        updated_at = parse_time(source["updatedAt"]) || created_at
+
+        record.assign_attributes(attrs.compact)
+        record.created_at = created_at if created_at && record.new_record?
+        record.save!
+
+        timestamps = {}
+        timestamps[:created_at] = created_at if created_at
+        timestamps[:updated_at] = updated_at if updated_at
+        record.update_columns(timestamps) if timestamps.any? && record.persisted?
+
+        record
+      end
+
+      def parse_date(value)
+        return if value.blank?
+
+        Date.iso8601(value.to_s[0, 10])
+      end
+
+      def parse_time(value)
+        return if value.blank?
+
+        Time.zone.parse(value.to_s)
+      end
+
+      def blank_to_nil(value)
+        value.presence
+      end
+    end
+  end
+end

--- a/api/app/services/data_migration/next_prisma_snapshot/validate.rb
+++ b/api/app/services/data_migration/next_prisma_snapshot/validate.rb
@@ -95,6 +95,19 @@ module DataMigration
           issues << "standing #{standing.fetch("id")} references missing tournament #{standing["tournamentId"]}" unless source_ids[:tournaments].include?(standing["tournamentId"])
           issues << "standing #{standing.fetch("id")} references missing team #{standing["teamId"]}" unless source_ids[:teams].include?(standing["teamId"])
         end
+
+        validate_tournament_references(source_ids[:tournaments], "articleLinks", "article")
+        validate_tournament_references(source_ids[:tournaments], "mediaAssets", "media asset")
+        validate_tournament_references(source_ids[:tournaments], "sponsors", "sponsor")
+        validate_tournament_references(source_ids[:tournaments], "contentIngestItems", "ingest item")
+      end
+
+      def validate_tournament_references(tournament_ids, record_key, label)
+        records.fetch(record_key, []).each do |record|
+          next if tournament_ids.include?(record["tournamentId"])
+
+          issues << "#{label} #{record.fetch("id")} references missing tournament #{record["tournamentId"]}"
+        end
       end
 
       def validate_ingest_imports

--- a/api/app/services/data_migration/next_prisma_snapshot/validate.rb
+++ b/api/app/services/data_migration/next_prisma_snapshot/validate.rb
@@ -1,0 +1,211 @@
+require "json"
+require "fileutils"
+require "set"
+
+module DataMigration
+  module NextPrismaSnapshot
+    class Validate
+      FORMAT = "fd-alumni-hub-next-prisma-export"
+      TABLES = {
+        "tournaments" => Tournament,
+        "teams" => Team,
+        "games" => Game,
+        "standings" => Standing,
+        "articleLinks" => ArticleLink,
+        "mediaAssets" => MediaAsset,
+        "sponsors" => Sponsor,
+        "contentIngestItems" => ContentIngestItem,
+        "adminWhitelists" => AdminWhitelist,
+        "appUsers" => User
+      }.freeze
+
+      attr_reader :path, :snapshot, :records, :issues, :warnings
+
+      def self.call(path, out_dir: nil)
+        new(path, out_dir: out_dir).call
+      end
+
+      def initialize(path, out_dir: nil)
+        @path = path
+        @snapshot = JSON.parse(File.read(path))
+        @records = snapshot.fetch("records")
+        @issues = []
+        @warnings = []
+        @out_dir = out_dir
+      end
+
+      def call
+        validate_format!
+        report = build_report
+        write_report(report) if @out_dir.present?
+        report
+      end
+
+      private
+
+      def validate_format!
+        return if snapshot["format"] == FORMAT && snapshot["version"].to_i == 1
+
+        raise ArgumentError, "Unsupported snapshot format/version"
+      end
+
+      def build_report
+        count_checks = TABLES.to_h do |record_key, model|
+          legacy_ids = source_legacy_ids(record_key)
+          imported_count = model.where(legacy_id: legacy_ids).count
+          missing_ids = legacy_ids - model.where(legacy_id: legacy_ids).pluck(:legacy_id)
+
+          issues << "#{record_key}: #{missing_ids.length} missing imported records" if missing_ids.any?
+
+          [ record_key, { source: legacy_ids.length, imported: imported_count, missing: missing_ids.length, missingIds: missing_ids.first(25) } ]
+        end
+
+        validate_relationships
+        validate_ingest_imports
+
+        {
+          path: path,
+          validatedAt: Time.current.iso8601,
+          sourceExportedAt: snapshot["exportedAt"],
+          ok: issues.empty?,
+          counts: count_checks,
+          scoreCoverage: score_coverage,
+          issues: issues,
+          warnings: warnings
+        }
+      end
+
+      def validate_relationships
+        source_ids = {
+          tournaments: source_legacy_ids("tournaments").to_set,
+          teams: source_legacy_ids("teams").to_set
+        }
+
+        records.fetch("teams", []).each do |team|
+          issues << "team #{team.fetch("id")} references missing tournament #{team["tournamentId"]}" unless source_ids[:tournaments].include?(team["tournamentId"])
+        end
+
+        records.fetch("games", []).each do |game|
+          issues << "game #{game.fetch("id")} references missing tournament #{game["tournamentId"]}" unless source_ids[:tournaments].include?(game["tournamentId"])
+          issues << "game #{game.fetch("id")} references missing home team #{game["homeTeamId"]}" unless source_ids[:teams].include?(game["homeTeamId"])
+          issues << "game #{game.fetch("id")} references missing away team #{game["awayTeamId"]}" unless source_ids[:teams].include?(game["awayTeamId"])
+        end
+
+        records.fetch("standings", []).each do |standing|
+          issues << "standing #{standing.fetch("id")} references missing tournament #{standing["tournamentId"]}" unless source_ids[:tournaments].include?(standing["tournamentId"])
+          issues << "standing #{standing.fetch("id")} references missing team #{standing["teamId"]}" unless source_ids[:teams].include?(standing["teamId"])
+        end
+      end
+
+      def validate_ingest_imports
+        source_by_legacy_id = records.fetch("contentIngestItems", []).index_by { |item| item["id"] }
+
+        ContentIngestItem.where(legacy_id: source_legacy_ids("contentIngestItems")).find_each do |item|
+          source = source_by_legacy_id[item.legacy_id]
+          if source&.dig("status") == "approved" && source["importedToId"].blank? && item.status == "pending"
+            warnings << "ingest item #{item.legacy_id} was approved in source without an imported record and was reset to pending"
+          end
+
+          next unless item.status == "approved"
+
+          if item.imported_to_id.blank?
+            issues << "approved ingest item #{item.legacy_id} has no imported_to_id"
+            next
+          end
+
+          imported_exists = item.kind == "article" ? ArticleLink.exists?(id: item.imported_to_id) : MediaAsset.exists?(id: item.imported_to_id)
+          issues << "approved ingest item #{item.legacy_id} references missing imported #{item.kind} #{item.imported_to_id}" unless imported_exists
+        end
+      end
+
+      def score_coverage
+        source_games = records.fetch("games", [])
+        rails_games = Game.where(legacy_id: source_games.filter_map { |game| game["id"] })
+
+        {
+          source: coverage_for_source(source_games),
+          rails: coverage_for_rails(rails_games)
+        }
+      end
+
+      def coverage_for_source(games)
+        total = games.length
+        scored = games.count { |game| !game["homeScore"].nil? && !game["awayScore"].nil? }
+        final_missing_scores = games.count { |game| game["status"] == "final" && (game["homeScore"].nil? || game["awayScore"].nil?) }
+
+        coverage_payload(total, scored, final_missing_scores)
+      end
+
+      def coverage_for_rails(scope)
+        total = scope.count
+        scored = scope.where.not(home_score: nil).where.not(away_score: nil).count
+        final_missing_scores = scope.where(status: "final").where("home_score IS NULL OR away_score IS NULL").count
+
+        coverage_payload(total, scored, final_missing_scores)
+      end
+
+      def coverage_payload(total, scored, final_missing_scores)
+        percent = total.positive? ? ((scored.to_f / total) * 1000).round / 10.0 : 0
+        { total: total, scored: scored, percent: percent, finalMissingScores: final_missing_scores }
+      end
+
+      def source_legacy_ids(record_key)
+        records.fetch(record_key, []).filter_map { |record| record["id"] }
+      end
+
+      def write_report(report)
+        FileUtils.mkdir_p(@out_dir)
+        File.write(File.join(@out_dir, "rails-import-validation.json"), JSON.pretty_generate(report) + "\n")
+        File.write(File.join(@out_dir, "rails-import-validation.md"), markdown_report(report))
+      end
+
+      def markdown_report(report)
+        lines = [
+          "# Rails Import Validation",
+          "",
+          "- Snapshot: `#{path}`",
+          "- Source exported at: #{report[:sourceExportedAt]}",
+          "- Validated at: #{report[:validatedAt]}",
+          "- Result: #{report[:ok] ? "PASS" : "FAIL"}",
+          "",
+          "## Counts",
+          "",
+          "| Record | Source | Imported | Missing |",
+          "| --- | ---: | ---: | ---: |"
+        ]
+
+        report[:counts].each do |record_key, counts|
+          lines << "| #{record_key} | #{counts[:source]} | #{counts[:imported]} | #{counts[:missing]} |"
+        end
+
+        lines += [
+          "",
+          "## Score coverage",
+          "",
+          "| Scope | Total | Scored | Coverage | Final games missing scores |",
+          "| --- | ---: | ---: | ---: | ---: |"
+        ]
+
+        report[:scoreCoverage].each do |scope, coverage|
+          lines << "| #{scope} | #{coverage[:total]} | #{coverage[:scored]} | #{coverage[:percent]}% | #{coverage[:finalMissingScores]} |"
+        end
+
+        lines += [ "", "## Issues", "" ]
+        if report[:issues].empty?
+          lines << "No issues found."
+        else
+          report[:issues].each { |issue| lines << "- #{issue}" }
+        end
+
+        lines += [ "", "## Warnings", "" ]
+        if report[:warnings].empty?
+          lines << "No warnings found."
+        else
+          report[:warnings].each { |warning| lines << "- #{warning}" }
+        end
+
+        lines.join("\n") + "\n"
+      end
+    end
+  end
+end

--- a/api/db/migrate/20260611000002_add_legacy_ids_for_next_migration.rb
+++ b/api/db/migrate/20260611000002_add_legacy_ids_for_next_migration.rb
@@ -1,0 +1,21 @@
+class AddLegacyIdsForNextMigration < ActiveRecord::Migration[8.1]
+  TABLES = %i[
+    tournaments
+    teams
+    games
+    standings
+    article_links
+    media_assets
+    sponsors
+    content_ingest_items
+    admin_whitelists
+    users
+  ].freeze
+
+  def change
+    TABLES.each do |table_name|
+      add_column table_name, :legacy_id, :string
+      add_index table_name, :legacy_id, unique: true, where: "legacy_id IS NOT NULL"
+    end
+  end
+end

--- a/api/db/migrate/20260611000003_allow_duplicate_media_asset_images.rb
+++ b/api/db/migrate/20260611000003_allow_duplicate_media_asset_images.rb
@@ -1,0 +1,6 @@
+class AllowDuplicateMediaAssetImages < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :media_assets, name: "index_media_assets_on_tournament_id_and_image_url"
+    add_index :media_assets, [ :tournament_id, :image_url ], name: "index_media_assets_on_tournament_id_and_image_url"
+  end
+end

--- a/api/db/migrate/20260611000004_add_placeholder_to_games.rb
+++ b/api/db/migrate/20260611000004_add_placeholder_to_games.rb
@@ -1,0 +1,6 @@
+class AddPlaceholderToGames < ActiveRecord::Migration[8.1]
+  def change
+    add_column :games, :placeholder, :boolean, default: false, null: false
+    add_index :games, [ :tournament_id, :placeholder ]
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_000004) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -75,6 +75,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000003) do
     t.bigint "home_team_id", null: false
     t.string "legacy_id"
     t.text "notes"
+    t.boolean "placeholder", default: false, null: false
     t.datetime "start_time", null: false
     t.string "status", default: "scheduled", null: false
     t.string "stream_url"
@@ -87,6 +88,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000003) do
     t.index ["legacy_id"], name: "index_games_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["status"], name: "index_games_on_status"
     t.index ["tournament_id", "division"], name: "index_games_on_tournament_id_and_division"
+    t.index ["tournament_id", "placeholder"], name: "index_games_on_tournament_id_and_placeholder"
     t.index ["tournament_id", "start_time"], name: "index_games_on_tournament_id_and_start_time"
     t.index ["tournament_id"], name: "index_games_on_tournament_id"
   end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_11_000003) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -18,22 +18,26 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
     t.string "email", null: false
+    t.string "legacy_id"
     t.text "notes"
     t.string "role", default: "admin", null: false
     t.datetime "updated_at", null: false
     t.index "lower((email)::text)", name: "index_admin_whitelists_on_lower_email", unique: true
+    t.index ["legacy_id"], name: "index_admin_whitelists_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
   end
 
   create_table "article_links", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.text "excerpt"
     t.string "image_url"
+    t.string "legacy_id"
     t.datetime "published_at"
     t.string "source", null: false
     t.string "title", null: false
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false
     t.string "url", null: false
+    t.index ["legacy_id"], name: "index_article_links_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["tournament_id", "published_at"], name: "index_article_links_on_tournament_id_and_published_at"
     t.index ["tournament_id", "url"], name: "index_article_links_on_tournament_id_and_url", unique: true
     t.index ["tournament_id"], name: "index_article_links_on_tournament_id"
@@ -46,6 +50,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.string "image_url"
     t.string "imported_to_id"
     t.string "kind", null: false
+    t.string "legacy_id"
     t.text "notes"
     t.string "source", null: false
     t.string "status", default: "pending", null: false
@@ -53,6 +58,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false
     t.string "url", null: false
+    t.index ["legacy_id"], name: "index_content_ingest_items_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["source", "status"], name: "index_content_ingest_items_on_source_and_status"
     t.index ["tournament_id", "status", "kind"], name: "index_ingest_on_tournament_status_kind"
     t.index ["tournament_id", "url"], name: "index_ingest_on_tournament_and_url", unique: true
@@ -67,6 +73,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.string "division"
     t.integer "home_score"
     t.bigint "home_team_id", null: false
+    t.string "legacy_id"
     t.text "notes"
     t.datetime "start_time", null: false
     t.string "status", default: "scheduled", null: false
@@ -77,6 +84,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.string "venue"
     t.index ["away_team_id"], name: "index_games_on_away_team_id"
     t.index ["home_team_id"], name: "index_games_on_home_team_id"
+    t.index ["legacy_id"], name: "index_games_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["status"], name: "index_games_on_status"
     t.index ["tournament_id", "division"], name: "index_games_on_tournament_id_and_division"
     t.index ["tournament_id", "start_time"], name: "index_games_on_tournament_id_and_start_time"
@@ -88,13 +96,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.text "caption"
     t.datetime "created_at", null: false
     t.string "image_url", null: false
+    t.string "legacy_id"
     t.string "source", null: false
     t.string "tags"
     t.datetime "taken_at"
     t.string "title", null: false
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["tournament_id", "image_url"], name: "index_media_assets_on_tournament_id_and_image_url", unique: true
+    t.index ["legacy_id"], name: "index_media_assets_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
+    t.index ["tournament_id", "image_url"], name: "index_media_assets_on_tournament_id_and_image_url"
     t.index ["tournament_id", "source", "taken_at"], name: "index_media_assets_on_tournament_id_and_source_and_taken_at"
     t.index ["tournament_id"], name: "index_media_assets_on_tournament_id"
   end
@@ -102,6 +112,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
   create_table "sponsors", force: :cascade do |t|
     t.boolean "active", default: true, null: false
     t.datetime "created_at", null: false
+    t.string "legacy_id"
     t.string "logo_url"
     t.string "name", null: false
     t.integer "position", default: 0, null: false
@@ -109,12 +120,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.string "tier"
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["legacy_id"], name: "index_sponsors_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["tournament_id", "active", "position"], name: "index_sponsors_on_tournament_id_and_active_and_position"
     t.index ["tournament_id"], name: "index_sponsors_on_tournament_id"
   end
 
   create_table "standings", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "legacy_id"
     t.integer "losses", default: 0, null: false
     t.integer "points_against", default: 0, null: false
     t.integer "points_for", default: 0, null: false
@@ -122,6 +135,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false
     t.integer "wins", default: 0, null: false
+    t.index ["legacy_id"], name: "index_standings_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["team_id"], name: "index_standings_on_team_id"
     t.index ["tournament_id", "team_id"], name: "index_standings_on_tournament_id_and_team_id", unique: true
     t.index ["tournament_id", "wins", "losses"], name: "index_standings_on_tournament_id_and_wins_and_losses"
@@ -133,8 +147,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.datetime "created_at", null: false
     t.string "display_name", null: false
     t.string "division"
+    t.string "legacy_id"
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false
+    t.index ["legacy_id"], name: "index_teams_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["tournament_id", "display_name"], name: "index_teams_on_tournament_and_display_name", unique: true
     t.index ["tournament_id", "division"], name: "index_teams_on_tournament_id_and_division"
     t.index ["tournament_id"], name: "index_teams_on_tournament_id"
@@ -143,11 +159,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
   create_table "tournaments", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "end_date", null: false
+    t.string "legacy_id"
     t.string "name", null: false
     t.date "start_date", null: false
     t.string "status", default: "upcoming", null: false
     t.datetime "updated_at", null: false
     t.integer "year", null: false
+    t.index ["legacy_id"], name: "index_tournaments_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
     t.index ["year", "name"], name: "index_tournaments_on_year_and_name", unique: true
     t.index ["year", "status"], name: "index_tournaments_on_year_and_status"
   end
@@ -159,10 +177,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_11_000001) do
     t.string "email", null: false
     t.string "first_name"
     t.string "last_name"
+    t.string "legacy_id"
     t.string "role", default: "staff", null: false
     t.datetime "updated_at", null: false
     t.index "lower((email)::text)", name: "index_users_on_lower_email", unique: true
     t.index ["clerk_id"], name: "index_users_on_clerk_id", unique: true, where: "(clerk_id IS NOT NULL)"
+    t.index ["legacy_id"], name: "index_users_on_legacy_id", unique: true, where: "(legacy_id IS NOT NULL)"
   end
 
   add_foreign_key "article_links", "tournaments", on_delete: :cascade

--- a/api/lib/tasks/fd_migration.rake
+++ b/api/lib/tasks/fd_migration.rake
@@ -1,0 +1,26 @@
+namespace :fd do
+  namespace :migration do
+    desc "Import an operator-created Next/Prisma snapshot into the Rails database"
+    task :import_next_snapshot, [ :path ] => :environment do |_task, args|
+      path = args[:path].presence || ENV["SNAPSHOT"]
+      abort "Usage: bin/rails 'fd:migration:import_next_snapshot[path/to/snapshot.json]' or SNAPSHOT=path/to/snapshot.json" if path.blank?
+
+      result = DataMigration::NextPrismaSnapshot::Import.call(path)
+      puts JSON.pretty_generate(result)
+    end
+
+    desc "Validate Rails imported records against a Next/Prisma snapshot"
+    task :validate_next_snapshot, [ :path ] => :environment do |_task, args|
+      path = args[:path].presence || ENV["SNAPSHOT"]
+      abort "Usage: bin/rails 'fd:migration:validate_next_snapshot[path/to/snapshot.json]' or SNAPSHOT=path/to/snapshot.json" if path.blank?
+
+      out_dir = ENV["OUT_DIR"].presence || Rails.root.join("..", "tmp", "fd-migration").to_s
+      report = DataMigration::NextPrismaSnapshot::Validate.call(path, out_dir: out_dir)
+
+      puts JSON.pretty_generate(report.slice(:ok, :counts, :scoreCoverage, :issues, :warnings))
+      abort "Rails import validation failed. See #{out_dir}/rails-import-validation.md" unless report[:ok]
+
+      puts "Rails import validation passed. Reports written to #{out_dir}"
+    end
+  end
+end

--- a/api/test/models/game_test.rb
+++ b/api/test/models/game_test.rb
@@ -12,7 +12,19 @@ class GameTest < ActiveSupport::TestCase
     @team = @tournament.teams.create!(class_year_label: "TBD", display_name: "Class TBD", division: "Special")
   end
 
-  test "allows scheduled unscored placeholder games with the same team" do
+  test "allows explicitly marked placeholder games with the same team" do
+    game = @tournament.games.build(
+      home_team: @team,
+      away_team: @team,
+      start_time: Time.zone.local(2026, 7, 3, 18, 0),
+      status: "scheduled",
+      placeholder: true
+    )
+
+    assert game.valid?
+  end
+
+  test "rejects unmarked scheduled same-team games" do
     game = @tournament.games.build(
       home_team: @team,
       away_team: @team,
@@ -20,7 +32,8 @@ class GameTest < ActiveSupport::TestCase
       status: "scheduled"
     )
 
-    assert game.valid?
+    assert_not game.valid?
+    assert_includes game.errors[:away_team_id], "must be different from home team"
   end
 
   test "rejects scored same-team games" do

--- a/api/test/models/game_test.rb
+++ b/api/test/models/game_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class GameTest < ActiveSupport::TestCase
+  setup do
+    @tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2026,
+      start_date: Date.new(2026, 7, 3),
+      end_date: Date.new(2026, 7, 24),
+      status: "live"
+    )
+    @team = @tournament.teams.create!(class_year_label: "TBD", display_name: "Class TBD", division: "Special")
+  end
+
+  test "allows scheduled unscored placeholder games with the same team" do
+    game = @tournament.games.build(
+      home_team: @team,
+      away_team: @team,
+      start_time: Time.zone.local(2026, 7, 3, 18, 0),
+      status: "scheduled"
+    )
+
+    assert game.valid?
+  end
+
+  test "rejects scored same-team games" do
+    game = @tournament.games.build(
+      home_team: @team,
+      away_team: @team,
+      start_time: Time.zone.local(2026, 7, 3, 18, 0),
+      status: "final",
+      home_score: 1,
+      away_score: 0
+    )
+
+    assert_not game.valid?
+    assert_includes game.errors[:away_team_id], "must be different from home team"
+  end
+end

--- a/api/test/services/next_prisma_snapshot_migration_test.rb
+++ b/api/test/services/next_prisma_snapshot_migration_test.rb
@@ -6,10 +6,14 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
     path = write_snapshot
 
     result = DataMigration::NextPrismaSnapshot::Import.call(path)
-    assert_equal 1, result[:counts]["tournaments"]
-    assert_equal 2, result[:counts]["teams"]
-    assert_equal 2, result[:counts]["games"]
-    assert_equal 2, result[:counts]["mediaAssets"]
+    assert_equal 1, result[:sourceCounts]["tournaments"]
+    assert_equal 1, result[:railsCounts]["tournaments"]
+    assert_equal 2, result[:sourceCounts]["teams"]
+    assert_equal 2, result[:railsCounts]["teams"]
+    assert_equal 2, result[:sourceCounts]["games"]
+    assert_equal 2, result[:railsCounts]["games"]
+    assert_equal 2, result[:sourceCounts]["mediaAssets"]
+    assert_equal 2, result[:railsCounts]["mediaAssets"]
 
     assert_no_difference -> { Tournament.count } do
       assert_no_difference -> { Team.count } do
@@ -39,12 +43,26 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
     assert_equal "approved", ingest_item.status
     assert_equal article.id.to_s, ingest_item.imported_to_id
     assert_equal "approved", media_ingest_item.status
-    assert media_ingest_item.imported_to_id.present?
+    assert_equal MediaAsset.find_by!(legacy_id: "next_media_1").id.to_s, media_ingest_item.imported_to_id
     assert_equal 2, MediaAsset.where(image_url: "https://example.test/media.jpg").count
 
     report = DataMigration::NextPrismaSnapshot::Validate.call(path)
     assert report[:ok], report[:issues].join("\n")
     assert_equal({ total: 2, scored: 1, percent: 50.0, finalMissingScores: 0 }, report[:scoreCoverage][:rails])
+  end
+
+  test "ambiguous media ingest inference resets approved source item to pending" do
+    payload = snapshot_payload
+    ingest = payload[:records][:contentIngestItems].find { |item| item[:id] == "next_ingest_2" }
+    ingest[:title] = "Ambiguous duplicate image"
+    path = write_snapshot(payload, "next-prisma-ambiguous-media-ingest-test.json")
+
+    DataMigration::NextPrismaSnapshot::Import.call(path)
+
+    item = ContentIngestItem.find_by!(legacy_id: "next_ingest_2")
+    assert_equal "pending", item.status
+    assert_nil item.imported_to_id
+    assert_includes item.notes, "reset to pending"
   end
 
   test "validator reports content records that reference missing tournaments" do

--- a/api/test/services/next_prisma_snapshot_migration_test.rb
+++ b/api/test/services/next_prisma_snapshot_migration_test.rb
@@ -1,0 +1,254 @@
+require "test_helper"
+require "tmpdir"
+
+class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
+  test "imports a Next Prisma snapshot idempotently and validates it" do
+    path = write_snapshot
+
+    result = DataMigration::NextPrismaSnapshot::Import.call(path)
+    assert_equal 1, result[:counts]["tournaments"]
+    assert_equal 2, result[:counts]["teams"]
+    assert_equal 1, result[:counts]["games"]
+    assert_equal 2, result[:counts]["mediaAssets"]
+
+    assert_no_difference -> { Tournament.count } do
+      assert_no_difference -> { Team.count } do
+        assert_no_difference -> { Game.count } do
+          DataMigration::NextPrismaSnapshot::Import.call(path)
+        end
+      end
+    end
+
+    tournament = Tournament.find_by!(legacy_id: "next_tournament_2025")
+    assert_equal "completed", tournament.status
+    assert_equal Date.new(2025, 6, 27), tournament.start_date
+
+    game = Game.find_by!(legacy_id: "next_game_1")
+    assert_equal tournament.id, game.tournament_id
+    assert_equal 50, game.home_score
+    assert_equal 44, game.away_score
+    assert_equal "https://clutch.test/live", game.stream_url
+
+    article = ArticleLink.find_by!(legacy_id: "next_article_1")
+    ingest_item = ContentIngestItem.find_by!(legacy_id: "next_ingest_1")
+    media_ingest_item = ContentIngestItem.find_by!(legacy_id: "next_ingest_2")
+    assert_equal "approved", ingest_item.status
+    assert_equal article.id.to_s, ingest_item.imported_to_id
+    assert_equal "approved", media_ingest_item.status
+    assert media_ingest_item.imported_to_id.present?
+    assert_equal 2, MediaAsset.where(image_url: "https://example.test/media.jpg").count
+
+    report = DataMigration::NextPrismaSnapshot::Validate.call(path)
+    assert report[:ok], report[:issues].join("\n")
+    assert_equal({ total: 1, scored: 1, percent: 100.0, finalMissingScores: 0 }, report[:scoreCoverage][:rails])
+  end
+
+  private
+
+  def write_snapshot
+    path = Rails.root.join("tmp", "next-prisma-snapshot-test.json")
+    FileUtils.mkdir_p(path.dirname)
+    File.write(path, JSON.pretty_generate(snapshot_payload))
+    path.to_s
+  end
+
+  def snapshot_payload
+    now = "2026-06-11T00:00:00.000Z"
+
+    {
+      format: "fd-alumni-hub-next-prisma-export",
+      version: 1,
+      exportedAt: now,
+      source: { app: "apps/web", databaseProvider: "postgresql" },
+      counts: {
+        tournaments: 1,
+        teams: 2,
+        games: 1,
+        standings: 1,
+        articleLinks: 1,
+        mediaAssets: 2,
+        sponsors: 1,
+        contentIngestItems: 2,
+        adminWhitelists: 1,
+        appUsers: 1
+      },
+      records: {
+        tournaments: [
+          {
+            id: "next_tournament_2025",
+            name: "FD Alumni Basketball Tournament",
+            year: 2025,
+            startDate: "2025-06-27T00:00:00.000Z",
+            endDate: "2025-07-19T00:00:00.000Z",
+            status: "completed",
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        teams: [
+          {
+            id: "next_team_2002_04",
+            tournamentId: "next_tournament_2025",
+            classYearLabel: "Class of 2002/04",
+            displayName: "Class of 2002/04",
+            division: "Maroon",
+            createdAt: now,
+            updatedAt: now
+          },
+          {
+            id: "next_team_2013",
+            tournamentId: "next_tournament_2025",
+            classYearLabel: "Class of 2013",
+            displayName: "Class of 2013",
+            division: "Maroon",
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        games: [
+          {
+            id: "next_game_1",
+            tournamentId: "next_tournament_2025",
+            homeTeamId: "next_team_2002_04",
+            awayTeamId: "next_team_2013",
+            startTime: "2025-07-19T10:00:00.000Z",
+            venue: "FD Phoenix Center",
+            status: "final",
+            homeScore: 50,
+            awayScore: 44,
+            streamUrl: "https://clutch.test/live",
+            ticketUrl: "https://guamtime.test/tickets",
+            notes: "phase=playoff",
+            division: "Maroon",
+            bracketCode: "F",
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        standings: [
+          {
+            id: "next_standing_1",
+            tournamentId: "next_tournament_2025",
+            teamId: "next_team_2002_04",
+            wins: 1,
+            losses: 0,
+            pointsFor: 50,
+            pointsAgainst: 44,
+            updatedAt: now
+          }
+        ],
+        articleLinks: [
+          {
+            id: "next_article_1",
+            tournamentId: "next_tournament_2025",
+            title: "Championship recap",
+            source: "GSPN",
+            url: "https://example.test/championship-recap",
+            publishedAt: "2025-07-19T00:00:00.000Z",
+            createdAt: now,
+            imageUrl: "https://example.test/photo.jpg",
+            excerpt: "Tournament recap"
+          }
+        ],
+        mediaAssets: [
+          {
+            id: "next_media_1",
+            tournamentId: "next_tournament_2025",
+            source: "GSPN",
+            title: "Championship photo",
+            imageUrl: "https://example.test/media.jpg",
+            articleUrl: "https://example.test/championship-recap",
+            caption: "Championship night",
+            tags: "championship",
+            takenAt: "2025-07-19T00:00:00.000Z",
+            createdAt: now,
+            updatedAt: now
+          },
+          {
+            id: "next_media_2",
+            tournamentId: "next_tournament_2025",
+            source: "GSPN",
+            title: "Duplicate source image with different caption",
+            imageUrl: "https://example.test/media.jpg",
+            articleUrl: "https://example.test/championship-recap",
+            caption: "Alternate caption",
+            tags: "championship,alternate",
+            takenAt: "2025-07-19T00:00:00.000Z",
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        sponsors: [
+          {
+            id: "next_sponsor_1",
+            tournamentId: "next_tournament_2025",
+            name: "Community Sponsor",
+            logoUrl: nil,
+            targetUrl: "https://example.test",
+            tier: "Community Partner",
+            active: true,
+            position: 1,
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        contentIngestItems: [
+          {
+            id: "next_ingest_1",
+            tournamentId: "next_tournament_2025",
+            kind: "article",
+            status: "approved",
+            source: "GSPN",
+            title: "Championship recap",
+            url: "https://example.test/championship-recap",
+            imageUrl: "https://example.test/photo.jpg",
+            excerpt: "Tournament recap",
+            confidence: "high",
+            notes: "Imported from Next",
+            importedToId: "next_article_1",
+            createdAt: now,
+            updatedAt: now
+          },
+          {
+            id: "next_ingest_2",
+            tournamentId: "next_tournament_2025",
+            kind: "media",
+            status: "approved",
+            source: "GSPN",
+            title: "Championship photo",
+            url: "https://example.test/media.jpg",
+            imageUrl: "https://example.test/media.jpg",
+            excerpt: "Tournament photo",
+            confidence: "high",
+            notes: "Imported from Next without importedToId",
+            importedToId: nil,
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        adminWhitelists: [
+          {
+            id: "next_whitelist_1",
+            email: "admin@example.test",
+            role: "admin",
+            isActive: true,
+            notes: "Next import",
+            createdAt: now,
+            updatedAt: now
+          }
+        ],
+        appUsers: [
+          {
+            id: "next_user_1",
+            clerkId: "clerk_next_user_1",
+            email: "admin@example.test",
+            role: "admin",
+            isActive: true,
+            createdAt: now,
+            updatedAt: now
+          }
+        ]
+      }
+    }
+  end
+end

--- a/api/test/services/next_prisma_snapshot_migration_test.rb
+++ b/api/test/services/next_prisma_snapshot_migration_test.rb
@@ -8,7 +8,7 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
     result = DataMigration::NextPrismaSnapshot::Import.call(path)
     assert_equal 1, result[:counts]["tournaments"]
     assert_equal 2, result[:counts]["teams"]
-    assert_equal 1, result[:counts]["games"]
+    assert_equal 2, result[:counts]["games"]
     assert_equal 2, result[:counts]["mediaAssets"]
 
     assert_no_difference -> { Tournament.count } do
@@ -29,6 +29,10 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
     assert_equal 44, game.away_score
     assert_equal "https://clutch.test/live", game.stream_url
 
+    placeholder_game = Game.find_by!(legacy_id: "next_game_placeholder")
+    assert placeholder_game.placeholder?
+    assert_equal placeholder_game.home_team_id, placeholder_game.away_team_id
+
     article = ArticleLink.find_by!(legacy_id: "next_article_1")
     ingest_item = ContentIngestItem.find_by!(legacy_id: "next_ingest_1")
     media_ingest_item = ContentIngestItem.find_by!(legacy_id: "next_ingest_2")
@@ -40,15 +44,32 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
 
     report = DataMigration::NextPrismaSnapshot::Validate.call(path)
     assert report[:ok], report[:issues].join("\n")
-    assert_equal({ total: 1, scored: 1, percent: 100.0, finalMissingScores: 0 }, report[:scoreCoverage][:rails])
+    assert_equal({ total: 2, scored: 1, percent: 50.0, finalMissingScores: 0 }, report[:scoreCoverage][:rails])
+  end
+
+  test "validator reports content records that reference missing tournaments" do
+    payload = snapshot_payload
+    payload[:records][:articleLinks].first[:tournamentId] = "missing_tournament"
+    payload[:records][:mediaAssets].first[:tournamentId] = "missing_tournament"
+    payload[:records][:sponsors].first[:tournamentId] = "missing_tournament"
+    payload[:records][:contentIngestItems].first[:tournamentId] = "missing_tournament"
+    path = write_snapshot(payload, "next-prisma-invalid-relationships-test.json")
+
+    report = DataMigration::NextPrismaSnapshot::Validate.call(path)
+
+    assert_not report[:ok]
+    assert_includes report[:issues], "article next_article_1 references missing tournament missing_tournament"
+    assert_includes report[:issues], "media asset next_media_1 references missing tournament missing_tournament"
+    assert_includes report[:issues], "sponsor next_sponsor_1 references missing tournament missing_tournament"
+    assert_includes report[:issues], "ingest item next_ingest_1 references missing tournament missing_tournament"
   end
 
   private
 
-  def write_snapshot
-    path = Rails.root.join("tmp", "next-prisma-snapshot-test.json")
+  def write_snapshot(payload = snapshot_payload, filename = "next-prisma-snapshot-test.json")
+    path = Rails.root.join("tmp", filename)
     FileUtils.mkdir_p(path.dirname)
-    File.write(path, JSON.pretty_generate(snapshot_payload))
+    File.write(path, JSON.pretty_generate(payload))
     path.to_s
   end
 
@@ -63,7 +84,7 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
       counts: {
         tournaments: 1,
         teams: 2,
-        games: 1,
+        games: 2,
         standings: 1,
         articleLinks: 1,
         mediaAssets: 2,
@@ -121,6 +142,24 @@ class NextPrismaSnapshotMigrationTest < ActiveSupport::TestCase
             notes: "phase=playoff",
             division: "Maroon",
             bracketCode: "F",
+            createdAt: now,
+            updatedAt: now
+          },
+          {
+            id: "next_game_placeholder",
+            tournamentId: "next_tournament_2025",
+            homeTeamId: "next_team_2013",
+            awayTeamId: "next_team_2013",
+            startTime: "2025-07-20T10:00:00.000Z",
+            venue: "FD Phoenix Center",
+            status: "scheduled",
+            homeScore: nil,
+            awayScore: nil,
+            streamUrl: nil,
+            ticketUrl: nil,
+            notes: "phase=playoff | placeholder=TBD",
+            division: "Special",
+            bracketCode: "TBD",
             createdAt: now,
             updatedAt: now
           }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,8 @@
     "apply:historical-gap-batch1": "tsx scripts/apply-historical-gap-batch1.ts",
     "finalize:historical-gap-batch1": "tsx scripts/finalize-historical-gap-batch1.ts",
     "qa-check": "tsx scripts/qa-smoke-check.ts",
-    "import:archive-content": "tsx scripts/import-archive-content.ts"
+    "import:archive-content": "tsx scripts/import-archive-content.ts",
+    "export:rails-migration": "tsx scripts/export-rails-migration.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1001.0",

--- a/apps/web/scripts/export-rails-migration.ts
+++ b/apps/web/scripts/export-rails-migration.ts
@@ -1,0 +1,109 @@
+import { PrismaClient } from '@prisma/client'
+import { mkdir, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const sourceUrl = process.env.SOURCE_DATABASE_URL || process.env.DATABASE_URL
+if (!sourceUrl) {
+  console.error('SOURCE_DATABASE_URL or DATABASE_URL is required for export')
+  process.exit(1)
+}
+
+process.env.DATABASE_URL = sourceUrl
+
+const prisma = new PrismaClient()
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+
+type ExportPayload = {
+  format: 'fd-alumni-hub-next-prisma-export'
+  version: 1
+  exportedAt: string
+  source: {
+    app: 'apps/web'
+    databaseProvider: 'postgresql'
+  }
+  counts: Record<string, number>
+  records: Record<string, unknown[]>
+}
+
+function argValue(name: string) {
+  const prefix = `${name}=`
+  const inline = process.argv.find((arg) => arg.startsWith(prefix))
+  if (inline) return inline.slice(prefix.length)
+
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1] : undefined
+}
+
+function defaultOutPath() {
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').replace('Z', '')
+  return `tmp/fd-migration/next-prisma-export-${stamp}.json`
+}
+
+async function main() {
+  const outPath = resolve(repoRoot, argValue('--out') || process.env.FD_EXPORT_PATH || defaultOutPath())
+
+  const [
+    tournaments,
+    teams,
+    games,
+    standings,
+    articleLinks,
+    mediaAssets,
+    sponsors,
+    contentIngestItems,
+    adminWhitelists,
+    appUsers,
+  ] = await Promise.all([
+    prisma.tournament.findMany({ orderBy: [ { year: 'asc' }, { name: 'asc' }, { id: 'asc' } ] }),
+    prisma.team.findMany({ orderBy: [ { tournamentId: 'asc' }, { displayName: 'asc' }, { id: 'asc' } ] }),
+    prisma.game.findMany({ orderBy: [ { tournamentId: 'asc' }, { startTime: 'asc' }, { id: 'asc' } ] }),
+    prisma.standing.findMany({ orderBy: [ { tournamentId: 'asc' }, { teamId: 'asc' }, { id: 'asc' } ] }),
+    prisma.articleLink.findMany({ orderBy: [ { tournamentId: 'asc' }, { publishedAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' } ] }),
+    prisma.mediaAsset.findMany({ orderBy: [ { tournamentId: 'asc' }, { takenAt: 'asc' }, { createdAt: 'asc' }, { id: 'asc' } ] }),
+    prisma.sponsor.findMany({ orderBy: [ { tournamentId: 'asc' }, { position: 'asc' }, { name: 'asc' }, { id: 'asc' } ] }),
+    prisma.contentIngestItem.findMany({ orderBy: [ { tournamentId: 'asc' }, { createdAt: 'asc' }, { id: 'asc' } ] }),
+    prisma.adminWhitelist.findMany({ orderBy: [ { email: 'asc' }, { id: 'asc' } ] }),
+    prisma.appUser.findMany({ orderBy: [ { email: 'asc' }, { id: 'asc' } ] }),
+  ])
+
+  const records = {
+    tournaments,
+    teams,
+    games,
+    standings,
+    articleLinks,
+    mediaAssets,
+    sponsors,
+    contentIngestItems,
+    adminWhitelists,
+    appUsers,
+  }
+
+  const payload: ExportPayload = {
+    format: 'fd-alumni-hub-next-prisma-export',
+    version: 1,
+    exportedAt: new Date().toISOString(),
+    source: {
+      app: 'apps/web',
+      databaseProvider: 'postgresql',
+    },
+    counts: Object.fromEntries(Object.entries(records).map(([key, value]) => [key, value.length])),
+    records,
+  }
+
+  await mkdir(dirname(outPath), { recursive: true })
+  await writeFile(outPath, `${JSON.stringify(payload, null, 2)}\n`)
+
+  console.log(`Exported Next/Prisma snapshot to ${outPath}`)
+  console.table(payload.counts)
+}
+
+main()
+  .catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+  .finally(async () => {
+    await prisma.$disconnect()
+  })

--- a/docs/RAILS-DATA-MIGRATION-LOCAL-VALIDATION.md
+++ b/docs/RAILS-DATA-MIGRATION-LOCAL-VALIDATION.md
@@ -47,6 +47,7 @@ After import, a local Rails API smoke check returned:
 ## Notes
 
 - Duplicate media image URLs from the Prisma source were preserved in Rails.
-- Four scheduled, unscored same-team placeholder games were imported and remain excluded from standings.
+- Four scheduled, unscored same-team placeholder games were imported with `games.placeholder = true` and remain excluded from standings.
+- Local Rails post-import summary confirmed 93 games, 4 placeholders, 28 scored games, 104 articles, and 143 media assets.
 - Twelve source ingest items that were marked approved without an imported content reference were reset to pending with a migration note for operator review.
 - Full verification gate passed after the migration work: `./scripts/gate.sh`.

--- a/docs/RAILS-DATA-MIGRATION-LOCAL-VALIDATION.md
+++ b/docs/RAILS-DATA-MIGRATION-LOCAL-VALIDATION.md
@@ -1,0 +1,52 @@
+# Rails Data Migration Local Validation
+
+Validated locally on 2026-06-12 ChST using an operator-created Next/Prisma snapshot and a clean local Rails database.
+
+## Commands run
+
+```bash
+node scripts/with-env.mjs npm --workspace @fd/web run export:rails-migration -- --out tmp/fd-migration/next-prisma-export-local.json
+
+cd api
+DATABASE_URL=postgres:///fd_alumni_hub_api_development DISABLE_DATABASE_ENVIRONMENT_CHECK=1 bin/rails db:drop db:create db:schema:load
+DATABASE_URL=postgres:///fd_alumni_hub_api_development bin/rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export-local.json]'
+DATABASE_URL=postgres:///fd_alumni_hub_api_development bin/rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export-local.json]'
+```
+
+## Result
+
+Validation passed with no blocking issues. The validator reported 12 non-blocking warnings for source ingest rows that were marked approved without imported content references; the importer reset those rows to pending for operator review.
+
+| Record | Source | Imported | Missing |
+| --- | ---: | ---: | ---: |
+| tournaments | 22 | 22 | 0 |
+| teams | 69 | 69 | 0 |
+| games | 93 | 93 | 0 |
+| standings | 29 | 29 | 0 |
+| articleLinks | 104 | 104 | 0 |
+| mediaAssets | 143 | 143 | 0 |
+| sponsors | 0 | 0 | 0 |
+| contentIngestItems | 100 | 100 | 0 |
+| adminWhitelists | 2 | 2 | 0 |
+| appUsers | 1 | 1 | 0 |
+
+## Score coverage
+
+| Scope | Total | Scored | Coverage | Final games missing scores |
+| --- | ---: | ---: | ---: | ---: |
+| source | 93 | 28 | 30.1% | 1 |
+| rails | 93 | 28 | 30.1% | 1 |
+
+## Rails API smoke checks
+
+After import, a local Rails API smoke check returned:
+
+- `GET /api/v1/public/home` selected tournament year: 2025, latest news: 5
+- `GET /api/v1/public/schedule?year=2025` returned 93 games across Gold, Maroon, Platinum, and Special divisions
+
+## Notes
+
+- Duplicate media image URLs from the Prisma source were preserved in Rails.
+- Four scheduled, unscored same-team placeholder games were imported and remain excluded from standings.
+- Twelve source ingest items that were marked approved without an imported content reference were reset to pending with a migration note for operator review.
+- Full verification gate passed after the migration work: `./scripts/gate.sh`.

--- a/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
+++ b/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
@@ -53,7 +53,7 @@ The importer is idempotent. It upserts by `legacy_id` and preserves relationship
 Migration normalizations:
 
 - Duplicate media image URLs are preserved because the Prisma source allows them.
-- Scheduled, unscored same-team games are allowed as imported placeholder/TBD games and do not affect standings.
+- Scheduled, unscored same-team games are marked with `games.placeholder = true` as imported placeholder/TBD games and do not affect standings.
 - Source ingest items marked `approved` without an imported article/media record are reset to `pending` with a migration note so Rails preserves the invariant that approved ingest items point at imported content.
 
 ## 4. Validate the import

--- a/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
+++ b/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
@@ -48,13 +48,14 @@ DATABASE_URL=postgres:///fd_alumni_hub_api_development \
   bin/rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export.json]'
 ```
 
-The importer is idempotent. It upserts by `legacy_id` and preserves relationships by mapping Prisma CUIDs to Rails bigint IDs.
+The importer is idempotent. It upserts by `legacy_id` and preserves relationships by mapping Prisma CUIDs to Rails bigint IDs. Import output reports both snapshot `sourceCounts` and post-import `railsCounts`.
 
 Migration normalizations:
 
 - Duplicate media image URLs are preserved because the Prisma source allows them.
 - Scheduled, unscored same-team games are marked with `games.placeholder = true` as imported placeholder/TBD games and do not affect standings.
 - Source ingest items marked `approved` without an imported article/media record are reset to `pending` with a migration note so Rails preserves the invariant that approved ingest items point at imported content.
+- Media ingest fallback inference only links to an imported media asset when the image URL is unique or when duplicate image URLs have exactly one title match; ambiguous cases are reset to pending for operator review.
 
 ## 4. Validate the import
 

--- a/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
+++ b/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
@@ -1,0 +1,100 @@
+# Rails Data Migration Runbook
+
+This runbook covers the operator-run migration from the current Next/Prisma database to the Rails-owned database.
+
+## Safety model
+
+- Treat the current Next/Prisma production database as **read-only**.
+- Do not point the Rails API at the Prisma production database.
+- Export snapshots explicitly, then import snapshots into a Rails local/staging database.
+- Keep `db/seeds.rb` for demo/local seed data only; real tournament data comes from this import path.
+- Snapshot files live under `tmp/fd-migration/` and are ignored by git.
+
+## 1. Export from Next/Prisma
+
+Use either `SOURCE_DATABASE_URL` or the existing `DATABASE_URL` loaded by `scripts/with-env.mjs`.
+
+```bash
+node scripts/with-env.mjs npm --workspace @fd/web run export:rails-migration -- --out tmp/fd-migration/next-prisma-export.json
+```
+
+The export includes:
+
+- tournaments
+- teams
+- games
+- standings
+- article links
+- media assets
+- sponsors
+- content ingest items
+- admin whitelist rows
+- app users
+
+## 2. Prepare local Rails DB
+
+Use an explicit local Rails database URL so Rails never points at the Prisma production DB by accident.
+
+```bash
+cd api
+DATABASE_URL=postgres:///fd_alumni_hub_api_development bin/rails db:create db:migrate
+```
+
+## 3. Import into Rails
+
+```bash
+cd api
+DATABASE_URL=postgres:///fd_alumni_hub_api_development \
+  bin/rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export.json]'
+```
+
+The importer is idempotent. It upserts by `legacy_id` and preserves relationships by mapping Prisma CUIDs to Rails bigint IDs.
+
+Migration normalizations:
+
+- Duplicate media image URLs are preserved because the Prisma source allows them.
+- Scheduled, unscored same-team games are allowed as imported placeholder/TBD games and do not affect standings.
+- Source ingest items marked `approved` without an imported article/media record are reset to `pending` with a migration note so Rails preserves the invariant that approved ingest items point at imported content.
+
+## 4. Validate the import
+
+```bash
+cd api
+DATABASE_URL=postgres:///fd_alumni_hub_api_development \
+  bin/rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export.json]'
+```
+
+Reports are written to:
+
+- `tmp/fd-migration/rails-import-validation.json`
+- `tmp/fd-migration/rails-import-validation.md`
+
+Validation checks:
+
+- source vs imported counts
+- relationship references
+- score coverage
+- approved ingest imported-record references
+
+## 5. Run Rails-backed frontend locally
+
+```bash
+# terminal 1
+cd api
+DATABASE_URL=postgres:///fd_alumni_hub_api_development bin/rails server -p 3001
+
+# terminal 2
+cp web/.env.example web/.env.local
+npm run web:dev
+```
+
+## 6. Staging path after local validation
+
+After local validation passes:
+
+1. Create a Rails-owned Neon branch/database.
+2. Deploy Rails API to Render with that Neon `DATABASE_URL`.
+3. Run Rails migrations against staging.
+4. Import the same snapshot into staging with the Rails import task.
+5. Deploy `/web` to Netlify staging with `VITE_API_BASE_URL` pointing to Render.
+6. Smoke test public and admin flows before any production cutover.

--- a/docs/RAILS-REACT-MIGRATION.md
+++ b/docs/RAILS-REACT-MIGRATION.md
@@ -216,3 +216,7 @@ Current Next backend routes map to Rails like this:
 - No SMS/email flows.
 - No sponsor CRM beyond basic sponsor records.
 - No automatic production data imports.
+
+## Post-migration follow-ups
+
+- Add Rails/Vite S3 direct uploads for admin media assets and sponsor logos, matching the current Next.js presigned upload flow and the Shimizu starter-app AWS S3 guide. See `docs/S3-UPLOAD-SETUP.md`.

--- a/docs/RAILS-REACT-MIGRATION.md
+++ b/docs/RAILS-REACT-MIGRATION.md
@@ -116,11 +116,11 @@ Status: **implemented side-by-side on `rails-migration/phase-2-web-parity`; need
 
 ### Phase 4: Data migration and staging validation
 
-Planned:
+Status: **in progress on `rails-migration/phase-3-data-migration`**
 
-- Export current Next/Prisma data.
-- Import into a Rails-owned Neon branch/new DB.
-- Validate counts and critical pages:
+- Export current Next/Prisma data with `npm --workspace @fd/web run export:rails-migration`.
+- Import into Rails with `bin/rails fd:migration:import_next_snapshot[...]`.
+- Validate counts and critical records with `bin/rails fd:migration:validate_next_snapshot[...]`:
   - tournaments
   - teams
   - games
@@ -128,8 +128,13 @@ Planned:
   - article links
   - media assets
   - sponsors
+  - ingest items
+  - admin whitelist/users
+- Preserve Prisma CUID relationships with Rails `legacy_id` columns.
 - Validate Guam date rendering and score coverage.
 - Run organizer walkthrough on staging.
+
+See `docs/RAILS-DATA-MIGRATION-RUNBOOK.md` for commands and safety notes.
 
 ### Phase 5: Cutover
 

--- a/docs/S3-UPLOAD-SETUP.md
+++ b/docs/S3-UPLOAD-SETUP.md
@@ -1,6 +1,8 @@
 # S3 Upload Setup (FD Alumni Hub)
 
-This project uses presigned POST uploads for media assets in Admin > Media.
+The current Next.js app uses presigned POST uploads for media assets in Admin > Media.
+
+The Rails-backed `/web` app should get the same capability before production cutover so admins can upload gallery images and sponsor logos directly from the app instead of pasting image URLs.
 
 ## Required env vars
 
@@ -25,15 +27,28 @@ Resource scope:
 
 Allow browser uploads from app origins (dev + prod), methods `POST,GET,HEAD`.
 
-## Flow
+## Current Next.js flow
 
 1. Admin picks image file in `/admin/media`
 2. App calls `POST /api/admin/media/presign`
 3. Browser uploads file directly to S3 using returned form fields
 4. App stores resulting public image URL in `MediaAsset.imageUrl`
 
+## Rails/Vite follow-up
+
+Implement after the data migration/staging work:
+
+1. Add Rails S3 configuration using the Brain-Dump starter-app AWS S3 guide.
+2. Add a Rails admin presign endpoint for public image uploads.
+3. Add upload controls in `/web` admin media and sponsor forms.
+4. Store the resulting public URL in `MediaAsset.image_url` or `Sponsor.logo_url`.
+5. Keep manual URL entry as a fallback.
+6. Validate file type (`image/*`), size limits, and least-privilege IAM permissions.
+
+Good implementation references: existing Shimizu Rails/Vite projects with S3 upload flows such as Marianas Open and Aire Services.
+
 ## Notes
 
-- Upload endpoint validates image MIME (`image/*`)
-- Upload is size-limited in presign conditions (default 10MB)
-- If no file is selected, manual `imageUrl` still works
+- Upload endpoint should validate image MIME (`image/*`).
+- Uploads should be size-limited in presign conditions, typically 10MB or less.
+- If no file is selected, manual image URL should still work.

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -41,6 +41,7 @@ export type Game = {
   notes: string | null
   division: string | null
   bracketCode: string | null
+  placeholder?: boolean
   createdAt?: string
   updatedAt?: string
   homeTeam?: TeamSummary


### PR DESCRIPTION
## Summary
- Adds an operator-run Next/Prisma → Rails data migration pipeline with JSON snapshot export, idempotent Rails import, and validation/reporting tasks.
- Adds `legacy_id` columns/indexes so Rails can preserve Prisma CUID relationships while using Rails bigint IDs.
- Adjusts Rails data constraints for real source data: duplicate media image URLs are preserved and scheduled unscored same-team placeholder games can import without affecting standings.
- Documents the local/staging migration runbook and commits a sanitized local validation report.

## Local data validation
Exported a read-only Next/Prisma snapshot and imported it into a clean local Rails database.

Imported and validated:
- tournaments: 22 / 22
- teams: 69 / 69
- games: 93 / 93
- standings: 29 / 29
- article links: 104 / 104
- media assets: 143 / 143
- sponsors: 0 / 0
- ingest items: 100 / 100
- admin whitelist rows: 2 / 2
- app users: 1 / 1

Score coverage matched source and Rails: 28 / 93 scored games, 30.1%, 1 final game missing scores.

Also smoke-tested local Rails API after import:
- `GET /api/v1/public/home` selected 2025 with 5 latest news items
- `GET /api/v1/public/schedule?year=2025` returned 93 games across Gold, Maroon, Platinum, and Special

## Notes
- No production cutover included.
- Source DB access is read-only at script level; snapshots are written to ignored `tmp/fd-migration/`.
- Twelve source ingest rows were marked approved without imported content references; the importer resets those to pending with a migration note for operator review.

## Verification
- `./scripts/gate.sh`
- Local export/import/validate run documented in `docs/RAILS-DATA-MIGRATION-LOCAL-VALIDATION.md`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR implements a full Next.js/Prisma → Rails data migration pipeline: a TypeScript export script that writes a sanitized JSON snapshot, an idempotent Rails import service that maps Prisma CUIDs to Rails bigint IDs via `legacy_id` columns, and a validation service that cross-checks counts and relationships. Schema changes relax the media-asset image-URL uniqueness constraint and introduce a `placeholder` boolean on games to accommodate real source data that cannot satisfy the original constraints.

- Adds `legacy_id` string columns and partial unique indexes on all ten domain tables, an export script (`apps/web/scripts/export-rails-migration.ts`), and import/validate services (`api/app/services/data_migration/next_prisma_snapshot/`), wired together by Rake tasks.
- The importer is wrapped in a single transaction, uses `find_by_legacy` → `find_or_initialize_by` for idempotency, and applies heuristic inference to re-link approved ingest items whose source `importedToId` is blank.
- Local validation confirmed a clean 469-record round-trip; snapshot files live under the now-gitignored `tmp/` directory.

<h3>Confidence Score: 5/5</h3>

Safe to merge: the migration pipeline is operator-run with no production cutover included, runs inside a single rollback-able transaction, and does not touch any live application path.

The import and validate services are well-structured, idempotent, and covered by a thorough integration test. Both previously flagged gaps — missing relationship checks for entity types beyond teams/games/standings, and the attrs.compact nil-stripping problem — are resolved in this version. Migrations are additive and backwards-compatible. The snapshot files are gitignored and the source database is accessed read-only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/app/services/data_migration/next_prisma_snapshot/import.rb | Core import service: idempotent upsert via legacy_id, single transaction, timestamp preservation via update_columns, placeholder detection, and ingest-status normalisation. No compact stripping and full relationship checks are present. |
| api/app/services/data_migration/next_prisma_snapshot/validate.rb | Validation service: count checks, relationship validation now covers all entity types (articleLinks, mediaAssets, sponsors, contentIngestItems) via validate_tournament_references, score coverage, and approved ingest cross-reference checks. |
| api/app/models/game.rb | Adds placeholder field to API serialisation and a short-circuit in teams_are_distinct for placeholder games; bypass is narrowed by the explicit boolean column rather than detecting inferred conditions at runtime. |
| api/db/migrate/20260611000002_add_legacy_ids_for_next_migration.rb | Adds nullable legacy_id string column with partial unique index (WHERE legacy_id IS NOT NULL) on all ten domain tables; safe to apply to a populated database. |
| api/db/migrate/20260611000003_allow_duplicate_media_asset_images.rb | Drops the unique constraint on (tournament_id, image_url) for media_assets and replaces it with a non-unique index; mirrors the removal of the model-level uniqueness validation. |
| api/db/migrate/20260611000004_add_placeholder_to_games.rb | Adds boolean placeholder column (default false, NOT NULL) and a composite index on (tournament_id, placeholder); clean migration. |
| apps/web/scripts/export-rails-migration.ts | Prisma read-only export script: reads all ten tables in parallel, writes a versioned JSON snapshot to a gitignored tmp/ path, supports --out override and SOURCE_DATABASE_URL for safe targeting. |
| api/lib/tasks/fd_migration.rake | Two rake entry points (import and validate) with path argument + ENV fallback, clear usage messages, and exit-on-failure after validation; straightforward and correct. |
| api/test/services/next_prisma_snapshot_migration_test.rb | Comprehensive service test covering idempotent round-trip, placeholder game, approved-ingest linking, ambiguous media inference (reset-to-pending), and invalid relationship detection. |
| api/test/models/game_test.rb | Unit tests for the placeholder bypass and the guard that still rejects unmarked or scored same-team games; covers the expected boundary cases. |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Op as Operator
    participant Exp as export-rails-migration.ts
    participant Prisma as Next/Prisma DB (read-only)
    participant Snap as JSON Snapshot (tmp/)
    participant Rake as Rake Task
    participant Import as Import Service
    participant Rails as Rails DB
    participant Validate as Validate Service

    Op->>Exp: "SOURCE_DATABASE_URL= npm run export:rails-migration"
    Exp->>Prisma: Prisma.findMany (10 tables, read-only)
    Prisma-->>Exp: records[]
    Exp->>Snap: write next-prisma-export.json

    Op->>Rake: fd:migration:import_next_snapshot[path]
    Rake->>Import: Import.call(path)
    Import->>Snap: JSON.parse(File.read)
    Import->>Rails: BEGIN TRANSACTION
    Import->>Rails: upsert tournaments (legacy_id)
    Import->>Rails: upsert teams
    Import->>Rails: upsert games (placeholder flag)
    Import->>Rails: upsert standings
    Import->>Rails: upsert article_links, media_assets, sponsors
    Import->>Rails: upsert content_ingest_items (status normalisation)
    Import->>Rails: upsert admin_whitelists, users
    Import->>Rails: COMMIT
    Import-->>Rake: sourceCounts / railsCounts

    Op->>Rake: fd:migration:validate_next_snapshot[path]
    Rake->>Validate: Validate.call(path, out_dir:)
    Validate->>Rails: count / pluck legacy_ids per table
    Validate->>Rails: query ingest item statuses
    Validate-->>Rake: report (ok, counts, issues, warnings)
    Rake->>Snap: write rails-import-validation.json/.md
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `api/app/services/data_migration/next_prisma_snapshot/import.rb`, line 377-379 ([link](https://github.com/shimizu-technology/fd-alumni-hub/blob/6b981c58448363b4e5bee58210c0c44132244aea/api/app/services/data_migration/next_prisma_snapshot/import.rb#L377-L379)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`attrs.compact` silently drops nil values, breaking field-clearing on re-import**

   `attrs.compact` removes every key whose value is `nil`, including fields intentionally nullified by `blank_to_nil`. If a source record previously had a value for an optional field (e.g. `venue`, `notes`, `stream_url`, `bracket_code`) and that field is later blank/null in the snapshot, a re-import will leave the old Rails value in place instead of clearing it. Since the import is designed to be idempotent and operator-runnable multiple times (potentially with a refreshed snapshot), any field that transitions to nil in the source will permanently diverge after the first import.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: api/app/services/data_migration/next_prisma_snapshot/import.rb
   Line: 377-379

   Comment:
   **`attrs.compact` silently drops nil values, breaking field-clearing on re-import**

   `attrs.compact` removes every key whose value is `nil`, including fields intentionally nullified by `blank_to_nil`. If a source record previously had a value for an optional field (e.g. `venue`, `notes`, `stream_url`, `bracket_code`) and that field is later blank/null in the snapshot, a re-import will leave the old Rails value in place instead of clearing it. Since the import is designed to be idempotent and operator-runnable multiple times (potentially with a refreshed snapshot), any field that transitions to nil in the source will permanently diverge after the first import.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `api/app/services/data_migration/next_prisma_snapshot/validate.rb`, line 490-510 ([link](https://github.com/shimizu-technology/fd-alumni-hub/blob/6b981c58448363b4e5bee58210c0c44132244aea/api/app/services/data_migration/next_prisma_snapshot/validate.rb#L490-L510)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`validate_relationships` only checks teams, games, and standings — leaves several entity types unchecked**

   `articleLinks`, `mediaAssets`, `sponsors`, and `contentIngestItems` all carry a `tournamentId` in the snapshot, but the relationship validator never confirms that those IDs reference a known tournament. A corrupted or truncated snapshot with orphaned tournament references on these entities would import silently and pass validation. Extending the same pattern used for teams/games/standings to cover these four entity types would close the gap.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: api/app/services/data_migration/next_prisma_snapshot/validate.rb
   Line: 490-510

   Comment:
   **`validate_relationships` only checks teams, games, and standings — leaves several entity types unchecked**

   `articleLinks`, `mediaAssets`, `sponsors`, and `contentIngestItems` all carry a `tournamentId` in the snapshot, but the relationship validator never confirms that those IDs reference a known tournament. A corrupted or truncated snapshot with orphaned tournament references on these entities would import silently and pass validation. Extending the same pattern used for teams/games/standings to cover these four entity types would close the gap.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Improve migration import reporting and m..."](https://github.com/shimizu-technology/fd-alumni-hub/commit/ed3ac7ef5d6c3962b761f5a88d4e64f4569e2b94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37124086)</sub>

<!-- /greptile_comment -->