### PR TITLE
Require Clerk auth for Rails React admin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,5 +82,5 @@ jobs:
       - name: Test
         env:
           RAILS_ENV: test
-          DATABASE_URL: postgres://postgres:postgres@localhost:5432/fd_alumni_hub_api_test
+          TEST_DATABASE_URL: postgres://postgres:postgres@localhost:5432/fd_alumni_hub_api_test
         run: bin/rails db:test:prepare test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
           working-directory: api
 
       - name: Security scan
-        run: bin/brakeman --no-pager
+        run: bundle exec brakeman --no-pager
 
       - name: Bundle audit
         run: bin/bundler-audit

--- a/api/.env.example
+++ b/api/.env.example
@@ -2,6 +2,7 @@
 # Local development uses config/database.yml defaults. Set DATABASE_URL only for
 # external/staging/production databases, not routine local test runs.
 # DATABASE_URL=postgresql://localhost/fd_alumni_hub_api_development
+# TEST_DATABASE_URL=postgresql://localhost/fd_alumni_hub_api_test
 # Development can use localhost origins. Production has no CORS fallback;
 # set this explicitly before deploying the Rails API.
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://127.0.0.1:3000

--- a/api/.env.example
+++ b/api/.env.example
@@ -1,15 +1,19 @@
 # Rails API local development
-RAILS_ENV=development
-DATABASE_URL=postgresql://localhost/fd_alumni_hub_api_development
+# Local development uses config/database.yml defaults. Set DATABASE_URL only for
+# external/staging/production databases, not routine local test runs.
+# DATABASE_URL=postgresql://localhost/fd_alumni_hub_api_development
 # Development can use localhost origins. Production has no CORS fallback;
 # set this explicitly before deploying the Rails API.
 ALLOWED_ORIGINS=http://localhost:5173,http://127.0.0.1:5173,http://localhost:3000,http://127.0.0.1:3000
 
-# Clerk admin auth
-# Prefer CLERK_JWKS_URL. CLERK_ISSUER can be used to derive /.well-known/jwks.json.
+# Clerk admin auth.
+# CLERK_JWKS_URL verifies token signatures. If CLERK_ISSUER is blank, Rails
+# derives the expected issuer from the JWKS URL origin.
 CLERK_JWKS_URL=
 CLERK_ISSUER=
+# Optional when using a custom Clerk JWT template with an aud claim.
 CLERK_AUDIENCE=
+# Required for Clerk Backend API email fallback when JWT claims omit email.
 CLERK_SECRET_KEY=
 
 # Optional local seed helpers. These only run when explicitly set.

--- a/api/README.md
+++ b/api/README.md
@@ -9,8 +9,10 @@ The current Next.js app in `apps/web` remains the production/fallback app until 
 ```bash
 cd api
 cp .env.example .env
+# Fill CLERK_JWKS_URL, CLERK_SECRET_KEY, and FD_ADMIN_EMAIL for local admin auth.
 bundle install
 bin/rails db:create db:migrate
+bin/rails db:seed
 bin/rails server -p 3001
 ```
 
@@ -56,11 +58,7 @@ Admin routes use Clerk JWTs with an allowlist:
 - `CLERK_JWKS_URL` or `CLERK_ISSUER` configures JWT verification.
 - `CLERK_SECRET_KEY` is optional fallback for email lookup when JWT claims omit email.
 
-Development-only tokens are supported for local API checks when a user already exists:
-
-```http
-Authorization: Bearer dev_token_you@example.com
-```
+Local admin testing should use real Clerk sign-in with an allowlisted email. Seed the allowlist with `FD_ADMIN_EMAIL=you@example.com bin/rails db:seed`, then sign in through the React/Vite app.
 
 ## Admin endpoints
 

--- a/api/app/services/clerk_auth.rb
+++ b/api/app/services/clerk_auth.rb
@@ -1,3 +1,5 @@
+require "uri"
+
 class ClerkAuth
   JWKS_CACHE_KEY = "clerk_jwks"
   JWKS_CACHE_TTL = 1.hour
@@ -9,12 +11,6 @@ class ClerkAuth
 
       if Rails.env.test? && token.start_with?("test_token_")
         return handle_test_token(token)
-      end
-
-      if token.start_with?("dev_token_")
-        return nil unless Rails.env.development?
-
-        return handle_dev_token(token)
       end
 
       jwks = fetch_jwks
@@ -94,13 +90,32 @@ class ClerkAuth
 
     def jwks_url
       ENV.fetch("CLERK_JWKS_URL", nil).presence || begin
-        issuer = expected_issuer
+        issuer = configured_issuer
         issuer.present? ? "#{issuer}/.well-known/jwks.json" : nil
       end
     end
 
     def expected_issuer
+      configured_issuer || issuer_from_jwks_url
+    end
+
+    def configured_issuer
       ENV.fetch("CLERK_ISSUER", nil).presence
+    end
+
+    def issuer_from_jwks_url
+      raw_url = ENV.fetch("CLERK_JWKS_URL", nil).presence
+      return nil unless raw_url
+
+      uri = URI.parse(raw_url)
+      return nil if uri.scheme.blank? || uri.host.blank?
+
+      origin = +"#{uri.scheme}://#{uri.host}"
+      origin << ":#{uri.port}" unless [ 80, 443 ].include?(uri.port)
+      origin
+    rescue URI::InvalidURIError => e
+      Rails.logger.warn("Invalid Clerk JWKS URL: #{e.message}")
+      nil
     end
 
     def expected_audience
@@ -118,19 +133,6 @@ class ClerkAuth
 
       {
         "sub" => user.clerk_id.presence || "test_clerk_#{user.id}",
-        "email" => user.email,
-        "first_name" => user.first_name,
-        "last_name" => user.last_name
-      }
-    end
-
-    def handle_dev_token(token)
-      email = token.delete_prefix("dev_token_").downcase
-      user = User.find_by("LOWER(email) = ?", email)
-      return nil unless user
-
-      {
-        "sub" => user.clerk_id.presence || "dev_clerk_#{user.id}",
         "email" => user.email,
         "first_name" => user.first_name,
         "last_name" => user.last_name

--- a/api/app/services/clerk_auth.rb
+++ b/api/app/services/clerk_auth.rb
@@ -111,7 +111,7 @@ class ClerkAuth
       return nil if uri.scheme.blank? || uri.host.blank?
 
       origin = +"#{uri.scheme}://#{uri.host}"
-      origin << ":#{uri.port}" unless [ 80, 443 ].include?(uri.port)
+      origin << ":#{uri.port}" unless uri.port == uri.default_port
       origin
     rescue URI::InvalidURIError => e
       Rails.logger.warn("Invalid Clerk JWKS URL: #{e.message}")

--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -11,7 +11,7 @@ development:
 test:
   <<: *default
   database: fd_alumni_hub_api_test
-  url: <%= ENV["DATABASE_URL"] %>
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   <<: *default

--- a/api/test/controllers/admin_auth_controller_test.rb
+++ b/api/test/controllers/admin_auth_controller_test.rb
@@ -96,6 +96,12 @@ class AdminAuthControllerTest < ActionDispatch::IntegrationTest
     assert_not_equal decoy.id.to_s, payload["id"]
   end
 
+  test "rejects dev token bypass attempts" do
+    get "/api/v1/me", headers: { "Authorization" => "Bearer dev_token_admin@example.com" }
+
+    assert_response :unauthorized
+  end
+
   test "rejects admin endpoints without auth" do
     get "/api/v1/admin/tournaments"
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,12 +1,11 @@
 # Rails API base. Include /api/v1.
 VITE_API_BASE_URL=http://localhost:3001/api/v1
 
-# Optional Clerk auth for admin routes.
+# Clerk auth for admin routes.
 VITE_CLERK_PUBLISHABLE_KEY=
+# Optional custom JWT template. Leave blank when using the default Clerk session token
+# plus Rails CLERK_SECRET_KEY email fallback.
 VITE_CLERK_JWT_TEMPLATE=
-
-# Local dev-only fallback token. Rails accepts dev_token_* only in development.
-VITE_DEV_AUTH_EMAIL=
 
 # Partner fallback links.
 VITE_GUAMTIME_URL=https://guamtime.net

--- a/web/README.md
+++ b/web/README.md
@@ -7,7 +7,9 @@ This app is additive and is not the current production frontend. Production rema
 ## Local development
 
 ```bash
-cp web/.env.example web/.env.local
+cp web/.env.example web/.env
+# Fill VITE_CLERK_PUBLISHABLE_KEY for admin auth.
+# Leave VITE_CLERK_JWT_TEMPLATE blank unless the Clerk app has a custom JWT template.
 
 # terminal 1
 cd api

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -58,5 +58,14 @@ export function App() {
 
   if (!clerkEnabled) return content
 
-  return <ClerkProvider publishableKey={clerkKey!}>{content}</ClerkProvider>
+  return (
+    <ClerkProvider
+      publishableKey={clerkKey!}
+      afterSignOutUrl="/"
+      signInFallbackRedirectUrl="/admin"
+      signUpFallbackRedirectUrl="/admin"
+    >
+      {content}
+    </ClerkProvider>
+  )
 }

--- a/web/src/components/AdminLayout.tsx
+++ b/web/src/components/AdminLayout.tsx
@@ -19,7 +19,7 @@ const adminItems = [
 
 export function AdminLayout() {
   const auth = useAuthContext()
-  const returnTo = `${window.location.pathname}${window.location.search}` || '/admin'
+  const returnTo = `${window.location.pathname}${window.location.search}`
 
   if (auth.isLoading) return <div className="admin-shell"><LoadingState label="Verifying admin access" /></div>
 

--- a/web/src/components/AdminLayout.tsx
+++ b/web/src/components/AdminLayout.tsx
@@ -19,6 +19,7 @@ const adminItems = [
 
 export function AdminLayout() {
   const auth = useAuthContext()
+  const returnTo = `${window.location.pathname}${window.location.search}` || '/admin'
 
   if (auth.isLoading) return <div className="admin-shell"><LoadingState label="Verifying admin access" /></div>
 
@@ -29,7 +30,7 @@ export function AdminLayout() {
           <IconShield size={32} />
           <h1>Admin access</h1>
           <p>Sign in with an allowlisted organizer account to manage tournament data.</p>
-          <SignInButton mode="modal" forceRedirectUrl="/admin">
+          <SignInButton mode="modal" forceRedirectUrl={returnTo}>
             <button className="btn primary">Sign in</button>
           </SignInButton>
         </div>
@@ -47,7 +48,7 @@ export function AdminLayout() {
           {auth.isClerkEnabled ? (
             <SignOutButton><button className="btn secondary">Sign out</button></SignOutButton>
           ) : (
-            <p className="muted">Set VITE_DEV_AUTH_EMAIL to a Rails development user for local admin access.</p>
+            <p className="muted">Configure Clerk before using admin routes.</p>
           )}
         </div>
       </div>

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -13,7 +13,6 @@ type AuthContextValue = {
 }
 
 const AuthContext = createContext<AuthContextValue | null>(null)
-const DEV_AUTH_EMAIL = import.meta.env.VITE_DEV_AUTH_EMAIL as string | undefined
 const CLERK_JWT_TEMPLATE = import.meta.env.VITE_CLERK_JWT_TEMPLATE as string | undefined
 
 export function useAuthContext() {
@@ -24,46 +23,25 @@ export function useAuthContext() {
 
 export function AuthProvider({ children, isClerkEnabled }: { children: ReactNode; isClerkEnabled: boolean }) {
   if (isClerkEnabled) return <ClerkBackedAuthProvider>{children}</ClerkBackedAuthProvider>
-  return <DevAuthProvider>{children}</DevAuthProvider>
+  return <ClerkRequiredAuthProvider>{children}</ClerkRequiredAuthProvider>
 }
 
-function DevAuthProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<CurrentUser | null>(null)
-  const [error, setError] = useState<string | null>(null)
-  const [isLoading, setIsLoading] = useState(Boolean(DEV_AUTH_EMAIL))
-
+function ClerkRequiredAuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
-    setAuthTokenGetter(async () => (DEV_AUTH_EMAIL ? `dev_token_${DEV_AUTH_EMAIL}` : null))
+    setAuthTokenGetter(null)
     return () => setAuthTokenGetter(null)
   }, [])
 
-  const refreshUser = async () => {
-    if (!DEV_AUTH_EMAIL) return
-    setIsLoading(true)
-    setError(null)
-    try {
-      const response = await api.getCurrentUser()
-      setUser(response.user)
-    } catch (err) {
-      setUser(null)
-      setError(err instanceof Error ? err.message : 'Unable to verify dev user')
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    void refreshUser()
-  }, [])
+  const refreshUser = async () => {}
 
   const value = useMemo<AuthContextValue>(() => ({
     isClerkEnabled: false,
-    isSignedIn: Boolean(DEV_AUTH_EMAIL),
-    isLoading,
-    user,
-    error,
+    isSignedIn: false,
+    isLoading: false,
+    user: null,
+    error: 'Clerk is not configured. Add VITE_CLERK_PUBLISHABLE_KEY before using admin routes.',
     refreshUser,
-  }), [isLoading, user, error])
+  }), [])
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>
 }


### PR DESCRIPTION
## Summary
- removes the Rails/Vite dev-token auth bypass so admin auth always goes through Clerk
- derives Clerk issuer validation from CLERK_JWKS_URL when CLERK_ISSUER is blank, while keeping optional audience validation for custom JWT templates
- updates local env/docs for Clerk-only admin setup and keeps tests on TEST_DATABASE_URL so local .env DATABASE_URL cannot leak into test runs
- preserves the attempted admin route after Clerk sign-in and adds coverage rejecting dev-token bypass attempts

## Local setup validated
- api/.env and web/.env remain ignored; no secrets committed
- Clerk publishable key and backend JWKS host were checked locally without printing secrets
- JWKS fetch succeeded locally
- shimizutechnology@gmail.com is allowlisted in the local Rails DB
- dev_token_* verification returns false

## Verification
- ./scripts/gate.sh

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `dev_token_*` authentication bypass and enforces Clerk JWT verification for all admin routes, both in the Rails API and the React frontend. It also isolates test database configuration via `TEST_DATABASE_URL` to prevent local `DATABASE_URL` from leaking into test runs.

- **Backend**: `ClerkAuth` drops the `handle_dev_token` path entirely and adds `issuer_from_jwks_url` to derive the expected issuer from `CLERK_JWKS_URL` when `CLERK_ISSUER` is blank, ensuring issuer validation is always active when a valid JWKS URL is provided.
- **Frontend**: `DevAuthProvider` is replaced by `ClerkRequiredAuthProvider` (always unauthenticated with a clear error message), `ClerkProvider` gains post-auth redirect props, and `AdminLayout` now preserves the full path+search as the sign-in return URL.
- **CI / config**: `TEST_DATABASE_URL` is threaded through `database.yml` and the CI workflow; `brakeman` is invoked via `bundle exec` for reproducibility; env examples and README are updated to document the Clerk-only setup.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the dev-token bypass is cleanly excised from both API and frontend, and all admin traffic now flows through Clerk JWT verification.

The auth path is straightforward: removing a bypass is lower-risk than adding one. The new issuer_from_jwks_url helper handles malformed URLs gracefully (returns nil, which causes the entire JWKS fetch to fail safe). The TEST_DATABASE_URL isolation is a pure improvement with no downside. Existing test coverage was extended to confirm the bypass is gone, and all changed files are internally consistent.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/app/services/clerk_auth.rb | Removes dev_token bypass, adds issuer_from_jwks_url to derive the expected issuer from CLERK_JWKS_URL when CLERK_ISSUER is blank; URI parsing and error handling are clean. |
| api/config/database.yml | Test environment switched from DATABASE_URL to TEST_DATABASE_URL, preventing local dev DB from bleeding into test runs. |
| .github/workflows/ci.yml | Aligned to TEST_DATABASE_URL; switched brakeman invocation from binstub to bundle exec for reliability. |
| api/test/controllers/admin_auth_controller_test.rb | Added test asserting dev_token_* tokens are rejected; existing test coverage for Clerk-based flows is maintained. |
| web/src/contexts/AuthContext.tsx | Replaces DevAuthProvider with ClerkRequiredAuthProvider that always returns unauthenticated state when Clerk is not configured; ClerkBackedAuthProvider unchanged. |
| web/src/App.tsx | ClerkProvider now includes afterSignOutUrl, signInFallbackRedirectUrl, and signUpFallbackRedirectUrl for better post-auth routing. |
| web/src/components/AdminLayout.tsx | SignInButton now redirects back to the current admin path (pathname + search) instead of the hardcoded /admin root, preserving the intended destination after sign-in. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Browser request to /admin/*] --> B{VITE_CLERK_PUBLISHABLE_KEY set?}
    B -- No --> C[ClerkRequiredAuthProvider\nisClerkEnabled: false\nuser: null]
    C --> D[AdminLayout: show 'Clerk not configured' error]
    B -- Yes --> E[ClerkBackedAuthProvider\ngetToken via Clerk SDK]
    E --> F[Rails API: Authorization: Bearer JWT]
    F --> G{token starts with test_token_?\nonly in test env}
    G -- Yes --> H[handle_test_token\nreturn user claims]
    G -- No --> I[fetch_jwks\nCLERK_JWKS_URL or CLERK_ISSUER]
    I --> J{JWKS fetched?}
    J -- No --> K[return nil → 401]
    J -- Yes --> L[JWT.decode with RS256\nverify_iss from configured_issuer\nor issuer_from_jwks_url]
    L --> M{Decode OK?}
    M -- No --> K
    M -- Yes --> N[Look up User by clerk_id or email\ncheck AdminWhitelist]
    N --> O{User active & allowlisted?}
    O -- No --> K
    O -- Yes --> P[Return user payload → 200]
```

<sub>Reviews (2): Last reviewed commit: ["Address Clerk auth review feedback"](https://github.com/shimizu-technology/fd-alumni-hub/commit/d3b544b9f3970c2bfad2c497a638c76d084117f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37444778)</sub>

<!-- /greptile_comment -->