### PR TITLE
Polish local smoke test admin feedback

### DIFF
--- a/docs/projects/fd-next-public-roadmap.md
+++ b/docs/projects/fd-next-public-roadmap.md
@@ -1,0 +1,150 @@
+# FD Alumni Basketball Hub — Public Roadmap
+
+Last updated: 2026-06-15
+Status: planning notes for the next Rails/Vite phases after local smoke-test polish
+
+## Current positioning
+
+Use the public name:
+
+> FD Alumni Basketball Hub
+
+Keep the language as a central tournament hub unless FD/organizers explicitly approve more official wording.
+
+The production Next.js app remains the fallback until Rails API + React/Vite staging is fully validated.
+
+## Decisions from local review
+
+- FD logo usage is approved for this project.
+- Preferred public name: `FD Alumni Basketball Hub`.
+- Public archive can show incomplete years as long as gaps are clearly labeled, e.g. `score pending`, `source pending`, or `research pending`.
+- Predictions should not require user sign-in.
+- Prediction voters can change their vote.
+- Prediction voting closes when admins explicitly close it.
+- Most public users will be on mobile; game-day/today UI should prioritize fast scanning on phones.
+- Optional rosters should support:
+  - player name required
+  - jersey number optional
+  - position optional
+  - nickname optional
+
+## Recommended implementation grouping
+
+Instead of five separate PRs, group the work into two larger but still reviewable phases.
+
+### Phase A — Public brand + archive depth
+
+Goal: make the public app feel like a polished FD alumni tournament hub and turn history into a useful archive.
+
+Scope:
+
+1. Public visual refresh
+   - Download and store approved FD logo assets from `fatherduenas.com`.
+   - Use FD crest/logo in the public header and homepage hero.
+   - Shift the public shell toward a stronger FD identity:
+     - maroon page/background system
+     - white/cream hero/content cards
+     - dark headline text inside light hero surfaces
+     - gold accents
+   - Keep admin styling separate; this is primarily public-facing.
+
+2. DB-backed history archive
+   - Replace the static-only history experience with DB-backed tournament archive pages where possible.
+   - Add routes like:
+     - `/history/2025`
+     - `/history/2024`
+   - Each tournament detail page should show:
+     - tournament dates/status
+     - champion/runner-up/final score if known
+     - game schedule/results
+     - standings/score coverage if available
+     - linked articles
+     - media/gallery items
+     - sponsors if available
+     - research-gap labels for incomplete data
+   - Keep the existing static champion ledger as fallback context for years with incomplete DB data.
+
+Likely backend/API work:
+
+- Add a public archive endpoint that returns a complete tournament bundle:
+  - tournament
+  - games
+  - standings
+  - articles
+  - media assets
+  - sponsors
+  - derived champion/final summary where possible
+- Consider adding explicit archive metadata later if derived champion data is not enough.
+
+### Phase B — Game-day operations + fan engagement
+
+Goal: make the hub useful during the live tournament and add lightweight fan participation.
+
+Scope:
+
+1. Today / Game Day page
+   - Recommended public label: `Today` or `Today at The Jungle`.
+   - Surface prominently on mobile, homepage, and schedule.
+   - Show:
+     - today’s games
+     - live/final statuses
+     - ticket/stream links
+     - host class
+     - food/menu notes
+     - announcements
+     - sponsor shoutouts if useful
+     - last updated timestamp
+   - Add admin controls for day-by-day game-day facts.
+
+2. Team rosters
+   - Add optional roster entries for each team.
+   - Admin can add/edit/remove roster entries from Teams page.
+   - Fields:
+     - name required
+     - jersey number optional
+     - position optional
+     - nickname optional
+     - sort order / active optional if useful
+   - Public side can expose rosters from team cards, standings, or a dedicated team detail view.
+
+3. Predictions
+   - Anonymous, no sign-in.
+   - Game-level prediction: who wins this game?
+   - Tournament-level prediction: who wins the tournament?
+   - User can change their vote.
+   - Admin can close voting.
+   - Store a local anonymous device token in browser storage; do not collect unnecessary PII.
+   - Treat one-device voting as a lightweight engagement feature, not fraud-proof polling.
+   - Show public percentages/results after voting or once configured to show.
+
+Likely backend/API work:
+
+- `game_day_notes` or similar table for host class, food/menu, announcements, active date.
+- `roster_entries` table tied to teams.
+- Prediction poll/vote tables:
+  - poll type: game or tournament
+  - closes/open flag controlled by admin
+  - vote target: team/game option
+  - anonymous voter token hash
+  - allow updating existing vote for same token/poll
+
+## Mobile-first UX notes
+
+- Public nav should stay simple; avoid adding too many top-level items.
+- If adding `Today`, consider replacing lower-priority nav visibility on mobile or surfacing it as a prominent homepage/schedule card.
+- Game cards should remain thumb-friendly with obvious Tickets/Stream/Prediction actions.
+- Prediction UI should be one-tap, not a form.
+- Tournament history detail pages should use compact sections and accordions on mobile.
+
+## Open questions before Phase A implementation
+
+- Which downloaded FD logo should be primary: crest-only, horizontal wordmark, or both by viewport?
+- Should archive detail URLs use year (`/history/2025`) or Rails tournament id? Recommendation: year for public readability, fallback lookup by id if needed.
+- Do organizers want any disclaimer text around historical/incomplete archive data?
+
+## Open questions before Phase B implementation
+
+- Preferred public nav label: `Today`, `Game Day`, or `At The Jungle`?
+- Should predictions be visible before voting, after voting, or only after admins enable result display?
+- Should admins be able to disable predictions per game/tournament?
+- Should rosters be visible immediately when entered, or should there be a public/private toggle?

--- a/web/src/pages/admin/AdminGamesPage.tsx
+++ b/web/src/pages/admin/AdminGamesPage.tsx
@@ -129,6 +129,7 @@ function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Div
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
   const scoreComplete = form.homeScore !== '' && form.awayScore !== ''
+  const detailsDirty = gameDetailsChanged(form, game, divisions)
   const projectedResult = gameResultLabel({
     ...game,
     homeScore: form.homeScore === '' ? null : Number(form.homeScore),
@@ -140,10 +141,16 @@ function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Div
   }, [game, divisions])
 
   const saveScores = async (statusOverride?: Game['status']) => {
+    if (detailsDirty) {
+      setEditingDetails(true)
+      setSaveError('Save or cancel game detail changes before saving scores.')
+      return
+    }
+
     setSaving(true)
     setSaveError('')
     try {
-      const nextStatus = statusOverride || game.status
+      const nextStatus = statusOverride || form.status
       await api.adminUpdateGame(game.id, {
         status: nextStatus,
         homeScore: form.homeScore === '' ? null : Number(form.homeScore),
@@ -237,13 +244,24 @@ function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Div
 function GameDetailsSummary({ game }: { game: Game }) {
   return (
     <dl className="game-detail-summary">
-      <div><dt>Start</dt><dd>{formatGuamDateTime(game.startTime)}</dd></div>
       <div><dt>Division</dt><dd>{game.division || 'Use team division'}</dd></div>
       <div><dt>Bracket</dt><dd>{game.bracketCode || 'Not set'}</dd></div>
       <div><dt>Tickets</dt><dd>{game.ticketUrl ? <a href={game.ticketUrl} target="_blank" rel="noreferrer">Open ticket link</a> : 'Not posted'}</dd></div>
       <div><dt>Stream</dt><dd>{game.streamUrl ? <a href={game.streamUrl} target="_blank" rel="noreferrer">Open stream link</a> : 'Not posted'}</dd></div>
     </dl>
   )
+}
+
+function gameDetailsChanged(form: ReturnType<typeof gameFormState>, game: Game, divisions: Division[]) {
+  const persisted = gameFormState(game, divisions)
+
+  return form.status !== persisted.status ||
+    form.startTime !== persisted.startTime ||
+    form.divisionId !== persisted.divisionId ||
+    form.bracketCode !== persisted.bracketCode ||
+    form.ticketUrl !== persisted.ticketUrl ||
+    form.streamUrl !== persisted.streamUrl ||
+    form.notes !== persisted.notes
 }
 
 function gameFormState(game: Game, divisions: Division[]) {

--- a/web/src/pages/admin/AdminGamesPage.tsx
+++ b/web/src/pages/admin/AdminGamesPage.tsx
@@ -124,17 +124,8 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
 }
 
 function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Division[]; onSaved: () => Promise<void> }) {
-  const [form, setForm] = useState({
-    status: game.status,
-    homeScore: game.homeScore?.toString() || '',
-    awayScore: game.awayScore?.toString() || '',
-    startTime: toLocalDateTimeInputValue(game.startTime),
-    divisionId: divisionValueFor(game, divisions),
-    bracketCode: game.bracketCode || '',
-    ticketUrl: game.ticketUrl || '',
-    streamUrl: game.streamUrl || '',
-    notes: game.notes || '',
-  })
+  const [form, setForm] = useState(gameFormState(game, divisions))
+  const [editingDetails, setEditingDetails] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
   const scoreComplete = form.homeScore !== '' && form.awayScore !== ''
@@ -144,14 +135,35 @@ function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Div
     awayScore: form.awayScore === '' ? null : Number(form.awayScore),
   })
 
-  const save = async (statusOverride?: Game['status']) => {
+  useEffect(() => {
+    setForm(gameFormState(game, divisions))
+  }, [game, divisions])
+
+  const saveScores = async (statusOverride?: Game['status']) => {
+    setSaving(true)
+    setSaveError('')
+    try {
+      const nextStatus = statusOverride || game.status
+      await api.adminUpdateGame(game.id, {
+        status: nextStatus,
+        homeScore: form.homeScore === '' ? null : Number(form.homeScore),
+        awayScore: form.awayScore === '' ? null : Number(form.awayScore),
+      })
+      if (statusOverride) setForm((current) => ({ ...current, status: statusOverride }))
+      await onSaved()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Unable to save score')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const saveDetails = async () => {
     setSaving(true)
     setSaveError('')
     try {
       await api.adminUpdateGame(game.id, {
-        status: statusOverride || form.status,
-        homeScore: form.homeScore === '' ? null : Number(form.homeScore),
-        awayScore: form.awayScore === '' ? null : Number(form.awayScore),
+        status: form.status,
         startTime: guamLocalDateTimeInputToIso(form.startTime),
         bracketCode: form.bracketCode,
         ticketUrl: form.ticketUrl || null,
@@ -160,35 +172,92 @@ function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Div
         venue: game.venue || DEFAULT_GAME_VENUE,
         ...divisionPayload(form.divisionId, divisions),
       })
+      setEditingDetails(false)
       await onSaved()
     } catch (err) {
-      setSaveError(err instanceof Error ? err.message : 'Unable to save game')
+      setSaveError(err instanceof Error ? err.message : 'Unable to save game details')
     } finally {
       setSaving(false)
     }
   }
 
+  const cancelDetails = () => {
+    setForm(gameFormState(game, divisions))
+    setEditingDetails(false)
+    setSaveError('')
+  }
+
   return (
-    <article className="admin-row-card">
-      <div className="admin-row-head"><div><strong>{game.awayTeam?.displayName} at {game.homeTeam?.displayName}</strong><span>{formatGuamDateTime(game.startTime)} · {game.venue || DEFAULT_GAME_VENUE}</span></div><StatusBadge status={game.status} /></div>
-      <FormGrid>
-        <Field label="Status"><select value={form.status} onChange={(event) => setForm({ ...form, status: event.target.value as Game['status'] })}><option value="scheduled">Scheduled</option><option value="live">Live</option><option value="final">Final</option></select></Field>
-        <Field label="Away score"><input type="number" value={form.awayScore} onChange={(event) => setForm({ ...form, awayScore: event.target.value })} /></Field>
-        <Field label="Home score"><input type="number" value={form.homeScore} onChange={(event) => setForm({ ...form, homeScore: event.target.value })} /></Field>
-        <Field label="Start"><input type="datetime-local" value={form.startTime} onChange={(event) => setForm({ ...form, startTime: event.target.value })} /></Field>
-        <Field label="Ticket URL"><input value={form.ticketUrl} onChange={(event) => setForm({ ...form, ticketUrl: event.target.value })} /></Field>
-        <Field label="Stream URL"><input value={form.streamUrl} onChange={(event) => setForm({ ...form, streamUrl: event.target.value })} /></Field>
-        <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} currentName={game.division} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
-        <Field label="Bracket"><input value={form.bracketCode} onChange={(event) => setForm({ ...form, bracketCode: event.target.value })} /></Field>
-      </FormGrid>
-      {projectedResult && <p className="form-note">{projectedResult}</p>}
-      {saveError && <p className="form-error" role="alert">{saveError}</p>}
-      <div className="row-actions">
-        <button className="btn secondary" onClick={() => save()} disabled={saving}>{saving ? 'Saving' : 'Save game'}</button>
-        <button className="btn primary" onClick={() => save('final')} disabled={saving || !scoreComplete}>{saving ? 'Saving' : 'Save final score'}</button>
+    <article className="admin-row-card game-admin-card">
+      <div className="admin-row-head">
+        <div>
+          <strong>{game.awayTeam?.displayName} at {game.homeTeam?.displayName}</strong>
+          <span>{formatGuamDateTime(game.startTime)} · {game.venue || DEFAULT_GAME_VENUE}</span>
+        </div>
+        <StatusBadge status={game.status} />
       </div>
+
+      <GameDetailsSummary game={game} />
+
+      <div className="score-entry-panel" aria-label={`Score entry for ${game.awayTeam?.displayName} at ${game.homeTeam?.displayName}`}>
+        <FormGrid>
+          <Field label="Away score"><input type="number" value={form.awayScore} onChange={(event) => setForm({ ...form, awayScore: event.target.value })} /></Field>
+          <Field label="Home score"><input type="number" value={form.homeScore} onChange={(event) => setForm({ ...form, homeScore: event.target.value })} /></Field>
+        </FormGrid>
+        {projectedResult && <p className="form-note">{projectedResult}</p>}
+        {saveError && <p className="form-error" role="alert">{saveError}</p>}
+        <div className="row-actions">
+          <button className="btn secondary" onClick={() => saveScores()} disabled={saving}>{saving ? 'Saving' : 'Save scores'}</button>
+          <button className="btn primary" onClick={() => saveScores('final')} disabled={saving || !scoreComplete}>{saving ? 'Saving' : 'Save final score'}</button>
+          <button className="btn secondary" type="button" onClick={() => setEditingDetails((value) => !value)} aria-expanded={editingDetails}>{editingDetails ? 'Hide game details' : 'Edit game details'}</button>
+        </div>
+      </div>
+
+      {editingDetails && (
+        <div className="game-detail-editor">
+          <div className="section-heading compact-heading"><h3>Game details</h3><span>Schedule, links, status</span></div>
+          <FormGrid>
+            <Field label="Status"><select value={form.status} onChange={(event) => setForm({ ...form, status: event.target.value as Game['status'] })}><option value="scheduled">Scheduled</option><option value="live">Live</option><option value="final">Final</option></select></Field>
+            <Field label="Start"><input type="datetime-local" value={form.startTime} onChange={(event) => setForm({ ...form, startTime: event.target.value })} /></Field>
+            <Field label="Ticket URL"><input value={form.ticketUrl} onChange={(event) => setForm({ ...form, ticketUrl: event.target.value })} /></Field>
+            <Field label="Stream URL"><input value={form.streamUrl} onChange={(event) => setForm({ ...form, streamUrl: event.target.value })} /></Field>
+            <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} currentName={game.division} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
+            <Field label="Bracket"><input value={form.bracketCode} onChange={(event) => setForm({ ...form, bracketCode: event.target.value })} /></Field>
+          </FormGrid>
+          <div className="row-actions">
+            <button className="btn secondary" type="button" onClick={cancelDetails} disabled={saving}>Cancel</button>
+            <button className="btn primary" type="button" onClick={saveDetails} disabled={saving}>{saving ? 'Saving' : 'Save game details'}</button>
+          </div>
+        </div>
+      )}
     </article>
   )
+}
+
+function GameDetailsSummary({ game }: { game: Game }) {
+  return (
+    <dl className="game-detail-summary">
+      <div><dt>Start</dt><dd>{formatGuamDateTime(game.startTime)}</dd></div>
+      <div><dt>Division</dt><dd>{game.division || 'Use team division'}</dd></div>
+      <div><dt>Bracket</dt><dd>{game.bracketCode || 'Not set'}</dd></div>
+      <div><dt>Tickets</dt><dd>{game.ticketUrl ? <a href={game.ticketUrl} target="_blank" rel="noreferrer">Open ticket link</a> : 'Not posted'}</dd></div>
+      <div><dt>Stream</dt><dd>{game.streamUrl ? <a href={game.streamUrl} target="_blank" rel="noreferrer">Open stream link</a> : 'Not posted'}</dd></div>
+    </dl>
+  )
+}
+
+function gameFormState(game: Game, divisions: Division[]) {
+  return {
+    status: game.status,
+    homeScore: game.homeScore?.toString() || '',
+    awayScore: game.awayScore?.toString() || '',
+    startTime: toLocalDateTimeInputValue(game.startTime),
+    divisionId: divisionValueFor(game, divisions),
+    bracketCode: game.bracketCode || '',
+    ticketUrl: game.ticketUrl || '',
+    streamUrl: game.streamUrl || '',
+    notes: game.notes || '',
+  }
 }
 
 function DivisionSelect({ value, divisions, currentName, onChange }: { value: string; divisions: Division[]; currentName?: string | null; onChange: (value: string) => void }) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -111,11 +111,11 @@ button:disabled { opacity: .62; cursor: progress; }
 .partner-strip strong { display: block; margin-top: .4rem; line-height: 1.35; }
 
 .toolbar-panel { display: flex; gap: 1rem; flex-wrap: wrap; align-items: end; }
-.toolbar-panel label, .field { display: grid; gap: .35rem; min-width: min(100%, 12rem); }
+.toolbar-panel label, .field { display: grid; align-content: start; align-self: start; gap: .35rem; min-width: min(100%, 12rem); }
 .field span, .toolbar-panel label span { font-size: .78rem; color: var(--muted); font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
 input, select, textarea { width: 100%; min-height: 2.75rem; border: 1px solid var(--line); border-radius: .85rem; background: #fff; padding: .75rem .85rem; color: var(--ink); }
 input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.26); border-color: var(--fd-gold); }
-.form-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .85rem; margin-bottom: 1rem; }
+.form-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); align-items: start; gap: .85rem; margin-bottom: 1rem; }
 .check-field { align-self: end; display: flex; gap: .55rem; align-items: center; font-weight: 800; color: var(--fd-maroon); padding-bottom: .7rem; }
 .check-field input { width: auto; }
 .form-error { margin: -.25rem 0 .2rem; color: var(--danger); font-weight: 800; }
@@ -245,6 +245,17 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .admin-row-head { display: flex; justify-content: space-between; gap: 1rem; align-items: center; }
 .admin-row-head span { display: block; color: var(--muted); margin-top: .2rem; }
 .row-actions { display: flex; gap: .55rem; flex-wrap: wrap; }
+.game-admin-card { gap: 1rem; }
+.game-detail-summary { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .65rem; margin: 0; }
+.game-detail-summary div { min-width: 0; padding: .85rem; border: 1px solid var(--line); border-radius: .9rem; background: var(--surface-strong); }
+.game-detail-summary dt { margin-bottom: .25rem; color: var(--muted); font-size: .72rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.game-detail-summary dd { margin: 0; overflow: hidden; color: var(--ink); font-weight: 850; text-overflow: ellipsis; white-space: nowrap; }
+.game-detail-summary a { color: var(--fd-maroon); font-weight: 900; }
+.score-entry-panel { display: grid; gap: .7rem; padding: .9rem; border: 1px solid rgba(111,29,53,.12); border-radius: 1rem; background: #fffaf3; }
+.score-entry-panel .form-grid { max-width: 40rem; grid-template-columns: repeat(2, minmax(0, 1fr)); margin-bottom: 0; }
+.game-detail-editor { display: grid; gap: .85rem; padding: .95rem; border: 1px dashed rgba(111,29,53,.24); border-radius: 1rem; background: #fff; }
+.compact-heading { margin-bottom: 0; }
+.compact-heading h3 { margin: 0; font-size: 1rem; }
 .notice-panel { color: var(--fd-maroon); font-weight: 900; background: var(--fd-gold-100); border-color: #ead095; }
 .workflow-panel { background: linear-gradient(135deg, #fff, var(--fd-gold-100)); }
 .workflow-steps { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .65rem; }
@@ -279,6 +290,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-topbar { display: none; }
   .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .form-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .game-detail-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .compact-admin-row { grid-template-columns: 1fr; }
 }
 
@@ -302,6 +314,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-page .page-header h1 { font-size: clamp(2rem, 11vw, 3rem); }
   .admin-row-head { align-items: flex-start; }
   .row-actions .btn, .game-actions .btn { width: 100%; }
+  .game-detail-summary, .score-entry-panel .form-grid { grid-template-columns: 1fr; }
   .compact-admin-row, .media-admin-row, .sponsor-admin-row { grid-template-columns: 1fr; }
   .compact-admin-row .form-grid, .media-admin-row .form-grid, .sponsor-admin-row .form-grid, .media-admin-row .row-actions, .sponsor-admin-row .row-actions, .media-admin-row .form-error, .sponsor-admin-row .form-error { grid-column: auto; }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -246,7 +246,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .admin-row-head span { display: block; color: var(--muted); margin-top: .2rem; }
 .row-actions { display: flex; gap: .55rem; flex-wrap: wrap; }
 .game-admin-card { gap: 1rem; }
-.game-detail-summary { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: .65rem; margin: 0; }
+.game-detail-summary { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: .65rem; margin: 0; }
 .game-detail-summary div { min-width: 0; padding: .85rem; border: 1px solid var(--line); border-radius: .9rem; background: var(--surface-strong); }
 .game-detail-summary dt { margin-bottom: .25rem; color: var(--muted); font-size: .72rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
 .game-detail-summary dd { margin: 0; overflow: hidden; color: var(--ink); font-weight: 850; text-overflow: ellipsis; white-space: nowrap; }


### PR DESCRIPTION
## Summary
- Make created games safer to manage by defaulting game cards to read-only details plus score entry only.
- Add an explicit `Edit game details` flow for schedule/link/status/division/bracket changes.
- Fix admin form-grid alignment so S3 upload controls do not stretch or push neighboring fields down on News/Media forms.
- Document the next public roadmap decisions for FD branding, archive detail pages, Today/Game Day, rosters, and predictions.

## Notes
- Public roadmap doc: `docs/projects/fd-next-public-roadmap.md`
- Brain-Dump project notes were also updated with the same roadmap direction.

## Verification
- `./scripts/gate.sh`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR polishes the admin game management UX by splitting the single game editor into a permanent score-entry panel and a collapsible "Edit game details" panel, with a `detailsDirty` guard that blocks score saves when unsaved detail changes exist. It also fixes a long-standing S3 upload control alignment bug in News/Media forms by adding `align-items: start` to `.form-grid` and `align-content: start` to `.field`.

- **AdminGamesPage.tsx**: `save()` is replaced by `saveScores()` (PATCH status + scores only) and `saveDetails()` (PATCH all scheduling/link fields); `gameFormState`, `gameDetailsChanged`, and `GameDetailsSummary` are extracted as pure helpers; `useEffect` resets the form on every reload.
- **styles.css**: New `.game-detail-summary`, `.score-entry-panel`, and `.game-detail-editor` classes with responsive breakpoints; the `.field`/`.form-grid` alignment fix is applied globally and resolves the stretching issue on all admin forms.
- **docs/projects/fd-next-public-roadmap.md**: New planning document for Phase A (brand refresh + DB-backed archive) and Phase B (Today page, team rosters, anonymous predictions).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the split into separate score and detail saves is backed by a PATCH API, so partial payloads cannot clobber unrelated fields; the detailsDirty guard correctly prevents race conditions between the two save paths.

The core save-path refactor is sound: adminUpdateGame uses PATCH, so sending only score fields from saveScores cannot reset startTime, venue, or division. The detailsDirty guard addresses the previously reported silent-discard issue. The two non-blocking observations (dead notes check, Hide not resetting form) are cosmetic and do not affect data integrity.

No files require special attention. The CSS alignment fix is a global change to .field and .form-grid — worth a quick visual check across other admin forms (News, Media, Sponsors) to confirm nothing regressed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/pages/admin/AdminGamesPage.tsx | Splits monolithic game editor into an always-visible score panel + collapsible details panel; adds detailsDirty guard that blocks score saves when details editor has unsaved changes; introduces gameFormState and gameDetailsChanged helpers and GameDetailsSummary component. |
| web/src/styles.css | Adds align-items/align-content: start to .field and .form-grid to fix S3 upload control stretching; new CSS classes for game-admin-card, game-detail-summary, score-entry-panel, game-detail-editor, and responsive breakpoints. |
| docs/projects/fd-next-public-roadmap.md | New planning document outlining Phase A (public brand + archive) and Phase B (game-day, rosters, predictions) roadmap; no executable code. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Admin opens game card] --> B[Score Entry Panel always visible]
    B --> C{Click Save scores / Save final score}
    C --> D{detailsDirty?}
    D -- Yes --> E[Re-open details panel\nShow error message\nAbort save]
    D -- No --> F[PATCH status + homeScore + awayScore]
    F --> G[onSaved → reload]
    G --> H[useEffect resets form]

    B --> I[Click Edit game details]
    I --> J[Details Panel expands]
    J --> K[Edit status / startTime / division / bracket / links]
    K --> L{Click Save game details}
    L --> M[PATCH all detail fields]
    M --> N[Close details panel]
    N --> G
    K --> O[Click Cancel]
    O --> P[Reset form to persisted state\nClose panel]
```

<sub>Reviews (2): Last reviewed commit: ["Address game editor review feedback"](https://github.com/shimizu-technology/fd-alumni-hub/commit/d041ed867ed618468925fa76b3a20b0900511a5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37557911)</sub>

<!-- /greptile_comment -->