### PR TITLE
Add game-day rosters and predictions

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -186,21 +186,21 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-musl)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (2.1.0)
@@ -459,14 +459,14 @@ CHECKSUMS
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   net-ssh (7.3.2) sha256=65029e213c380e20e5fd92ece663934ab0a0fe888e0cd7cc6a5b664074362dd4
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
-  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
-  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
-  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
-  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
-  nokogiri (1.19.3-x86_64-darwin) sha256=77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d
-  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
-  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   parallel (2.1.0) sha256=b35258865c2e31134c5ecb708beaaf6772adf9d5efae28e93e99260877b09356
   parser (3.3.11.1) sha256=d17ace7aabe3e72c3cc94043714be27cc6f852f104d81aa284c2281aecc65d54

--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     csv (3.3.5)
@@ -409,7 +409,7 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f

--- a/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
+++ b/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
@@ -31,7 +31,7 @@ module Api
         end
 
         def update
-          note = GameDayNote.find(params[:id])
+          note = admin_tournament.game_day_notes.find(params[:id])
 
           if note.update(note_params.except(:date, :tournament_id))
             render json: { gameDayNote: note.api_json }

--- a/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
+++ b/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
@@ -2,6 +2,10 @@ module Api
   module V1
     module Admin
       class GameDayNotesController < BaseController
+        class InvalidDateParam < StandardError; end
+
+        rescue_from InvalidDateParam, with: :render_invalid_date
+
         def index
           tournament = admin_tournament
           date = requested_date || Time.zone.today
@@ -62,8 +66,18 @@ module Api
           assign_param(attrs, permitted, :announcement, :announcement)
           assign_param(attrs, permitted, :sponsor_shoutout, :sponsor_shoutout, :sponsorShoutout)
           assign_param(attrs, permitted, :active, :active)
-          attrs[:date] = Date.iso8601(attrs[:date]) if attrs[:date].is_a?(String) && attrs[:date].present?
+          attrs[:date] = parse_note_date(attrs[:date]) if attrs[:date].is_a?(String) && attrs[:date].present?
           attrs
+        end
+
+        def parse_note_date(value)
+          Date.iso8601(value)
+        rescue ArgumentError
+          raise InvalidDateParam
+        end
+
+        def render_invalid_date
+          render json: { errors: [ "Date must be a valid ISO 8601 date" ] }, status: :unprocessable_entity
         end
       end
     end

--- a/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
+++ b/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
@@ -1,0 +1,71 @@
+module Api
+  module V1
+    module Admin
+      class GameDayNotesController < BaseController
+        def index
+          tournament = admin_tournament
+          date = requested_date || Time.zone.today
+          note = tournament.game_day_notes.find_by(date: date)
+          games = tournament.games.includes(:division_record, home_team: :division_record, away_team: :division_record).where(start_time: date.beginning_of_day..date.end_of_day).ordered
+
+          render json: {
+            tournament: tournament.api_json,
+            date: date.iso8601,
+            gameDayNote: note&.api_json,
+            games: games.map(&:api_json),
+            predictionPolls: tournament.prediction_polls.includes(:prediction_votes, :game).ordered.map(&:api_json)
+          }
+        end
+
+        def create
+          tournament = admin_tournament
+          attrs = note_params.merge(tournament: tournament)
+          note = tournament.game_day_notes.find_or_initialize_by(date: attrs[:date] || Time.zone.today)
+          created = note.new_record?
+
+          if note.update(attrs.except(:date))
+            render json: { gameDayNote: note.api_json }, status: created ? :created : :ok
+          else
+            render_errors(note)
+          end
+        end
+
+        def update
+          note = GameDayNote.find(params[:id])
+
+          if note.update(note_params.except(:date, :tournament_id))
+            render json: { gameDayNote: note.api_json }
+          else
+            render_errors(note)
+          end
+        end
+
+        private
+
+        def requested_date
+          return nil if params[:date].blank?
+
+          Date.iso8601(params[:date])
+        rescue ArgumentError
+          nil
+        end
+
+        def note_params
+          raw = params.fetch(:gameDayNote, params.fetch(:game_day_note, params))
+          permitted = raw.permit(:tournament_id, :tournamentId, :date, :host_class, :hostClass, :food_menu, :foodMenu, :announcement, :sponsor_shoutout, :sponsorShoutout, :active)
+
+          attrs = {}
+          assign_param(attrs, permitted, :tournament_id, :tournament_id, :tournamentId)
+          assign_param(attrs, permitted, :date, :date)
+          assign_param(attrs, permitted, :host_class, :host_class, :hostClass)
+          assign_param(attrs, permitted, :food_menu, :food_menu, :foodMenu)
+          assign_param(attrs, permitted, :announcement, :announcement)
+          assign_param(attrs, permitted, :sponsor_shoutout, :sponsor_shoutout, :sponsorShoutout)
+          assign_param(attrs, permitted, :active, :active)
+          attrs[:date] = Date.iso8601(attrs[:date]) if attrs[:date].is_a?(String) && attrs[:date].present?
+          attrs
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
+++ b/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
@@ -17,7 +17,7 @@ module Api
             date: date.iso8601,
             gameDayNote: note&.api_json,
             games: games.map(&:api_json),
-            predictionPolls: tournament.prediction_polls.includes(:prediction_votes, :game).ordered.map(&:api_json)
+            predictionPolls: prediction_polls_for_admin(tournament).map(&:api_json)
           }
         end
 
@@ -45,6 +45,12 @@ module Api
         end
 
         private
+
+        def prediction_polls_for_admin(tournament)
+          tournament.prediction_polls
+            .includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ])
+            .ordered
+        end
 
         def requested_date
           return nil if params[:date].blank?

--- a/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
+++ b/api/app/controllers/api/v1/admin/game_day_notes_controller.rb
@@ -19,7 +19,7 @@ module Api
 
         def create
           tournament = admin_tournament
-          attrs = note_params.merge(tournament: tournament)
+          attrs = note_params.except(:tournament_id)
           note = tournament.game_day_notes.find_or_initialize_by(date: attrs[:date] || Time.zone.today)
           created = note.new_record?
 

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -4,7 +4,9 @@ module Api
       class PredictionPollsController < BaseController
         def index
           tournament = admin_tournament
-          polls = tournament.prediction_polls.includes(:prediction_votes, :game).ordered
+          polls = tournament.prediction_polls
+            .includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ])
+            .ordered
 
           render json: { tournament: tournament.api_json, predictionPolls: polls.map(&:api_json) }
         end

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -59,7 +59,7 @@ module Api
         end
 
         def prediction_poll_for_response(id)
-          PredictionPoll.includes(:prediction_votes, :tournament, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
+          PredictionPoll.includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
         end
       end
     end

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -44,7 +44,7 @@ module Api
 
         def prediction_poll_params
           raw = params.fetch(:predictionPoll, params.fetch(:prediction_poll, params))
-          permitted = raw.permit(:tournament_id, :tournamentId, :game_id, :gameId, :poll_type, :pollType, :question, :status, :show_results, :showResults, :closes_at, :closesAt)
+          permitted = raw.permit(:tournament_id, :tournamentId, :game_id, :gameId, :poll_type, :pollType, :question, :status, :closes_at, :closesAt)
 
           attrs = {}
           assign_param(attrs, permitted, :tournament_id, :tournament_id, :tournamentId)
@@ -52,7 +52,6 @@ module Api
           assign_param(attrs, permitted, :poll_type, :poll_type, :pollType)
           assign_param(attrs, permitted, :question, :question)
           assign_param(attrs, permitted, :status, :status)
-          assign_param(attrs, permitted, :show_results, :show_results, :showResults)
           assign_param(attrs, permitted, :closes_at, :closes_at, :closesAt)
           attrs[:poll_type] ||= "game" if attrs[:game_id].present?
           attrs[:poll_type] ||= "tournament"

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -22,6 +22,8 @@ module Api
           else
             render_errors(poll)
           end
+        rescue ActiveRecord::RecordNotUnique
+          render_prediction_poll_uniqueness_error
         end
 
         def update
@@ -35,6 +37,10 @@ module Api
         end
 
         private
+
+        def render_prediction_poll_uniqueness_error
+          render json: { errors: [ "A tournament prediction poll already exists for this tournament" ] }, status: :unprocessable_entity
+        end
 
         def prediction_poll_params
           raw = params.fetch(:predictionPoll, params.fetch(:prediction_poll, params))

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -20,7 +20,7 @@ module Api
         end
 
         def update
-          poll = PredictionPoll.find(params[:id])
+          poll = admin_tournament.prediction_polls.find(params[:id])
 
           if poll.update(prediction_poll_params.except(:tournament_id, :game_id, :poll_type))
             render json: { predictionPoll: poll.api_json }

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -10,7 +10,10 @@ module Api
         end
 
         def create
-          poll = PredictionPoll.new(prediction_poll_params)
+          attrs = prediction_poll_params.except(:tournament_id)
+          game_id = attrs.delete(:game_id)
+          poll = admin_tournament.prediction_polls.build(attrs)
+          poll.game = admin_tournament.games.find(game_id) if game_id.present?
 
           if poll.save
             render json: { predictionPoll: poll.api_json }, status: :created

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -1,0 +1,60 @@
+module Api
+  module V1
+    module Admin
+      class PredictionPollsController < BaseController
+        def index
+          tournament = admin_tournament
+          polls = tournament.prediction_polls.includes(:prediction_votes, :game).ordered
+
+          render json: { tournament: tournament.api_json, predictionPolls: polls.map(&:api_json) }
+        end
+
+        def create
+          poll = PredictionPoll.new(prediction_poll_params)
+
+          if poll.save
+            render json: { predictionPoll: poll.api_json }, status: :created
+          else
+            render_errors(poll)
+          end
+        end
+
+        def update
+          poll = PredictionPoll.find(params[:id])
+
+          if poll.update(prediction_poll_params.except(:tournament_id, :game_id, :poll_type))
+            render json: { predictionPoll: poll.api_json }
+          else
+            render_errors(poll)
+          end
+        end
+
+        private
+
+        def prediction_poll_params
+          raw = params.fetch(:predictionPoll, params.fetch(:prediction_poll, params))
+          permitted = raw.permit(:tournament_id, :tournamentId, :game_id, :gameId, :poll_type, :pollType, :question, :status, :show_results, :showResults, :closes_at, :closesAt)
+
+          attrs = {}
+          assign_param(attrs, permitted, :tournament_id, :tournament_id, :tournamentId)
+          assign_param(attrs, permitted, :game_id, :game_id, :gameId)
+          assign_param(attrs, permitted, :poll_type, :poll_type, :pollType)
+          assign_param(attrs, permitted, :question, :question)
+          assign_param(attrs, permitted, :status, :status)
+          assign_param(attrs, permitted, :show_results, :show_results, :showResults)
+          assign_param(attrs, permitted, :closes_at, :closes_at, :closesAt)
+          attrs[:poll_type] ||= "game" if attrs[:game_id].present?
+          attrs[:poll_type] ||= "tournament"
+          attrs[:question] = default_question(attrs) if attrs[:question].blank?
+          attrs
+        end
+
+        def default_question(attrs)
+          return "Who wins this game?" if attrs[:poll_type] == "game"
+
+          "Who wins the tournament?"
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
+++ b/api/app/controllers/api/v1/admin/prediction_polls_controller.rb
@@ -13,10 +13,10 @@ module Api
           attrs = prediction_poll_params.except(:tournament_id)
           game_id = attrs.delete(:game_id)
           poll = admin_tournament.prediction_polls.build(attrs)
-          poll.game = admin_tournament.games.find(game_id) if game_id.present?
+          poll.game = admin_tournament.games.find(game_id) if poll.poll_type == "game" && game_id.present?
 
           if poll.save
-            render json: { predictionPoll: poll.api_json }, status: :created
+            render json: { predictionPoll: prediction_poll_for_response(poll.id).api_json }, status: :created
           else
             render_errors(poll)
           end
@@ -26,7 +26,7 @@ module Api
           poll = admin_tournament.prediction_polls.find(params[:id])
 
           if poll.update(prediction_poll_params.except(:tournament_id, :game_id, :poll_type))
-            render json: { predictionPoll: poll.api_json }
+            render json: { predictionPoll: prediction_poll_for_response(poll.id).api_json }
           else
             render_errors(poll)
           end
@@ -56,6 +56,10 @@ module Api
           return "Who wins this game?" if attrs[:poll_type] == "game"
 
           "Who wins the tournament?"
+        end
+
+        def prediction_poll_for_response(id)
+          PredictionPoll.includes(:prediction_votes, :tournament, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
         end
       end
     end

--- a/api/app/controllers/api/v1/admin/roster_entries_controller.rb
+++ b/api/app/controllers/api/v1/admin/roster_entries_controller.rb
@@ -13,7 +13,7 @@ module Api
         end
 
         def update
-          roster_entry = RosterEntry.find(params[:id])
+          roster_entry = roster_entry_scope.find(params[:id])
 
           if roster_entry.update(roster_entry_params.except(:team_id))
             render json: { rosterEntry: roster_entry.api_json }
@@ -23,11 +23,15 @@ module Api
         end
 
         def destroy
-          RosterEntry.find(params[:id]).destroy!
+          roster_entry_scope.find(params[:id]).destroy!
           head :no_content
         end
 
         private
+
+        def roster_entry_scope
+          RosterEntry.joins(:team).where(teams: { tournament_id: admin_tournament.id })
+        end
 
         def roster_entry_params
           raw = params.fetch(:rosterEntry, params.fetch(:roster_entry, params))

--- a/api/app/controllers/api/v1/admin/roster_entries_controller.rb
+++ b/api/app/controllers/api/v1/admin/roster_entries_controller.rb
@@ -1,0 +1,49 @@
+module Api
+  module V1
+    module Admin
+      class RosterEntriesController < BaseController
+        def create
+          roster_entry = RosterEntry.new(roster_entry_params)
+
+          if roster_entry.save
+            render json: { rosterEntry: roster_entry.api_json }, status: :created
+          else
+            render_errors(roster_entry)
+          end
+        end
+
+        def update
+          roster_entry = RosterEntry.find(params[:id])
+
+          if roster_entry.update(roster_entry_params.except(:team_id))
+            render json: { rosterEntry: roster_entry.api_json }
+          else
+            render_errors(roster_entry)
+          end
+        end
+
+        def destroy
+          RosterEntry.find(params[:id]).destroy!
+          head :no_content
+        end
+
+        private
+
+        def roster_entry_params
+          raw = params.fetch(:rosterEntry, params.fetch(:roster_entry, params))
+          permitted = raw.permit(:team_id, :teamId, :name, :jersey_number, :jerseyNumber, :position, :nickname, :sort_order, :sortOrder, :active)
+
+          attrs = {}
+          assign_param(attrs, permitted, :team_id, :team_id, :teamId)
+          assign_param(attrs, permitted, :name, :name)
+          assign_param(attrs, permitted, :jersey_number, :jersey_number, :jerseyNumber)
+          assign_param(attrs, permitted, :position, :position)
+          assign_param(attrs, permitted, :nickname, :nickname)
+          assign_param(attrs, permitted, :sort_order, :sort_order, :sortOrder)
+          assign_param(attrs, permitted, :active, :active)
+          attrs
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/api/v1/admin/roster_entries_controller.rb
+++ b/api/app/controllers/api/v1/admin/roster_entries_controller.rb
@@ -3,7 +3,9 @@ module Api
     module Admin
       class RosterEntriesController < BaseController
         def create
-          roster_entry = RosterEntry.new(roster_entry_params)
+          attrs = roster_entry_params
+          team = admin_tournament.teams.find(attrs.delete(:team_id))
+          roster_entry = team.roster_entries.build(attrs)
 
           if roster_entry.save
             render json: { rosterEntry: roster_entry.api_json }, status: :created

--- a/api/app/controllers/api/v1/admin/teams_controller.rb
+++ b/api/app/controllers/api/v1/admin/teams_controller.rb
@@ -10,7 +10,8 @@ module Api
         end
 
         def create
-          team = Team.new(team_params)
+          attrs = team_params
+          team = admin_tournament.teams.build(attrs.except(:tournament_id))
 
           if team.save
             render json: { team: team_for_response(team.id).api_json }, status: :created
@@ -20,10 +21,20 @@ module Api
         end
 
         def update
-          team = Team.find(params[:id])
+          team = admin_tournament.teams.find(params[:id])
 
-          if team.update(team_params)
+          if team.update(team_params.except(:tournament_id))
             render json: { team: team_for_response(team.id).api_json }
+          else
+            render_errors(team)
+          end
+        end
+
+        def destroy
+          team = admin_tournament.teams.find(params[:id])
+
+          if team.destroy
+            head :no_content
           else
             render_errors(team)
           end

--- a/api/app/controllers/api/v1/admin/teams_controller.rb
+++ b/api/app/controllers/api/v1/admin/teams_controller.rb
@@ -3,7 +3,7 @@ module Api
     module Admin
       class TeamsController < BaseController
         def index
-          teams = Team.includes(:tournament, :division_record).order(:tournament_id, :division, :display_name)
+          teams = Team.includes(:tournament, :division_record, :roster_entries).order(:tournament_id, :division, :display_name)
           teams = teams.where(tournament_id: params[:tournamentId]) if params[:tournamentId].present?
 
           render json: { teams: teams.map(&:api_json) }

--- a/api/app/controllers/api/v1/admin/teams_controller.rb
+++ b/api/app/controllers/api/v1/admin/teams_controller.rb
@@ -6,7 +6,7 @@ module Api
           teams = Team.includes(:tournament, :division_record, :roster_entries).order(:tournament_id, :division, :display_name)
           teams = teams.where(tournament_id: params[:tournamentId]) if params[:tournamentId].present?
 
-          render json: { teams: teams.map(&:api_json) }
+          render json: { teams: teams.map { |team| team.api_json(include_roster: true) } }
         end
 
         def create
@@ -14,7 +14,7 @@ module Api
           team = admin_tournament.teams.build(attrs.except(:tournament_id))
 
           if team.save
-            render json: { team: team_for_response(team.id).api_json }, status: :created
+            render json: { team: team_for_response(team.id).api_json(include_roster: true) }, status: :created
           else
             render_errors(team)
           end
@@ -24,7 +24,7 @@ module Api
           team = admin_tournament.teams.find(params[:id])
 
           if team.update(team_params.except(:tournament_id))
-            render json: { team: team_for_response(team.id).api_json }
+            render json: { team: team_for_response(team.id).api_json(include_roster: true) }
           else
             render_errors(team)
           end

--- a/api/app/controllers/api/v1/admin/teams_controller.rb
+++ b/api/app/controllers/api/v1/admin/teams_controller.rb
@@ -13,7 +13,7 @@ module Api
           team = Team.new(team_params)
 
           if team.save
-            render json: { team: team.api_json }, status: :created
+            render json: { team: team_for_response(team.id).api_json }, status: :created
           else
             render_errors(team)
           end
@@ -23,13 +23,17 @@ module Api
           team = Team.find(params[:id])
 
           if team.update(team_params)
-            render json: { team: team.api_json }
+            render json: { team: team_for_response(team.id).api_json }
           else
             render_errors(team)
           end
         end
 
         private
+
+        def team_for_response(id)
+          Team.includes(:tournament, :division_record, :roster_entries).find(id)
+        end
 
         def team_params
           raw = params.fetch(:team, params)

--- a/api/app/controllers/api/v1/public/home_controller.rb
+++ b/api/app/controllers/api/v1/public/home_controller.rb
@@ -14,23 +14,45 @@ module Api
               todayGames: [],
               liveGames: [],
               latestNews: [],
-              gameDayNote: nil
+              gameDayNote: nil,
+              predictionPolls: []
             }
           end
 
           today_range = Time.zone.now.beginning_of_day..Time.zone.now.end_of_day
           games_scope = tournament.games.includes(:division_record, home_team: :division_record, away_team: :division_record)
+          today_games = games_scope.where(start_time: today_range).ordered.limit(20).to_a
+          live_games = games_scope.where(status: "live").ordered.limit(10).to_a
           game_day_note = tournament.game_day_notes.find_by(date: Time.zone.today, active: true)
+          polls = relevant_polls(tournament, today_games).to_a
 
           render json: {
             tournament: tournament.api_json,
             upcomingOrLiveTournament: context[:upcoming_or_live]&.api_json,
             latestResultsTournament: context[:latest_completed_with_games]&.api_json,
-            todayGames: games_scope.where(start_time: today_range).ordered.limit(20).map(&:api_json),
-            liveGames: games_scope.where(status: "live").ordered.limit(10).map(&:api_json),
+            todayGames: today_games.map(&:api_json),
+            liveGames: live_games.map(&:api_json),
             latestNews: tournament.article_links.includes(game: [ :division_record, { home_team: :division_record, away_team: :division_record } ]).latest.limit(5).map(&:api_json),
-            gameDayNote: game_day_note&.api_json
+            gameDayNote: game_day_note&.api_json,
+            predictionPolls: polls.map { |poll| poll.api_json(voter_token_hash: voter_token_hash) }
           }
+        end
+
+        private
+
+        def relevant_polls(tournament, today_games)
+          game_ids = today_games.map(&:id)
+          tournament.prediction_polls
+            .includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ])
+            .where("poll_type = ? OR game_id IN (?)", "tournament", game_ids.presence || [ nil ])
+            .ordered
+        end
+
+        def voter_token_hash
+          token = request.headers["X-FD-Voter-Token"].to_s.strip
+          return nil if token.blank?
+
+          PredictionVote.token_hash(token)
         end
       end
     end

--- a/api/app/controllers/api/v1/public/home_controller.rb
+++ b/api/app/controllers/api/v1/public/home_controller.rb
@@ -13,12 +13,14 @@ module Api
               latestResultsTournament: context[:latest_completed_with_games]&.api_json,
               todayGames: [],
               liveGames: [],
-              latestNews: []
+              latestNews: [],
+              gameDayNote: nil
             }
           end
 
           today_range = Time.zone.now.beginning_of_day..Time.zone.now.end_of_day
           games_scope = tournament.games.includes(:division_record, home_team: :division_record, away_team: :division_record)
+          game_day_note = tournament.game_day_notes.find_by(date: Time.zone.today, active: true)
 
           render json: {
             tournament: tournament.api_json,
@@ -26,7 +28,8 @@ module Api
             latestResultsTournament: context[:latest_completed_with_games]&.api_json,
             todayGames: games_scope.where(start_time: today_range).ordered.limit(20).map(&:api_json),
             liveGames: games_scope.where(status: "live").ordered.limit(10).map(&:api_json),
-            latestNews: tournament.article_links.includes(game: [ :division_record, { home_team: :division_record, away_team: :division_record } ]).latest.limit(5).map(&:api_json)
+            latestNews: tournament.article_links.includes(game: [ :division_record, { home_team: :division_record, away_team: :division_record } ]).latest.limit(5).map(&:api_json),
+            gameDayNote: game_day_note&.api_json
           }
         end
       end

--- a/api/app/controllers/api/v1/public/prediction_votes_controller.rb
+++ b/api/app/controllers/api/v1/public/prediction_votes_controller.rb
@@ -28,7 +28,7 @@ module Api
         end
 
         def prediction_poll_for_response(id)
-          PredictionPoll.includes(:prediction_votes, :tournament, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
+          PredictionPoll.includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
         end
       end
     end

--- a/api/app/controllers/api/v1/public/prediction_votes_controller.rb
+++ b/api/app/controllers/api/v1/public/prediction_votes_controller.rb
@@ -1,0 +1,32 @@
+module Api
+  module V1
+    module Public
+      class PredictionVotesController < BaseController
+        def create
+          poll = PredictionPoll.find(params[:prediction_poll_id])
+          token = vote_params[:voterToken].to_s.strip
+          return render json: { error: "Voter token is required" }, status: :unprocessable_entity if token.blank?
+
+          vote = poll.prediction_votes.find_or_initialize_by(voter_token_hash: PredictionVote.token_hash(token))
+          vote.team_id = vote_params[:teamId]
+
+          if vote.save
+            render json: { predictionPoll: poll.reload.api_json(voter_token_hash: vote.voter_token_hash) }
+          else
+            render json: { errors: vote.errors.full_messages }, status: :unprocessable_entity
+          end
+        end
+
+        private
+
+        def vote_params
+          raw = params.fetch(:predictionVote, params)
+          raw.permit(:teamId, :team_id, :voterToken, :voter_token).tap do |permitted|
+            permitted[:teamId] ||= permitted[:team_id]
+            permitted[:voterToken] ||= permitted[:voter_token]
+          end
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/api/v1/public/prediction_votes_controller.rb
+++ b/api/app/controllers/api/v1/public/prediction_votes_controller.rb
@@ -3,7 +3,7 @@ module Api
     module Public
       class PredictionVotesController < BaseController
         def create
-          poll = PredictionPoll.find(params[:prediction_poll_id])
+          poll = prediction_poll_for_vote(params[:prediction_poll_id])
           token = vote_params[:voterToken].to_s.strip
           return render json: { error: "Voter token is required" }, status: :unprocessable_entity if token.blank?
 
@@ -38,8 +38,16 @@ module Api
           vote
         end
 
+        def prediction_poll_for_vote(id)
+          PredictionPoll
+            .includes({ tournament: { teams: :division_record } }, game: [ :home_team, :away_team ])
+            .find(id)
+        end
+
         def prediction_poll_for_response(id)
-          PredictionPoll.includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
+          PredictionPoll
+            .includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ])
+            .find(id)
         end
       end
     end

--- a/api/app/controllers/api/v1/public/prediction_votes_controller.rb
+++ b/api/app/controllers/api/v1/public/prediction_votes_controller.rb
@@ -11,7 +11,7 @@ module Api
           vote.team_id = vote_params[:teamId]
 
           if vote.save
-            render json: { predictionPoll: poll.reload.api_json(voter_token_hash: vote.voter_token_hash) }
+            render json: { predictionPoll: prediction_poll_for_response(poll.id).api_json(voter_token_hash: vote.voter_token_hash) }
           else
             render json: { errors: vote.errors.full_messages }, status: :unprocessable_entity
           end
@@ -25,6 +25,10 @@ module Api
             permitted[:teamId] ||= permitted[:team_id]
             permitted[:voterToken] ||= permitted[:voter_token]
           end
+        end
+
+        def prediction_poll_for_response(id)
+          PredictionPoll.includes(:prediction_votes, :tournament, game: [ { home_team: :division_record }, { away_team: :division_record } ]).find(id)
         end
       end
     end

--- a/api/app/controllers/api/v1/public/prediction_votes_controller.rb
+++ b/api/app/controllers/api/v1/public/prediction_votes_controller.rb
@@ -7,10 +7,9 @@ module Api
           token = vote_params[:voterToken].to_s.strip
           return render json: { error: "Voter token is required" }, status: :unprocessable_entity if token.blank?
 
-          vote = poll.prediction_votes.find_or_initialize_by(voter_token_hash: PredictionVote.token_hash(token))
-          vote.team_id = vote_params[:teamId]
+          vote = persist_vote(poll, PredictionVote.token_hash(token), vote_params[:teamId])
 
-          if vote.save
+          if vote.errors.empty?
             render json: { predictionPoll: prediction_poll_for_response(poll.id).api_json(voter_token_hash: vote.voter_token_hash) }
           else
             render json: { errors: vote.errors.full_messages }, status: :unprocessable_entity
@@ -25,6 +24,18 @@ module Api
             permitted[:teamId] ||= permitted[:team_id]
             permitted[:voterToken] ||= permitted[:voter_token]
           end
+        end
+
+        def persist_vote(poll, voter_token_hash, team_id)
+          vote = poll.prediction_votes.find_or_initialize_by(voter_token_hash: voter_token_hash)
+          vote.team_id = team_id
+          vote.save
+          vote
+        rescue ActiveRecord::RecordNotUnique
+          vote = poll.prediction_votes.find_by!(voter_token_hash: voter_token_hash)
+          vote.team_id = team_id
+          vote.save
+          vote
         end
 
         def prediction_poll_for_response(id)

--- a/api/app/controllers/api/v1/public/today_controller.rb
+++ b/api/app/controllers/api/v1/public/today_controller.rb
@@ -1,0 +1,53 @@
+module Api
+  module V1
+    module Public
+      class TodayController < BaseController
+        def show
+          tournament = current_tournament
+          return render_not_found("Tournament not found") unless tournament
+
+          day = requested_date || Time.zone.today
+          games = tournament.games
+            .includes(:division_record, home_team: [ :division_record, :roster_entries ], away_team: [ :division_record, :roster_entries ])
+            .where(start_time: day.beginning_of_day..day.end_of_day)
+            .ordered
+          note = tournament.game_day_notes.active.find_by(date: day)
+          polls = relevant_polls(tournament, games)
+          voter_hash = voter_token_hash
+
+          render json: {
+            tournament: tournament.api_json,
+            date: day.iso8601,
+            gameDayNote: note&.api_json,
+            games: games.map { |game| game.api_json(include_rosters: true) },
+            predictionPolls: polls.map { |poll| poll.api_json(voter_token_hash: voter_hash) },
+            sponsors: tournament.sponsors.active.ordered.limit(4).map(&:api_json),
+            lastUpdatedAt: [ note&.updated_at, games.map(&:updated_at).max, polls.map(&:updated_at).max ].compact.max&.iso8601
+          }
+        end
+
+        private
+
+        def requested_date
+          return nil if params[:date].blank?
+
+          Date.iso8601(params[:date])
+        rescue ArgumentError
+          nil
+        end
+
+        def relevant_polls(tournament, games)
+          game_ids = games.map(&:id)
+          tournament.prediction_polls.includes(:prediction_votes, :game).where("poll_type = ? OR game_id IN (?)", "tournament", game_ids.presence || [ nil ]).ordered
+        end
+
+        def voter_token_hash
+          token = request.headers["X-FD-Voter-Token"].to_s.strip
+          return nil if token.blank?
+
+          PredictionVote.token_hash(token)
+        end
+      end
+    end
+  end
+end

--- a/api/app/controllers/api/v1/public/today_controller.rb
+++ b/api/app/controllers/api/v1/public/today_controller.rb
@@ -11,10 +11,11 @@ module Api
             .includes(:division_record, home_team: [ :division_record, :roster_entries ], away_team: [ :division_record, :roster_entries ])
             .where(start_time: day.beginning_of_day..day.end_of_day)
             .ordered
+            .to_a
           note = tournament.game_day_notes.active.find_by(date: day)
-          polls = relevant_polls(tournament, games)
+          polls = relevant_polls(tournament, games).to_a
           voter_hash = voter_token_hash
-          last_updated_at = [ note&.updated_at, games.maximum(:updated_at), polls.maximum(:updated_at) ].compact.max
+          last_updated_at = latest_updated_at(note, games, polls)
 
           render json: {
             tournament: tournament.api_json,
@@ -39,7 +40,14 @@ module Api
 
         def relevant_polls(tournament, games)
           game_ids = games.map(&:id)
-          tournament.prediction_polls.includes(:prediction_votes, :game).where("poll_type = ? OR game_id IN (?)", "tournament", game_ids.presence || [ nil ]).ordered
+          tournament.prediction_polls
+            .includes(:prediction_votes, game: [ { home_team: :division_record }, { away_team: :division_record } ])
+            .where("poll_type = ? OR game_id IN (?)", "tournament", game_ids.presence || [ nil ])
+            .ordered
+        end
+
+        def latest_updated_at(*record_groups)
+          record_groups.flatten.compact.filter_map(&:updated_at).max
         end
 
         def voter_token_hash

--- a/api/app/controllers/api/v1/public/today_controller.rb
+++ b/api/app/controllers/api/v1/public/today_controller.rb
@@ -14,6 +14,7 @@ module Api
           note = tournament.game_day_notes.active.find_by(date: day)
           polls = relevant_polls(tournament, games)
           voter_hash = voter_token_hash
+          last_updated_at = [ note&.updated_at, games.maximum(:updated_at), polls.maximum(:updated_at) ].compact.max
 
           render json: {
             tournament: tournament.api_json,
@@ -22,7 +23,7 @@ module Api
             games: games.map { |game| game.api_json(include_rosters: true) },
             predictionPolls: polls.map { |poll| poll.api_json(voter_token_hash: voter_hash) },
             sponsors: tournament.sponsors.active.ordered.limit(4).map(&:api_json),
-            lastUpdatedAt: [ note&.updated_at, games.map(&:updated_at).max, polls.map(&:updated_at).max ].compact.max&.iso8601
+            lastUpdatedAt: last_updated_at&.iso8601
           }
         end
 

--- a/api/app/controllers/api/v1/public/today_controller.rb
+++ b/api/app/controllers/api/v1/public/today_controller.rb
@@ -41,7 +41,7 @@ module Api
         def relevant_polls(tournament, games)
           game_ids = games.map(&:id)
           tournament.prediction_polls
-            .includes(:prediction_votes, game: [ { home_team: :division_record }, { away_team: :division_record } ])
+            .includes(:prediction_votes, { tournament: { teams: :division_record } }, game: [ { home_team: :division_record }, { away_team: :division_record } ])
             .where("poll_type = ? OR game_id IN (?)", "tournament", game_ids.presence || [ nil ])
             .ordered
         end

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -97,7 +97,7 @@ class Game < ApplicationRecord
       division: team.resolved_division
     }
 
-    payload[:rosterEntries] = team.roster_entries.active.ordered.map(&:api_json) if include_roster
+    payload[:rosterEntries] = team.roster_entries_api_json(active_only: true) if include_roster
     payload
   end
 

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -8,6 +8,7 @@ class Game < ApplicationRecord
 
   has_many :article_links, dependent: :nullify
   has_many :media_assets, dependent: :nullify
+  has_many :prediction_polls, dependent: :destroy
 
   validates :start_time, presence: true
   validates :status, inclusion: { in: STATUSES }
@@ -53,7 +54,7 @@ class Game < ApplicationRecord
     }
   end
 
-  def api_json(include_teams: true)
+  def api_json(include_teams: true, include_rosters: false)
     payload = {
       id: id.to_s,
       tournamentId: tournament_id.to_s,
@@ -76,8 +77,8 @@ class Game < ApplicationRecord
     }
 
     if include_teams
-      payload[:homeTeam] = team_summary(home_team)
-      payload[:awayTeam] = team_summary(away_team)
+      payload[:homeTeam] = team_summary(home_team, include_roster: include_rosters)
+      payload[:awayTeam] = team_summary(away_team, include_roster: include_rosters)
     end
 
     payload
@@ -85,16 +86,19 @@ class Game < ApplicationRecord
 
   private
 
-  def team_summary(team)
+  def team_summary(team, include_roster: false)
     return nil unless team
 
-    {
+    payload = {
       id: team.id.to_s,
       displayName: team.display_name,
       classYearLabel: team.class_year_label,
       divisionId: team.division_id&.to_s,
       division: team.resolved_division
     }
+
+    payload[:rosterEntries] = team.roster_entries.active.ordered.map(&:api_json) if include_roster
+    payload
   end
 
   def copy_division_name_from_record

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -65,8 +65,8 @@ class Game < ApplicationRecord
       status: status,
       homeScore: home_score,
       awayScore: away_score,
-      streamUrl: stream_url,
-      ticketUrl: ticket_url,
+      streamUrl: external_url(stream_url),
+      ticketUrl: external_url(ticket_url),
       notes: notes,
       divisionId: division_id&.to_s,
       division: resolved_division,
@@ -85,6 +85,15 @@ class Game < ApplicationRecord
   end
 
   private
+
+  def external_url(value)
+    url = value.to_s.strip
+    return nil if url.blank?
+    return "https:#{url}" if url.start_with?("//")
+    return url if url.match?(/\A[a-z][a-z0-9+.-]*:/i)
+
+    "https://#{url}"
+  end
 
   def team_summary(team, include_roster: false)
     return nil unless team

--- a/api/app/models/game_day_note.rb
+++ b/api/app/models/game_day_note.rb
@@ -1,0 +1,23 @@
+class GameDayNote < ApplicationRecord
+  belongs_to :tournament
+
+  validates :date, presence: true, uniqueness: { scope: :tournament_id }
+
+  scope :active, -> { where(active: true) }
+  scope :ordered, -> { order(date: :desc, id: :desc) }
+
+  def api_json
+    {
+      id: id.to_s,
+      tournamentId: tournament_id.to_s,
+      date: date&.iso8601,
+      hostClass: host_class,
+      foodMenu: food_menu,
+      announcement: announcement,
+      sponsorShoutout: sponsor_shoutout,
+      active: active,
+      createdAt: created_at&.iso8601,
+      updatedAt: updated_at&.iso8601
+    }
+  end
+end

--- a/api/app/models/prediction_poll.rb
+++ b/api/app/models/prediction_poll.rb
@@ -37,7 +37,7 @@ class PredictionPoll < ApplicationRecord
     selected_team_id = selected_team_id_for(voter_token_hash, preloaded_votes)
     totals_by_team = prediction_vote_totals(preloaded_votes)
     total_votes = totals_by_team.values.sum
-    results_visible = show_results? || selected_team_id.present? || !open_for_voting?
+    results_visible = true
 
     {
       id: id.to_s,
@@ -47,7 +47,7 @@ class PredictionPoll < ApplicationRecord
       question: question,
       status: status,
       open: open_for_voting?,
-      showResults: show_results,
+      showResults: true,
       closesAt: closes_at&.iso8601,
       totalVotes: results_visible ? total_votes : nil,
       resultsVisible: results_visible,

--- a/api/app/models/prediction_poll.rb
+++ b/api/app/models/prediction_poll.rb
@@ -30,8 +30,9 @@ class PredictionPoll < ApplicationRecord
   end
 
   def api_json(voter_token_hash: nil)
-    selected_team_id = voter_token_hash.present? ? prediction_votes.find_by(voter_token_hash: voter_token_hash)&.team_id : nil
-    totals_by_team = prediction_votes.group(:team_id).count
+    preloaded_votes = preloaded_prediction_votes
+    selected_team_id = selected_team_id_for(voter_token_hash, preloaded_votes)
+    totals_by_team = prediction_vote_totals(preloaded_votes)
     total_votes = totals_by_team.values.sum
     results_visible = show_results? || selected_team_id.present? || !open_for_voting?
 
@@ -56,6 +57,28 @@ class PredictionPoll < ApplicationRecord
   end
 
   private
+
+  def preloaded_prediction_votes
+    prediction_votes.to_a if association(:prediction_votes).loaded?
+  end
+
+  def selected_team_id_for(voter_token_hash, preloaded_votes)
+    return nil if voter_token_hash.blank?
+
+    if preloaded_votes
+      preloaded_votes.find { |vote| vote.voter_token_hash == voter_token_hash }&.team_id
+    else
+      prediction_votes.find_by(voter_token_hash: voter_token_hash)&.team_id
+    end
+  end
+
+  def prediction_vote_totals(preloaded_votes)
+    return prediction_votes.group(:team_id).count unless preloaded_votes
+
+    preloaded_votes.each_with_object(Hash.new(0)) do |vote, totals|
+      totals[vote.team_id] += 1
+    end
+  end
 
   def option_json(team, totals_by_team, total_votes, selected_team_id, results_visible)
     votes = totals_by_team[team.id] || 0

--- a/api/app/models/prediction_poll.rb
+++ b/api/app/models/prediction_poll.rb
@@ -11,6 +11,7 @@ class PredictionPoll < ApplicationRecord
   validates :question, presence: true
   validate :game_poll_has_game
   validate :game_belongs_to_tournament
+  validate :single_tournament_poll
 
   scope :ordered, -> { order(:poll_type, :game_id, :id) }
   scope :open_for_voting, -> { where(status: "open").where("closes_at IS NULL OR closes_at > ?", Time.current) }
@@ -101,5 +102,13 @@ class PredictionPoll < ApplicationRecord
     return if game.blank? || tournament_id.blank? || game.tournament_id == tournament_id
 
     errors.add(:game, "must belong to the selected tournament")
+  end
+
+  def single_tournament_poll
+    return unless poll_type == "tournament" && tournament_id.present?
+
+    existing_poll = PredictionPoll.where(tournament_id: tournament_id, poll_type: "tournament")
+    existing_poll = existing_poll.where.not(id: id) if id.present?
+    errors.add(:poll_type, "already has a tournament prediction poll") if existing_poll.exists?
   end
 end

--- a/api/app/models/prediction_poll.rb
+++ b/api/app/models/prediction_poll.rb
@@ -1,0 +1,82 @@
+class PredictionPoll < ApplicationRecord
+  POLL_TYPES = %w[game tournament].freeze
+  STATUSES = %w[open closed].freeze
+
+  belongs_to :tournament
+  belongs_to :game, optional: true
+  has_many :prediction_votes, dependent: :destroy
+
+  validates :poll_type, inclusion: { in: POLL_TYPES }
+  validates :status, inclusion: { in: STATUSES }
+  validates :question, presence: true
+  validate :game_poll_has_game
+  validate :game_belongs_to_tournament
+
+  scope :ordered, -> { order(:poll_type, :game_id, :id) }
+  scope :open_for_voting, -> { where(status: "open").where("closes_at IS NULL OR closes_at > ?", Time.current) }
+
+  def open_for_voting?
+    status == "open" && (closes_at.blank? || closes_at.future?)
+  end
+
+  def option_teams
+    @option_teams ||= begin
+      if poll_type == "game" && game
+        [ game.away_team, game.home_team ].compact
+      else
+        tournament.teams.includes(:division_record).order(:division, :display_name, :id)
+      end
+    end
+  end
+
+  def api_json(voter_token_hash: nil)
+    selected_team_id = voter_token_hash.present? ? prediction_votes.find_by(voter_token_hash: voter_token_hash)&.team_id : nil
+    totals_by_team = prediction_votes.group(:team_id).count
+    total_votes = totals_by_team.values.sum
+    results_visible = show_results? || selected_team_id.present? || !open_for_voting?
+
+    {
+      id: id.to_s,
+      tournamentId: tournament_id.to_s,
+      gameId: game_id&.to_s,
+      pollType: poll_type,
+      question: question,
+      status: status,
+      open: open_for_voting?,
+      showResults: show_results,
+      closesAt: closes_at&.iso8601,
+      totalVotes: results_visible ? total_votes : nil,
+      resultsVisible: results_visible,
+      selectedTeamId: selected_team_id&.to_s,
+      game: game&.summary_json,
+      options: option_teams.map { |team| option_json(team, totals_by_team, total_votes, selected_team_id, results_visible) },
+      createdAt: created_at&.iso8601,
+      updatedAt: updated_at&.iso8601
+    }
+  end
+
+  private
+
+  def option_json(team, totals_by_team, total_votes, selected_team_id, results_visible)
+    votes = totals_by_team[team.id] || 0
+    {
+      teamId: team.id.to_s,
+      displayName: team.display_name,
+      classYearLabel: team.class_year_label,
+      division: team.resolved_division,
+      selected: selected_team_id == team.id,
+      votes: results_visible ? votes : nil,
+      percent: results_visible && total_votes.positive? ? ((votes.to_f / total_votes) * 100).round : nil
+    }
+  end
+
+  def game_poll_has_game
+    errors.add(:game, "is required for game prediction polls") if poll_type == "game" && game.blank?
+  end
+
+  def game_belongs_to_tournament
+    return if game.blank? || tournament_id.blank? || game.tournament_id == tournament_id
+
+    errors.add(:game, "must belong to the selected tournament")
+  end
+end

--- a/api/app/models/prediction_poll.rb
+++ b/api/app/models/prediction_poll.rb
@@ -37,7 +37,6 @@ class PredictionPoll < ApplicationRecord
     selected_team_id = selected_team_id_for(voter_token_hash, preloaded_votes)
     totals_by_team = prediction_vote_totals(preloaded_votes)
     total_votes = totals_by_team.values.sum
-    results_visible = true
 
     {
       id: id.to_s,
@@ -47,13 +46,11 @@ class PredictionPoll < ApplicationRecord
       question: question,
       status: status,
       open: open_for_voting?,
-      showResults: true,
       closesAt: closes_at&.iso8601,
-      totalVotes: results_visible ? total_votes : nil,
-      resultsVisible: results_visible,
+      totalVotes: total_votes,
       selectedTeamId: selected_team_id&.to_s,
       game: game&.summary_json,
-      options: option_teams.map { |team| option_json(team, totals_by_team, total_votes, selected_team_id, results_visible) },
+      options: option_teams.map { |team| option_json(team, totals_by_team, total_votes, selected_team_id) },
       createdAt: created_at&.iso8601,
       updatedAt: updated_at&.iso8601
     }
@@ -83,7 +80,7 @@ class PredictionPoll < ApplicationRecord
     end
   end
 
-  def option_json(team, totals_by_team, total_votes, selected_team_id, results_visible)
+  def option_json(team, totals_by_team, total_votes, selected_team_id)
     votes = totals_by_team[team.id] || 0
     {
       teamId: team.id.to_s,
@@ -91,8 +88,8 @@ class PredictionPoll < ApplicationRecord
       classYearLabel: team.class_year_label,
       division: team.resolved_division,
       selected: selected_team_id == team.id,
-      votes: results_visible ? votes : nil,
-      percent: results_visible && total_votes.positive? ? ((votes.to_f / total_votes) * 100).round : nil
+      votes: votes,
+      percent: total_votes.positive? ? ((votes.to_f / total_votes) * 100).round : nil
     }
   end
 

--- a/api/app/models/prediction_poll.rb
+++ b/api/app/models/prediction_poll.rb
@@ -24,6 +24,8 @@ class PredictionPoll < ApplicationRecord
     @option_teams ||= begin
       if poll_type == "game" && game
         [ game.away_team, game.home_team ].compact
+      elsif tournament.association(:teams).loaded?
+        tournament.teams.sort_by { |team| [ team.division.to_s, team.display_name.to_s, team.id || 0 ] }
       else
         tournament.teams.includes(:division_record).order(:division, :display_name, :id)
       end

--- a/api/app/models/prediction_vote.rb
+++ b/api/app/models/prediction_vote.rb
@@ -1,0 +1,30 @@
+require "digest"
+
+class PredictionVote < ApplicationRecord
+  belongs_to :prediction_poll
+  belongs_to :team
+
+  validates :voter_token_hash, presence: true
+  validates :voter_token_hash, uniqueness: { scope: :prediction_poll_id }
+  validate :poll_is_open
+  validate :team_is_valid_option
+
+  def self.token_hash(token)
+    Digest::SHA256.hexdigest(token.to_s)
+  end
+
+  private
+
+  def poll_is_open
+    return if prediction_poll&.open_for_voting?
+
+    errors.add(:prediction_poll, "is closed")
+  end
+
+  def team_is_valid_option
+    return if prediction_poll.blank? || team.blank?
+    return if prediction_poll.option_teams.map(&:id).include?(team_id)
+
+    errors.add(:team, "is not an option for this prediction")
+  end
+end

--- a/api/app/models/roster_entry.rb
+++ b/api/app/models/roster_entry.rb
@@ -1,0 +1,23 @@
+class RosterEntry < ApplicationRecord
+  belongs_to :team
+
+  validates :name, presence: true
+
+  scope :active, -> { where(active: true) }
+  scope :ordered, -> { order(:sort_order, :jersey_number, :name, :id) }
+
+  def api_json
+    {
+      id: id.to_s,
+      teamId: team_id.to_s,
+      name: name,
+      jerseyNumber: jersey_number,
+      position: position,
+      nickname: nickname,
+      sortOrder: sort_order,
+      active: active,
+      createdAt: created_at&.iso8601,
+      updatedAt: updated_at&.iso8601
+    }
+  end
+end

--- a/api/app/models/team.rb
+++ b/api/app/models/team.rb
@@ -5,6 +5,8 @@ class Team < ApplicationRecord
   has_many :home_games, class_name: "Game", foreign_key: :home_team_id, dependent: :restrict_with_error, inverse_of: :home_team
   has_many :away_games, class_name: "Game", foreign_key: :away_team_id, dependent: :restrict_with_error, inverse_of: :away_team
   has_many :standings, dependent: :destroy
+  has_many :roster_entries, dependent: :destroy
+  has_many :prediction_votes, dependent: :destroy
 
   before_validation :copy_division_name_from_record
 
@@ -17,8 +19,8 @@ class Team < ApplicationRecord
     division_record&.name || division
   end
 
-  def api_json
-    {
+  def api_json(include_roster: true)
+    payload = {
       id: id.to_s,
       tournamentId: tournament_id.to_s,
       classYearLabel: class_year_label,
@@ -28,6 +30,9 @@ class Team < ApplicationRecord
       createdAt: created_at&.iso8601,
       updatedAt: updated_at&.iso8601
     }
+
+    payload[:rosterEntries] = roster_entries.ordered.map(&:api_json) if include_roster
+    payload
   end
 
   private

--- a/api/app/models/team.rb
+++ b/api/app/models/team.rb
@@ -31,11 +31,27 @@ class Team < ApplicationRecord
       updatedAt: updated_at&.iso8601
     }
 
-    payload[:rosterEntries] = roster_entries.ordered.map(&:api_json) if include_roster
+    payload[:rosterEntries] = roster_entries_api_json if include_roster
     payload
   end
 
+  def roster_entries_api_json(active_only: false)
+    roster_entries_for_api(active_only: active_only).map(&:api_json)
+  end
+
   private
+
+  def roster_entries_for_api(active_only: false)
+    return roster_entries_scope(active_only: active_only).ordered.to_a unless association(:roster_entries).loaded?
+
+    entries = roster_entries.to_a
+    entries = entries.select(&:active?) if active_only
+    entries.sort_by { |entry| [ entry.sort_order || 0, entry.jersey_number.to_s, entry.name.to_s, entry.id || 0 ] }
+  end
+
+  def roster_entries_scope(active_only: false)
+    active_only ? roster_entries.active : roster_entries
+  end
 
   def copy_division_name_from_record
     self.division = division_record.name if division_record

--- a/api/app/models/team.rb
+++ b/api/app/models/team.rb
@@ -19,7 +19,7 @@ class Team < ApplicationRecord
     division_record&.name || division
   end
 
-  def api_json(include_roster: true)
+  def api_json(include_roster: false)
     payload = {
       id: id.to_s,
       tournamentId: tournament_id.to_s,

--- a/api/app/models/tournament.rb
+++ b/api/app/models/tournament.rb
@@ -8,6 +8,8 @@ class Tournament < ApplicationRecord
   has_many :media_assets, dependent: :destroy
   has_many :sponsors, dependent: :destroy
   has_many :content_ingest_items, dependent: :destroy
+  has_many :game_day_notes, dependent: :destroy
+  has_many :prediction_polls, dependent: :destroy
 
   validates :name, presence: true
   validates :year, presence: true, numericality: { only_integer: true }

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
 
       namespace :public do
         resource :home, only: :show, controller: :home
+        resource :today, only: :show, controller: :today
+        resources :prediction_polls, path: "prediction-polls", only: [] do
+          post :vote, to: "prediction_votes#create"
+        end
         resources :tournaments, only: [ :index, :show ]
         get :schedule, to: "schedule#index"
         get :standings, to: "standings#index"
@@ -23,6 +27,9 @@ Rails.application.routes.draw do
         end
         resources :divisions, only: [ :index, :create, :update ]
         resources :teams, only: [ :index, :create, :update ]
+        resources :roster_entries, path: "roster-entries", only: [ :create, :update, :destroy ]
+        resources :game_day_notes, path: "game-day-notes", only: [ :index, :create, :update ]
+        resources :prediction_polls, path: "prediction-polls", only: [ :index, :create, :update ]
         resources :games, only: [ :index, :show, :create, :update ]
         resources :articles, only: [ :index, :show, :create, :update, :destroy ]
         resources :media_assets, path: "media-assets", only: [ :index, :show, :create, :update, :destroy ]

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
           post :recompute_standings, path: "recompute-standings", on: :member
         end
         resources :divisions, only: [ :index, :create, :update ]
-        resources :teams, only: [ :index, :create, :update ]
+        resources :teams, only: [ :index, :create, :update, :destroy ]
         resources :roster_entries, path: "roster-entries", only: [ :create, :update, :destroy ]
         resources :game_day_notes, path: "game-day-notes", only: [ :index, :create, :update ]
         resources :prediction_polls, path: "prediction-polls", only: [ :index, :create, :update ]

--- a/api/db/migrate/20260615000001_add_game_day_rosters_and_predictions.rb
+++ b/api/db/migrate/20260615000001_add_game_day_rosters_and_predictions.rb
@@ -34,7 +34,6 @@ class AddGameDayRostersAndPredictions < ActiveRecord::Migration[8.1]
       t.string :poll_type, null: false
       t.string :question, null: false
       t.string :status, null: false, default: "open"
-      t.boolean :show_results, null: false, default: true
       t.datetime :closes_at
 
       t.timestamps

--- a/api/db/migrate/20260615000001_add_game_day_rosters_and_predictions.rb
+++ b/api/db/migrate/20260615000001_add_game_day_rosters_and_predictions.rb
@@ -1,0 +1,56 @@
+class AddGameDayRostersAndPredictions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :game_day_notes do |t|
+      t.references :tournament, null: false, foreign_key: { on_delete: :cascade }
+      t.date :date, null: false
+      t.string :host_class
+      t.text :food_menu
+      t.text :announcement
+      t.text :sponsor_shoutout
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+    add_index :game_day_notes, [ :tournament_id, :date ], unique: true
+    add_index :game_day_notes, [ :date, :active ]
+
+    create_table :roster_entries do |t|
+      t.references :team, null: false, foreign_key: { on_delete: :cascade }
+      t.string :name, null: false
+      t.string :jersey_number
+      t.string :position
+      t.string :nickname
+      t.integer :sort_order, null: false, default: 0
+      t.boolean :active, null: false, default: true
+
+      t.timestamps
+    end
+    add_index :roster_entries, [ :team_id, :active, :sort_order ]
+    add_index :roster_entries, [ :team_id, :name ]
+
+    create_table :prediction_polls do |t|
+      t.references :tournament, null: false, foreign_key: { on_delete: :cascade }
+      t.references :game, foreign_key: { on_delete: :cascade }
+      t.string :poll_type, null: false
+      t.string :question, null: false
+      t.string :status, null: false, default: "open"
+      t.boolean :show_results, null: false, default: true
+      t.datetime :closes_at
+
+      t.timestamps
+    end
+    add_index :prediction_polls, [ :tournament_id, :poll_type ]
+    add_index :prediction_polls, [ :game_id, :poll_type ], unique: true, where: "game_id IS NOT NULL"
+    add_index :prediction_polls, [ :status, :closes_at ]
+
+    create_table :prediction_votes do |t|
+      t.references :prediction_poll, null: false, foreign_key: { on_delete: :cascade }
+      t.references :team, null: false, foreign_key: { on_delete: :cascade }
+      t.string :voter_token_hash, null: false
+
+      t.timestamps
+    end
+    add_index :prediction_votes, [ :prediction_poll_id, :voter_token_hash ], unique: true, name: "index_prediction_votes_on_poll_and_token_hash"
+    add_index :prediction_votes, [ :prediction_poll_id, :team_id ]
+  end
+end

--- a/api/db/migrate/20260615000002_add_unique_tournament_prediction_poll_index.rb
+++ b/api/db/migrate/20260615000002_add_unique_tournament_prediction_poll_index.rb
@@ -1,0 +1,15 @@
+class AddUniqueTournamentPredictionPollIndex < ActiveRecord::Migration[8.1]
+  def up
+    remove_index :prediction_polls, name: "index_prediction_polls_on_tournament_id_and_poll_type", if_exists: true
+    add_index :prediction_polls,
+      [ :tournament_id, :poll_type ],
+      unique: true,
+      where: "poll_type = 'tournament'",
+      name: "index_prediction_polls_on_unique_tournament_poll"
+  end
+
+  def down
+    remove_index :prediction_polls, name: "index_prediction_polls_on_unique_tournament_poll", if_exists: true
+    add_index :prediction_polls, [ :tournament_id, :poll_type ], name: "index_prediction_polls_on_tournament_id_and_poll_type"
+  end
+end

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -150,7 +150,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_000002) do
     t.bigint "game_id"
     t.string "poll_type", null: false
     t.string "question", null: false
-    t.boolean "show_results", default: true, null: false
     t.string "status", default: "open", null: false
     t.bigint "tournament_id", null: false
     t.datetime "updated_at", null: false

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_000002) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -157,7 +157,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_000001) do
     t.index ["game_id", "poll_type"], name: "index_prediction_polls_on_game_id_and_poll_type", unique: true, where: "(game_id IS NOT NULL)"
     t.index ["game_id"], name: "index_prediction_polls_on_game_id"
     t.index ["status", "closes_at"], name: "index_prediction_polls_on_status_and_closes_at"
-    t.index ["tournament_id", "poll_type"], name: "index_prediction_polls_on_tournament_id_and_poll_type"
+    t.index ["tournament_id", "poll_type"], name: "index_prediction_polls_on_unique_tournament_poll", unique: true, where: "((poll_type)::text = 'tournament'::text)"
     t.index ["tournament_id"], name: "index_prediction_polls_on_tournament_id"
   end
 

--- a/api/db/schema.rb
+++ b/api/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_15_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -79,6 +79,21 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_000002) do
     t.index ["slug"], name: "index_divisions_on_slug", unique: true
   end
 
+  create_table "game_day_notes", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.text "announcement"
+    t.datetime "created_at", null: false
+    t.date "date", null: false
+    t.text "food_menu"
+    t.string "host_class"
+    t.text "sponsor_shoutout"
+    t.bigint "tournament_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["date", "active"], name: "index_game_day_notes_on_date_and_active"
+    t.index ["tournament_id", "date"], name: "index_game_day_notes_on_tournament_id_and_date", unique: true
+    t.index ["tournament_id"], name: "index_game_day_notes_on_tournament_id"
+  end
+
   create_table "games", force: :cascade do |t|
     t.integer "away_score"
     t.bigint "away_team_id", null: false
@@ -127,6 +142,50 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_000002) do
     t.index ["tournament_id", "image_url"], name: "index_media_assets_on_tournament_id_and_image_url"
     t.index ["tournament_id", "source", "taken_at"], name: "index_media_assets_on_tournament_id_and_source_and_taken_at"
     t.index ["tournament_id"], name: "index_media_assets_on_tournament_id"
+  end
+
+  create_table "prediction_polls", force: :cascade do |t|
+    t.datetime "closes_at"
+    t.datetime "created_at", null: false
+    t.bigint "game_id"
+    t.string "poll_type", null: false
+    t.string "question", null: false
+    t.boolean "show_results", default: true, null: false
+    t.string "status", default: "open", null: false
+    t.bigint "tournament_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id", "poll_type"], name: "index_prediction_polls_on_game_id_and_poll_type", unique: true, where: "(game_id IS NOT NULL)"
+    t.index ["game_id"], name: "index_prediction_polls_on_game_id"
+    t.index ["status", "closes_at"], name: "index_prediction_polls_on_status_and_closes_at"
+    t.index ["tournament_id", "poll_type"], name: "index_prediction_polls_on_tournament_id_and_poll_type"
+    t.index ["tournament_id"], name: "index_prediction_polls_on_tournament_id"
+  end
+
+  create_table "prediction_votes", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "prediction_poll_id", null: false
+    t.bigint "team_id", null: false
+    t.datetime "updated_at", null: false
+    t.string "voter_token_hash", null: false
+    t.index ["prediction_poll_id", "team_id"], name: "index_prediction_votes_on_prediction_poll_id_and_team_id"
+    t.index ["prediction_poll_id", "voter_token_hash"], name: "index_prediction_votes_on_poll_and_token_hash", unique: true
+    t.index ["prediction_poll_id"], name: "index_prediction_votes_on_prediction_poll_id"
+    t.index ["team_id"], name: "index_prediction_votes_on_team_id"
+  end
+
+  create_table "roster_entries", force: :cascade do |t|
+    t.boolean "active", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "jersey_number"
+    t.string "name", null: false
+    t.string "nickname"
+    t.string "position"
+    t.integer "sort_order", default: 0, null: false
+    t.bigint "team_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["team_id", "active", "sort_order"], name: "index_roster_entries_on_team_id_and_active_and_sort_order"
+    t.index ["team_id", "name"], name: "index_roster_entries_on_team_id_and_name"
+    t.index ["team_id"], name: "index_roster_entries_on_team_id"
   end
 
   create_table "sponsors", force: :cascade do |t|
@@ -210,12 +269,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_000002) do
   add_foreign_key "article_links", "games", on_delete: :nullify
   add_foreign_key "article_links", "tournaments", on_delete: :cascade
   add_foreign_key "content_ingest_items", "tournaments", on_delete: :cascade
+  add_foreign_key "game_day_notes", "tournaments", on_delete: :cascade
   add_foreign_key "games", "divisions", on_delete: :nullify
   add_foreign_key "games", "teams", column: "away_team_id"
   add_foreign_key "games", "teams", column: "home_team_id"
   add_foreign_key "games", "tournaments", on_delete: :cascade
   add_foreign_key "media_assets", "games", on_delete: :nullify
   add_foreign_key "media_assets", "tournaments", on_delete: :cascade
+  add_foreign_key "prediction_polls", "games", on_delete: :cascade
+  add_foreign_key "prediction_polls", "tournaments", on_delete: :cascade
+  add_foreign_key "prediction_votes", "prediction_polls", on_delete: :cascade
+  add_foreign_key "prediction_votes", "teams", on_delete: :cascade
+  add_foreign_key "roster_entries", "teams", on_delete: :cascade
   add_foreign_key "sponsors", "tournaments", on_delete: :cascade
   add_foreign_key "standings", "teams", on_delete: :cascade
   add_foreign_key "standings", "tournaments", on_delete: :cascade

--- a/api/test/controllers/admin_game_day_controller_test.rb
+++ b/api/test/controllers/admin_game_day_controller_test.rb
@@ -16,16 +16,16 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "staff can upsert game-day note and create prediction poll" do
-    post "/api/v1/admin/game-day-notes",
-      params: { gameDayNote: { tournamentId: @tournament.id, date: "2026-07-03", hostClass: "Class of 2006", foodMenu: "BBQ" } },
+    post "/api/v1/admin/game-day-notes?tournamentId=#{@tournament.id}",
+      params: { gameDayNote: { date: "2026-07-03", hostClass: "Class of 2006", foodMenu: "BBQ" } },
       headers: auth_headers,
       as: :json
 
     assert_response :created
     assert_equal "Class of 2006", JSON.parse(response.body).dig("gameDayNote", "hostClass")
 
-    post "/api/v1/admin/prediction-polls",
-      params: { predictionPoll: { tournamentId: @tournament.id, gameId: @game.id, pollType: "game" } },
+    post "/api/v1/admin/prediction-polls?tournamentId=#{@tournament.id}",
+      params: { predictionPoll: { gameId: @game.id, pollType: "game" } },
       headers: auth_headers,
       as: :json
 
@@ -36,7 +36,7 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "staff can add roster entry" do
-    post "/api/v1/admin/roster-entries",
+    post "/api/v1/admin/roster-entries?tournamentId=#{@tournament.id}",
       params: { rosterEntry: { teamId: @home.id, name: "Juan Duenas", jerseyNumber: "10", position: "G" } },
       headers: auth_headers,
       as: :json
@@ -46,11 +46,8 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
     assert_equal "10", @home.roster_entries.first.jersey_number
   end
 
-  test "admin mutations are scoped to selected tournament" do
-    other_tournament = Tournament.create!(name: "FD Alumni Basketball Tournament", year: 2025, start_date: Date.new(2025, 7, 3), end_date: Date.new(2025, 7, 24), status: "completed")
-    other_away = other_tournament.teams.create!(class_year_label: "2015", display_name: "Class of 2015", division: "Maroon")
-    other_home = other_tournament.teams.create!(class_year_label: "2014", display_name: "Class of 2014", division: "Maroon")
-    other_game = other_tournament.games.create!(home_team: other_home, away_team: other_away, start_time: Time.zone.local(2025, 7, 3, 18, 30), status: "scheduled")
+  test "admin updates and deletes are scoped to selected tournament" do
+    other_tournament, other_home, other_game = build_other_tournament_context
     other_note = other_tournament.game_day_notes.create!(date: Date.new(2025, 7, 3), host_class: "Other host")
     other_poll = other_tournament.prediction_polls.create!(game: other_game, poll_type: "game", question: "Other poll")
     other_roster_entry = other_home.roster_entries.create!(name: "Other Player")
@@ -77,7 +74,64 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
     assert RosterEntry.exists?(other_roster_entry.id)
   end
 
+  test "admin creates ignore cross-tournament ids from request bodies" do
+    other_tournament, other_home, other_game = build_other_tournament_context
+
+    assert_difference -> { @tournament.game_day_notes.count }, 1 do
+      assert_no_difference -> { other_tournament.game_day_notes.count } do
+        post "/api/v1/admin/game-day-notes?tournamentId=#{@tournament.id}",
+          params: { gameDayNote: { tournamentId: other_tournament.id, date: "2026-07-03", hostClass: "Selected host" } },
+          headers: auth_headers,
+          as: :json
+      end
+    end
+    assert_response :created
+    assert_equal @tournament.id.to_s, JSON.parse(response.body).dig("gameDayNote", "tournamentId")
+
+    assert_difference -> { @tournament.prediction_polls.count }, 1 do
+      assert_no_difference -> { other_tournament.prediction_polls.count } do
+        post "/api/v1/admin/prediction-polls?tournamentId=#{@tournament.id}",
+          params: { predictionPoll: { tournamentId: other_tournament.id, pollType: "tournament" } },
+          headers: auth_headers,
+          as: :json
+      end
+    end
+    assert_response :created
+    assert_equal @tournament.id.to_s, JSON.parse(response.body).dig("predictionPoll", "tournamentId")
+
+    assert_no_difference -> { RosterEntry.count } do
+      post "/api/v1/admin/roster-entries?tournamentId=#{@tournament.id}",
+        params: { rosterEntry: { teamId: other_home.id, name: "Wrong Tournament" } },
+        headers: auth_headers,
+        as: :json
+    end
+    assert_response :not_found
+
+    assert_no_difference -> { PredictionPoll.count } do
+      post "/api/v1/admin/prediction-polls?tournamentId=#{@tournament.id}",
+        params: { predictionPoll: { gameId: other_game.id, pollType: "game" } },
+        headers: auth_headers,
+        as: :json
+    end
+    assert_response :not_found
+  end
+
   private
+
+  def build_other_tournament_context
+    other_tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2025,
+      start_date: Date.new(2025, 7, 3),
+      end_date: Date.new(2025, 7, 24),
+      status: "completed"
+    )
+    other_away = other_tournament.teams.create!(class_year_label: "2015", display_name: "Class of 2015", division: "Maroon")
+    other_home = other_tournament.teams.create!(class_year_label: "2014", display_name: "Class of 2014", division: "Maroon")
+    other_game = other_tournament.games.create!(home_team: other_home, away_team: other_away, start_time: Time.zone.local(2025, 7, 3, 18, 30), status: "scheduled")
+
+    [ other_tournament, other_home, other_game ]
+  end
 
   def auth_headers
     { "Authorization" => "Bearer test_token_#{@user.id}" }

--- a/api/test/controllers/admin_game_day_controller_test.rb
+++ b/api/test/controllers/admin_game_day_controller_test.rb
@@ -116,6 +116,20 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "duplicate tournament prediction poll returns validation error" do
+    @tournament.prediction_polls.create!(poll_type: "tournament", question: "Who wins the tournament?")
+
+    assert_no_difference -> { PredictionPoll.count } do
+      post "/api/v1/admin/prediction-polls?tournamentId=#{@tournament.id}",
+        params: { predictionPoll: { pollType: "tournament" } },
+        headers: auth_headers,
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "tournament prediction poll"
+  end
+
   test "invalid game-day note date returns validation error" do
     assert_no_difference -> { GameDayNote.count } do
       post "/api/v1/admin/game-day-notes?tournamentId=#{@tournament.id}",

--- a/api/test/controllers/admin_game_day_controller_test.rb
+++ b/api/test/controllers/admin_game_day_controller_test.rb
@@ -116,6 +116,27 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
     assert_response :not_found
   end
 
+  test "invalid game-day note date returns validation error" do
+    assert_no_difference -> { GameDayNote.count } do
+      post "/api/v1/admin/game-day-notes?tournamentId=#{@tournament.id}",
+        params: { gameDayNote: { date: "next-Friday", hostClass: "Class of 2006" } },
+        headers: auth_headers,
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"], "Date must be a valid ISO 8601 date"
+
+    note = @tournament.game_day_notes.create!(date: Date.new(2026, 7, 3), host_class: "Original host")
+    patch "/api/v1/admin/game-day-notes/#{note.id}?tournamentId=#{@tournament.id}",
+      params: { gameDayNote: { date: "bad-date", hostClass: "Changed host" } },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert_equal "Original host", note.reload.host_class
+  end
+
   private
 
   def build_other_tournament_context

--- a/api/test/controllers/admin_game_day_controller_test.rb
+++ b/api/test/controllers/admin_game_day_controller_test.rb
@@ -46,6 +46,37 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
     assert_equal "10", @home.roster_entries.first.jersey_number
   end
 
+  test "admin mutations are scoped to selected tournament" do
+    other_tournament = Tournament.create!(name: "FD Alumni Basketball Tournament", year: 2025, start_date: Date.new(2025, 7, 3), end_date: Date.new(2025, 7, 24), status: "completed")
+    other_away = other_tournament.teams.create!(class_year_label: "2015", display_name: "Class of 2015", division: "Maroon")
+    other_home = other_tournament.teams.create!(class_year_label: "2014", display_name: "Class of 2014", division: "Maroon")
+    other_game = other_tournament.games.create!(home_team: other_home, away_team: other_away, start_time: Time.zone.local(2025, 7, 3, 18, 30), status: "scheduled")
+    other_note = other_tournament.game_day_notes.create!(date: Date.new(2025, 7, 3), host_class: "Other host")
+    other_poll = other_tournament.prediction_polls.create!(game: other_game, poll_type: "game", question: "Other poll")
+    other_roster_entry = other_home.roster_entries.create!(name: "Other Player")
+
+    patch "/api/v1/admin/game-day-notes/#{other_note.id}",
+      params: { tournamentId: @tournament.id, gameDayNote: { hostClass: "Wrong host" } },
+      headers: auth_headers,
+      as: :json
+    assert_response :not_found
+    assert_equal "Other host", other_note.reload.host_class
+
+    patch "/api/v1/admin/prediction-polls/#{other_poll.id}",
+      params: { tournamentId: @tournament.id, predictionPoll: { status: "closed" } },
+      headers: auth_headers,
+      as: :json
+    assert_response :not_found
+    assert_equal "open", other_poll.reload.status
+
+    delete "/api/v1/admin/roster-entries/#{other_roster_entry.id}",
+      params: { tournamentId: @tournament.id },
+      headers: auth_headers,
+      as: :json
+    assert_response :not_found
+    assert RosterEntry.exists?(other_roster_entry.id)
+  end
+
   private
 
   def auth_headers

--- a/api/test/controllers/admin_game_day_controller_test.rb
+++ b/api/test/controllers/admin_game_day_controller_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(email: "admin-gameday@example.com", clerk_id: "test_clerk_gameday", role: "admin")
+    @tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2026,
+      start_date: Date.new(2026, 7, 3),
+      end_date: Date.new(2026, 7, 24),
+      status: "upcoming"
+    )
+    @away = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Maroon")
+    @home = @tournament.teams.create!(class_year_label: "2016", display_name: "Class of 2016", division: "Maroon")
+    @game = @tournament.games.create!(home_team: @home, away_team: @away, start_time: Time.zone.local(2026, 7, 3, 18, 30), status: "scheduled")
+  end
+
+  test "staff can upsert game-day note and create prediction poll" do
+    post "/api/v1/admin/game-day-notes",
+      params: { gameDayNote: { tournamentId: @tournament.id, date: "2026-07-03", hostClass: "Class of 2006", foodMenu: "BBQ" } },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :created
+    assert_equal "Class of 2006", JSON.parse(response.body).dig("gameDayNote", "hostClass")
+
+    post "/api/v1/admin/prediction-polls",
+      params: { predictionPoll: { tournamentId: @tournament.id, gameId: @game.id, pollType: "game" } },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal "Who wins this game?", body.dig("predictionPoll", "question")
+    assert_equal "open", body.dig("predictionPoll", "status")
+  end
+
+  test "staff can add roster entry" do
+    post "/api/v1/admin/roster-entries",
+      params: { rosterEntry: { teamId: @home.id, name: "Juan Duenas", jerseyNumber: "10", position: "G" } },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :created
+    assert_equal "Juan Duenas", JSON.parse(response.body).dig("rosterEntry", "name")
+    assert_equal "10", @home.roster_entries.first.jersey_number
+  end
+
+  private
+
+  def auth_headers
+    { "Authorization" => "Bearer test_token_#{@user.id}" }
+  end
+end

--- a/api/test/controllers/admin_teams_controller_test.rb
+++ b/api/test/controllers/admin_teams_controller_test.rb
@@ -53,6 +53,32 @@ class AdminTeamsControllerTest < ActionDispatch::IntegrationTest
     assert_nil body.dig("team", "division")
   end
 
+  test "team can be deleted when it has no games" do
+    removable = @tournament.teams.create!(class_year_label: "2018", display_name: "Class of 2018", division: "Gold")
+
+    delete "/api/v1/admin/teams/#{removable.id}",
+      params: { tournamentId: @tournament.id },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :no_content
+    assert_not Team.exists?(removable.id)
+  end
+
+  test "team with games cannot be deleted" do
+    opponent = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Maroon")
+    @tournament.games.create!(home_team: @team, away_team: opponent, start_time: Time.zone.local(2026, 7, 3, 18, 30), status: "scheduled")
+
+    delete "/api/v1/admin/teams/#{@team.id}",
+      params: { tournamentId: @tournament.id },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert Team.exists?(@team.id)
+    assert_includes JSON.parse(response.body)["errors"].join, "Cannot delete record"
+  end
+
   test "missing team returns JSON 404" do
     patch "/api/v1/admin/teams/999999",
       params: { team: { division: "Gold" } },

--- a/api/test/controllers/public_home_controller_test.rb
+++ b/api/test/controllers/public_home_controller_test.rb
@@ -25,6 +25,6 @@ class PublicHomeControllerTest < ActionDispatch::IntegrationTest
     assert_equal "BBQ plates", body.dig("gameDayNote", "foodMenu")
     assert_equal @game.id.to_s, body.dig("todayGames", 0, "id")
     assert_equal @poll.id.to_s, body.dig("predictionPolls", 0, "id")
-    assert_equal true, body.dig("predictionPolls", 0, "resultsVisible")
+    assert_nil body.dig("predictionPolls", 0, "resultsVisible")
   end
 end

--- a/api/test/controllers/public_home_controller_test.rb
+++ b/api/test/controllers/public_home_controller_test.rb
@@ -12,16 +12,19 @@ class PublicHomeControllerTest < ActionDispatch::IntegrationTest
     @away = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Maroon")
     @home = @tournament.teams.create!(class_year_label: "2016", display_name: "Class of 2016", division: "Maroon")
     @game = @tournament.games.create!(home_team: @home, away_team: @away, start_time: Time.zone.now.change(hour: 18, min: 30), status: "scheduled")
+    @poll = @tournament.prediction_polls.create!(game: @game, poll_type: "game", question: "Who wins this game?")
     @tournament.game_day_notes.create!(date: Time.zone.today, host_class: "Class of 2006", food_menu: "BBQ plates", announcement: "Doors open at 6")
   end
 
   test "home endpoint includes active game-day note for today" do
-    get "/api/v1/public/home"
+    get "/api/v1/public/home", headers: { "X-FD-Voter-Token" => "home-device" }
 
     assert_response :success
     body = JSON.parse(response.body)
     assert_equal @tournament.id.to_s, body.dig("tournament", "id")
     assert_equal "BBQ plates", body.dig("gameDayNote", "foodMenu")
     assert_equal @game.id.to_s, body.dig("todayGames", 0, "id")
+    assert_equal @poll.id.to_s, body.dig("predictionPolls", 0, "id")
+    assert_equal true, body.dig("predictionPolls", 0, "resultsVisible")
   end
 end

--- a/api/test/controllers/public_home_controller_test.rb
+++ b/api/test/controllers/public_home_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class PublicHomeControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2099,
+      start_date: Date.new(2099, 7, 3),
+      end_date: Date.new(2099, 7, 24),
+      status: "upcoming"
+    )
+    @away = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Maroon")
+    @home = @tournament.teams.create!(class_year_label: "2016", display_name: "Class of 2016", division: "Maroon")
+    @game = @tournament.games.create!(home_team: @home, away_team: @away, start_time: Time.zone.now.change(hour: 18, min: 30), status: "scheduled")
+    @tournament.game_day_notes.create!(date: Time.zone.today, host_class: "Class of 2006", food_menu: "BBQ plates", announcement: "Doors open at 6")
+  end
+
+  test "home endpoint includes active game-day note for today" do
+    get "/api/v1/public/home"
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal @tournament.id.to_s, body.dig("tournament", "id")
+    assert_equal "BBQ plates", body.dig("gameDayNote", "foodMenu")
+    assert_equal @game.id.to_s, body.dig("todayGames", 0, "id")
+  end
+end

--- a/api/test/controllers/public_today_and_predictions_controller_test.rb
+++ b/api/test/controllers/public_today_and_predictions_controller_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class PublicTodayAndPredictionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2026,
+      start_date: Date.new(2026, 7, 3),
+      end_date: Date.new(2026, 7, 24),
+      status: "upcoming"
+    )
+    @away = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Maroon")
+    @home = @tournament.teams.create!(class_year_label: "2016", display_name: "Class of 2016", division: "Maroon")
+    @home.roster_entries.create!(name: "Juan Duenas", jersey_number: "10", position: "G", nickname: "JD")
+    @game = @tournament.games.create!(
+      home_team: @home,
+      away_team: @away,
+      start_time: Time.zone.local(2026, 7, 3, 18, 30),
+      status: "scheduled",
+      division: "Maroon",
+      venue: "The Jungle"
+    )
+    @tournament.game_day_notes.create!(date: Date.new(2026, 7, 3), host_class: "Class of 2006", food_menu: "BBQ", announcement: "Doors open at 6")
+    @poll = @tournament.prediction_polls.create!(game: @game, poll_type: "game", question: "Who wins this game?")
+  end
+
+  test "today endpoint returns game-day notes rosters and prediction polls" do
+    get "/api/v1/public/today", params: { year: 2026, date: "2026-07-03" }
+
+    assert_response :success
+    body = JSON.parse(response.body)
+    assert_equal "2026-07-03", body["date"]
+    assert_equal "Class of 2006", body.dig("gameDayNote", "hostClass")
+    assert_equal 1, body["games"].length
+    assert_equal "Juan Duenas", body.dig("games", 0, "homeTeam", "rosterEntries", 0, "name")
+    assert_equal @poll.id.to_s, body.dig("predictionPolls", 0, "id")
+  end
+
+  test "anonymous prediction vote can be changed for same device token" do
+    post "/api/v1/public/prediction-polls/#{@poll.id}/vote",
+      params: { predictionVote: { voterToken: "device-123", teamId: @away.id } },
+      as: :json
+
+    assert_response :success
+    assert_equal @away.id.to_s, JSON.parse(response.body).dig("predictionPoll", "selectedTeamId")
+    assert_equal 1, @poll.prediction_votes.count
+
+    post "/api/v1/public/prediction-polls/#{@poll.id}/vote",
+      params: { predictionVote: { voterToken: "device-123", teamId: @home.id } },
+      as: :json
+
+    assert_response :success
+    assert_equal 1, @poll.prediction_votes.count
+    assert_equal @home.id, @poll.prediction_votes.first.team_id
+    assert_equal @home.id.to_s, JSON.parse(response.body).dig("predictionPoll", "selectedTeamId")
+  end
+
+  test "closed prediction poll rejects votes" do
+    @poll.update!(status: "closed")
+
+    post "/api/v1/public/prediction-polls/#{@poll.id}/vote",
+      params: { predictionVote: { voterToken: "device-closed", teamId: @away.id } },
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "Prediction poll is closed"
+  end
+end

--- a/api/test/models/game_test.rb
+++ b/api/test/models/game_test.rb
@@ -12,6 +12,23 @@ class GameTest < ActiveSupport::TestCase
     @team = @tournament.teams.create!(class_year_label: "TBD", display_name: "Class TBD", division: "Special")
   end
 
+  test "api json normalizes partner links without a scheme" do
+    opponent = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Special")
+    game = @tournament.games.create!(
+      home_team: @team,
+      away_team: opponent,
+      start_time: Time.zone.local(2026, 7, 3, 18, 0),
+      status: "scheduled",
+      ticket_url: "guamtime.net/tickets/fd",
+      stream_url: "clutchguam.com/live/fd"
+    )
+
+    payload = game.api_json
+
+    assert_equal "https://guamtime.net/tickets/fd", payload[:ticketUrl]
+    assert_equal "https://clutchguam.com/live/fd", payload[:streamUrl]
+  end
+
   test "allows explicitly marked placeholder games with the same team" do
     game = @tournament.games.build(
       home_team: @team,

--- a/api/test/models/prediction_poll_test.rb
+++ b/api/test/models/prediction_poll_test.rb
@@ -34,6 +34,18 @@ class PredictionPollTest < ActiveSupport::TestCase
     assert_match "tournament", index.where.to_s
   end
 
+  test "api_json always exposes prediction totals" do
+    @poll.update!(show_results: false)
+    @poll.prediction_votes.create!(team: @away, voter_token_hash: PredictionVote.token_hash("device-1"))
+
+    payload = @poll.reload.api_json
+
+    assert_equal true, payload[:showResults]
+    assert_equal true, payload[:resultsVisible]
+    assert_equal 1, payload[:totalVotes]
+    assert_equal 1, payload[:options].find { |option| option[:teamId] == @away.id.to_s }[:votes]
+  end
+
   test "api_json uses preloaded prediction votes for selected vote and totals" do
     voter_hash = PredictionVote.token_hash("device-1")
     @poll.prediction_votes.create!(team: @away, voter_token_hash: voter_hash)

--- a/api/test/models/prediction_poll_test.rb
+++ b/api/test/models/prediction_poll_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class PredictionPollTest < ActiveSupport::TestCase
+  setup do
+    @tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2026,
+      start_date: Date.new(2026, 7, 3),
+      end_date: Date.new(2026, 7, 24),
+      status: "upcoming"
+    )
+    @away = @tournament.teams.create!(class_year_label: "2017", display_name: "Class of 2017", division: "Maroon")
+    @home = @tournament.teams.create!(class_year_label: "2016", display_name: "Class of 2016", division: "Maroon")
+    @game = @tournament.games.create!(home_team: @home, away_team: @away, start_time: Time.zone.local(2026, 7, 3, 18, 30), status: "scheduled")
+    @poll = @tournament.prediction_polls.create!(game: @game, poll_type: "game", question: "Who wins this game?")
+  end
+
+  test "api_json uses preloaded prediction votes for selected vote and totals" do
+    voter_hash = PredictionVote.token_hash("device-1")
+    @poll.prediction_votes.create!(team: @away, voter_token_hash: voter_hash)
+    @poll.prediction_votes.create!(team: @home, voter_token_hash: PredictionVote.token_hash("device-2"))
+    poll = PredictionPoll.includes(:prediction_votes, game: [ :home_team, :away_team ]).find(@poll.id)
+
+    payload = nil
+    queries = capture_sql do
+      payload = poll.api_json(voter_token_hash: voter_hash)
+    end
+
+    prediction_vote_queries = queries.select { |sql| sql.include?("prediction_votes") }
+    assert_empty prediction_vote_queries
+    assert_equal @away.id.to_s, payload[:selectedTeamId]
+    assert_equal 2, payload[:totalVotes]
+    assert_equal 1, payload[:options].find { |option| option[:teamId] == @away.id.to_s }[:votes]
+  end
+
+  private
+
+  def capture_sql
+    queries = []
+    subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |_name, _started, _finished, _id, payload|
+      next if payload[:name] == "SCHEMA" || payload[:cached]
+
+      queries << payload[:sql]
+    end
+    yield
+    queries
+  ensure
+    ActiveSupport::Notifications.unsubscribe(subscriber) if subscriber
+  end
+end

--- a/api/test/models/prediction_poll_test.rb
+++ b/api/test/models/prediction_poll_test.rb
@@ -15,6 +15,25 @@ class PredictionPollTest < ActiveSupport::TestCase
     @poll = @tournament.prediction_polls.create!(game: @game, poll_type: "game", question: "Who wins this game?")
   end
 
+  test "allows only one tournament prediction poll per tournament" do
+    @tournament.prediction_polls.create!(poll_type: "tournament", question: "Who wins the tournament?")
+    duplicate = @tournament.prediction_polls.build(poll_type: "tournament", question: "Who wins it now?")
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:poll_type], "already has a tournament prediction poll"
+  end
+
+  test "database has unique tournament prediction poll index" do
+    index = ActiveRecord::Base.connection.indexes(:prediction_polls).find do |candidate|
+      candidate.name == "index_prediction_polls_on_unique_tournament_poll"
+    end
+
+    assert index
+    assert index.unique
+    assert_equal [ "tournament_id", "poll_type" ], index.columns
+    assert_match "tournament", index.where.to_s
+  end
+
   test "api_json uses preloaded prediction votes for selected vote and totals" do
     voter_hash = PredictionVote.token_hash("device-1")
     @poll.prediction_votes.create!(team: @away, voter_token_hash: voter_hash)

--- a/api/test/models/prediction_poll_test.rb
+++ b/api/test/models/prediction_poll_test.rb
@@ -34,14 +34,13 @@ class PredictionPollTest < ActiveSupport::TestCase
     assert_match "tournament", index.where.to_s
   end
 
-  test "api_json always exposes prediction totals" do
-    @poll.update!(show_results: false)
+  test "api_json exposes prediction totals" do
     @poll.prediction_votes.create!(team: @away, voter_token_hash: PredictionVote.token_hash("device-1"))
 
     payload = @poll.reload.api_json
 
-    assert_equal true, payload[:showResults]
-    assert_equal true, payload[:resultsVisible]
+    assert_not payload.key?(:showResults)
+    assert_not payload.key?(:resultsVisible)
     assert_equal 1, payload[:totalVotes]
     assert_equal 1, payload[:options].find { |option| option[:teamId] == @away.id.to_s }[:votes]
   end

--- a/api/test/models/team_test.rb
+++ b/api/test/models/team_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class TeamTest < ActiveSupport::TestCase
+  setup do
+    @tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2026,
+      start_date: Date.new(2026, 7, 3),
+      end_date: Date.new(2026, 7, 24),
+      status: "upcoming"
+    )
+    @team = @tournament.teams.create!(class_year_label: "2016", display_name: "Class of 2016", division: "Maroon")
+  end
+
+  test "api json omits rosters unless requested" do
+    @team.roster_entries.create!(name: "Juan Duenas", jersey_number: "10")
+
+    assert_not @team.api_json.key?(:rosterEntries)
+    assert_equal "Juan Duenas", @team.api_json(include_roster: true).dig(:rosterEntries, 0, :name)
+  end
+end

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -7,6 +7,12 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://fd-alumni-hub.netlify.app/today</loc>
+    <lastmod>2026-06-15</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.98</priority>
+  </url>
+  <url>
     <loc>https://fd-alumni-hub.netlify.app/schedule</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>daily</changefreq>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthProvider } from './contexts/AuthContext'
 import { PublicLayout } from './components/PublicLayout'
 import { AdminLayout } from './components/AdminLayout'
 import { HomePage } from './pages/public/HomePage'
+import { TodayPage } from './pages/public/TodayPage'
 import { SchedulePage } from './pages/public/SchedulePage'
 import { StandingsPage } from './pages/public/StandingsPage'
 import { WatchPage } from './pages/public/WatchPage'
@@ -15,6 +16,7 @@ import { SponsorsPage } from './pages/public/SponsorsPage'
 import { AdminOverviewPage } from './pages/admin/AdminOverviewPage'
 import { AdminTournamentsPage } from './pages/admin/AdminTournamentsPage'
 import { AdminGamesPage } from './pages/admin/AdminGamesPage'
+import { AdminGameDayPage } from './pages/admin/AdminGameDayPage'
 import { AdminStandingsPage } from './pages/admin/AdminStandingsPage'
 import { AdminDivisionsPage } from './pages/admin/AdminDivisionsPage'
 import { AdminLinksPage } from './pages/admin/AdminLinksPage'
@@ -33,6 +35,7 @@ export function App() {
       <Routes>
         <Route element={<PublicLayout />}>
           <Route index element={<HomePage />} />
+          <Route path="today" element={<TodayPage />} />
           <Route path="schedule" element={<SchedulePage />} />
           <Route path="standings" element={<StandingsPage />} />
           <Route path="watch" element={<WatchPage />} />
@@ -46,6 +49,7 @@ export function App() {
           <Route index element={<AdminOverviewPage />} />
           <Route path="tournaments" element={<AdminTournamentsPage />} />
           <Route path="games" element={<AdminGamesPage />} />
+          <Route path="game-day" element={<AdminGameDayPage />} />
           <Route path="standings" element={<AdminStandingsPage />} />
           <Route path="divisions" element={<AdminDivisionsPage />} />
           <Route path="links" element={<AdminLinksPage />} />

--- a/web/src/components/AdminLayout.tsx
+++ b/web/src/components/AdminLayout.tsx
@@ -56,6 +56,7 @@ const navSections: NavSection[] = [
     items: [
       { to: '/admin/divisions', label: 'Teams', icon: IconUsers },
       { to: '/admin/games', label: 'Games', icon: IconCalendar },
+      { to: '/admin/game-day', label: 'Game Day', icon: IconHome },
       { to: '/admin/standings', label: 'Standings', icon: IconChart },
     ],
   },

--- a/web/src/components/PredictionPollCard.tsx
+++ b/web/src/components/PredictionPollCard.tsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import type { PredictionPoll } from '../lib/types'
+
+export function PredictionPollCard({ poll, onVote, compact = false }: { poll: PredictionPoll; onVote: (poll: PredictionPoll, teamId: string) => Promise<void>; compact?: boolean }) {
+  const [savingTeamId, setSavingTeamId] = useState<string | null>(null)
+
+  const choose = async (teamId: string) => {
+    setSavingTeamId(teamId)
+    try {
+      await onVote(poll, teamId)
+    } finally {
+      setSavingTeamId(null)
+    }
+  }
+
+  return (
+    <div className={`prediction-card ${compact ? 'compact' : ''}`}>
+      <div className="prediction-card-head">
+        <span>{poll.open ? 'Voting open' : 'Voting closed'}</span>
+        <strong>{poll.question}</strong>
+      </div>
+      <div className="prediction-options">
+        {poll.options.map((option) => (
+          <button key={option.teamId} type="button" className={option.selected ? 'selected' : ''} onClick={() => choose(option.teamId)} disabled={!poll.open || savingTeamId !== null}>
+            <span>{option.displayName}</span>
+            <small>{option.percent ?? 0}% · {option.votes ?? 0} votes</small>
+          </button>
+        ))}
+      </div>
+      {poll.selectedTeamId && poll.open && <small className="prediction-note">Vote saved. Tap another team to change it.</small>}
+    </div>
+  )
+}

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet } from 'react-router-dom'
 import { useState } from 'react'
 import { IconClose, IconMenu, IconShield } from './Icons'
+import { externalHref } from '../lib/urls'
 
 const navItems = [
   { to: '/', label: 'Home' },
@@ -56,8 +57,8 @@ export function PublicLayout() {
           <p>A central guide to schedule, standings, tickets, streams, coverage, sponsors, and tournament history.</p>
         </div>
         <div className="footer-links">
-          <a href={import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net'} target="_blank" rel="noreferrer">GuamTime</a>
-          <a href={import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com'} target="_blank" rel="noreferrer">Clutch</a>
+          <a href={externalHref(import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net') || undefined} target="_blank" rel="noreferrer">GuamTime</a>
+          <a href={externalHref(import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com') || undefined} target="_blank" rel="noreferrer">Clutch</a>
         </div>
       </footer>
     </div>

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -4,6 +4,7 @@ import { IconClose, IconMenu, IconShield } from './Icons'
 
 const navItems = [
   { to: '/', label: 'Home' },
+  { to: '/today', label: 'Today' },
   { to: '/schedule', label: 'Schedule' },
   { to: '/standings', label: 'Standings' },
   { to: '/watch', label: 'Watch' },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -171,8 +171,9 @@ export const api = {
   adminUpdateDivision: (id: string, payload: Partial<Division>) => request<{ division: Division }>(`/admin/divisions/${id}`, json('PATCH', { division: payload })),
 
   adminTeams: (tournamentId?: string | null) => request<{ teams: Team[] }>(`/admin/teams${query({ tournamentId })}`),
-  adminCreateTeam: (payload: Partial<Team>) => request<{ team: Team }>('/admin/teams', json('POST', { team: payload })),
-  adminUpdateTeam: (id: string, payload: Partial<Team>) => request<{ team: Team }>(`/admin/teams/${id}`, json('PATCH', { team: payload })),
+  adminCreateTeam: (payload: Partial<Team>) => request<{ team: Team }>(`/admin/teams${query({ tournamentId: payload.tournamentId })}`, json('POST', { team: payload })),
+  adminUpdateTeam: (id: string, payload: Partial<Team>, tournamentId?: string | null) => request<{ team: Team }>(`/admin/teams/${id}${query({ tournamentId })}`, json('PATCH', { team: payload })),
+  adminDeleteTeam: (id: string, tournamentId?: string | null) => request<void>(`/admin/teams/${id}${query({ tournamentId })}`, { method: 'DELETE' }),
   adminCreateRosterEntry: (payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries${query({ tournamentId })}`, json('POST', { rosterEntry: payload })),
   adminUpdateRosterEntry: (id: string, payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries/${id}${query({ tournamentId })}`, json('PATCH', { rosterEntry: payload })),
   adminDeleteRosterEntry: (id: string, tournamentId?: string | null) => request<void>(`/admin/roster-entries/${id}${query({ tournamentId })}`, { method: 'DELETE' }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -130,6 +130,7 @@ export const api = {
     todayGames: Game[]
     liveGames: Game[]
     latestNews: Article[]
+    gameDayNote: GameDayNote | null
   }>('/public/home'),
   publicToday: (params: { tournamentId?: string | null; year?: number | null; date?: string | null } = {}, voterToken?: string | null) =>
     request<{

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -173,7 +173,7 @@ export const api = {
   adminTeams: (tournamentId?: string | null) => request<{ teams: Team[] }>(`/admin/teams${query({ tournamentId })}`),
   adminCreateTeam: (payload: Partial<Team>) => request<{ team: Team }>('/admin/teams', json('POST', { team: payload })),
   adminUpdateTeam: (id: string, payload: Partial<Team>) => request<{ team: Team }>(`/admin/teams/${id}`, json('PATCH', { team: payload })),
-  adminCreateRosterEntry: (payload: Partial<RosterEntry>) => request<{ rosterEntry: RosterEntry }>('/admin/roster-entries', json('POST', { rosterEntry: payload })),
+  adminCreateRosterEntry: (payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries${query({ tournamentId })}`, json('POST', { rosterEntry: payload })),
   adminUpdateRosterEntry: (id: string, payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries/${id}${query({ tournamentId })}`, json('PATCH', { rosterEntry: payload })),
   adminDeleteRosterEntry: (id: string, tournamentId?: string | null) => request<void>(`/admin/roster-entries/${id}${query({ tournamentId })}`, { method: 'DELETE' }),
 
@@ -184,9 +184,9 @@ export const api = {
     games: Game[]
     predictionPolls: PredictionPoll[]
   }>(`/admin/game-day-notes${query(params)}`),
-  adminSaveGameDayNote: (payload: Partial<GameDayNote>) => request<{ gameDayNote: GameDayNote }>('/admin/game-day-notes', json('POST', { gameDayNote: payload })),
+  adminSaveGameDayNote: (payload: Partial<GameDayNote>) => request<{ gameDayNote: GameDayNote }>(`/admin/game-day-notes${query({ tournamentId: payload.tournamentId })}`, json('POST', { gameDayNote: payload })),
   adminPredictionPolls: (tournamentId?: string | null) => request<{ tournament: Tournament; predictionPolls: PredictionPoll[] }>(`/admin/prediction-polls${query({ tournamentId })}`),
-  adminCreatePredictionPoll: (payload: Partial<PredictionPoll>) => request<{ predictionPoll: PredictionPoll }>('/admin/prediction-polls', json('POST', { predictionPoll: payload })),
+  adminCreatePredictionPoll: (payload: Partial<PredictionPoll>) => request<{ predictionPoll: PredictionPoll }>(`/admin/prediction-polls${query({ tournamentId: payload.tournamentId })}`, json('POST', { predictionPoll: payload })),
   adminUpdatePredictionPoll: (id: string, payload: Partial<PredictionPoll>, tournamentId?: string | null) => request<{ predictionPoll: PredictionPoll }>(`/admin/prediction-polls/${id}${query({ tournamentId })}`, json('PATCH', { predictionPoll: payload })),
 
   adminGames: (tournamentId?: string | null) => request<{ games: Game[] }>(`/admin/games${query({ tournamentId })}`),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -174,8 +174,8 @@ export const api = {
   adminCreateTeam: (payload: Partial<Team>) => request<{ team: Team }>('/admin/teams', json('POST', { team: payload })),
   adminUpdateTeam: (id: string, payload: Partial<Team>) => request<{ team: Team }>(`/admin/teams/${id}`, json('PATCH', { team: payload })),
   adminCreateRosterEntry: (payload: Partial<RosterEntry>) => request<{ rosterEntry: RosterEntry }>('/admin/roster-entries', json('POST', { rosterEntry: payload })),
-  adminUpdateRosterEntry: (id: string, payload: Partial<RosterEntry>) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries/${id}`, json('PATCH', { rosterEntry: payload })),
-  adminDeleteRosterEntry: (id: string) => request<void>(`/admin/roster-entries/${id}`, { method: 'DELETE' }),
+  adminUpdateRosterEntry: (id: string, payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries/${id}${query({ tournamentId })}`, json('PATCH', { rosterEntry: payload })),
+  adminDeleteRosterEntry: (id: string, tournamentId?: string | null) => request<void>(`/admin/roster-entries/${id}${query({ tournamentId })}`, { method: 'DELETE' }),
 
   adminGameDay: (params: { tournamentId?: string | null; date?: string | null } = {}) => request<{
     tournament: Tournament
@@ -187,7 +187,7 @@ export const api = {
   adminSaveGameDayNote: (payload: Partial<GameDayNote>) => request<{ gameDayNote: GameDayNote }>('/admin/game-day-notes', json('POST', { gameDayNote: payload })),
   adminPredictionPolls: (tournamentId?: string | null) => request<{ tournament: Tournament; predictionPolls: PredictionPoll[] }>(`/admin/prediction-polls${query({ tournamentId })}`),
   adminCreatePredictionPoll: (payload: Partial<PredictionPoll>) => request<{ predictionPoll: PredictionPoll }>('/admin/prediction-polls', json('POST', { predictionPoll: payload })),
-  adminUpdatePredictionPoll: (id: string, payload: Partial<PredictionPoll>) => request<{ predictionPoll: PredictionPoll }>(`/admin/prediction-polls/${id}`, json('PATCH', { predictionPoll: payload })),
+  adminUpdatePredictionPoll: (id: string, payload: Partial<PredictionPoll>, tournamentId?: string | null) => request<{ predictionPoll: PredictionPoll }>(`/admin/prediction-polls/${id}${query({ tournamentId })}`, json('PATCH', { predictionPoll: payload })),
 
   adminGames: (tournamentId?: string | null) => request<{ games: Game[] }>(`/admin/games${query({ tournamentId })}`),
   adminCreateGame: (payload: Partial<Game>) => request<{ game: Game }>('/admin/games', json('POST', { game: payload })),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,8 +3,11 @@ import type {
   CurrentUser,
   Division,
   Game,
+  GameDayNote,
   IngestItem,
   MediaAsset,
+  PredictionPoll,
+  RosterEntry,
   ScoreCoverage,
   Sponsor,
   Standing,
@@ -128,6 +131,18 @@ export const api = {
     liveGames: Game[]
     latestNews: Article[]
   }>('/public/home'),
+  publicToday: (params: { tournamentId?: string | null; year?: number | null; date?: string | null } = {}, voterToken?: string | null) =>
+    request<{
+      tournament: Tournament | null
+      date: string
+      gameDayNote: GameDayNote | null
+      games: Game[]
+      predictionPolls: PredictionPoll[]
+      sponsors: Sponsor[]
+      lastUpdatedAt: string | null
+    }>(`/public/today${query(params)}`, voterToken ? { headers: { 'X-FD-Voter-Token': voterToken } } : {}),
+  publicVotePrediction: (pollId: string, payload: { teamId: string; voterToken: string }) =>
+    request<{ predictionPoll: PredictionPoll }>(`/public/prediction-polls/${pollId}/vote`, json('POST', { predictionVote: payload })),
 
   publicTournaments: () => request<{ tournaments: Tournament[]; activeTournament: Tournament | null }>('/public/tournaments'),
   publicSchedule: (params: { tournamentId?: string | null; year?: number | null; division?: string | null; phase?: string | null } = {}) =>
@@ -158,6 +173,21 @@ export const api = {
   adminTeams: (tournamentId?: string | null) => request<{ teams: Team[] }>(`/admin/teams${query({ tournamentId })}`),
   adminCreateTeam: (payload: Partial<Team>) => request<{ team: Team }>('/admin/teams', json('POST', { team: payload })),
   adminUpdateTeam: (id: string, payload: Partial<Team>) => request<{ team: Team }>(`/admin/teams/${id}`, json('PATCH', { team: payload })),
+  adminCreateRosterEntry: (payload: Partial<RosterEntry>) => request<{ rosterEntry: RosterEntry }>('/admin/roster-entries', json('POST', { rosterEntry: payload })),
+  adminUpdateRosterEntry: (id: string, payload: Partial<RosterEntry>) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries/${id}`, json('PATCH', { rosterEntry: payload })),
+  adminDeleteRosterEntry: (id: string) => request<void>(`/admin/roster-entries/${id}`, { method: 'DELETE' }),
+
+  adminGameDay: (params: { tournamentId?: string | null; date?: string | null } = {}) => request<{
+    tournament: Tournament
+    date: string
+    gameDayNote: GameDayNote | null
+    games: Game[]
+    predictionPolls: PredictionPoll[]
+  }>(`/admin/game-day-notes${query(params)}`),
+  adminSaveGameDayNote: (payload: Partial<GameDayNote>) => request<{ gameDayNote: GameDayNote }>('/admin/game-day-notes', json('POST', { gameDayNote: payload })),
+  adminPredictionPolls: (tournamentId?: string | null) => request<{ tournament: Tournament; predictionPolls: PredictionPoll[] }>(`/admin/prediction-polls${query({ tournamentId })}`),
+  adminCreatePredictionPoll: (payload: Partial<PredictionPoll>) => request<{ predictionPoll: PredictionPoll }>('/admin/prediction-polls', json('POST', { predictionPoll: payload })),
+  adminUpdatePredictionPoll: (id: string, payload: Partial<PredictionPoll>) => request<{ predictionPoll: PredictionPoll }>(`/admin/prediction-polls/${id}`, json('PATCH', { predictionPoll: payload })),
 
   adminGames: (tournamentId?: string | null) => request<{ games: Game[] }>(`/admin/games${query({ tournamentId })}`),
   adminCreateGame: (payload: Partial<Game>) => request<{ game: Game }>('/admin/games', json('POST', { game: payload })),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -123,7 +123,7 @@ function query(params: Record<string, string | number | null | undefined>) {
 export const api = {
   getCurrentUser: () => request<{ user: CurrentUser }>('/me'),
 
-  publicHome: () => request<{
+  publicHome: (voterToken?: string | null) => request<{
     tournament: Tournament | null
     upcomingOrLiveTournament: Tournament | null
     latestResultsTournament: Tournament | null
@@ -131,7 +131,8 @@ export const api = {
     liveGames: Game[]
     latestNews: Article[]
     gameDayNote: GameDayNote | null
-  }>('/public/home'),
+    predictionPolls: PredictionPoll[]
+  }>('/public/home', voterToken ? { headers: { 'X-FD-Voter-Token': voterToken } } : {}),
   publicToday: (params: { tournamentId?: string | null; year?: number | null; date?: string | null } = {}, voterToken?: string | null) =>
     request<{
       tournament: Tournament | null

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -177,10 +177,8 @@ export type PredictionPoll = {
   question: string
   status: 'open' | 'closed'
   open: boolean
-  showResults: boolean
   closesAt: string | null
   totalVotes: number | null
-  resultsVisible: boolean
   selectedTeamId: string | null
   game?: RelatedGameSummary | null
   options: PredictionOption[]

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -33,11 +33,38 @@ export type Team = {
   displayName: string
   divisionId?: string | null
   division: string | null
+  rosterEntries?: RosterEntry[]
   createdAt?: string
   updatedAt?: string
 }
 
-export type TeamSummary = Pick<Team, 'id' | 'displayName' | 'classYearLabel' | 'divisionId' | 'division'>
+export type RosterEntry = {
+  id: string
+  teamId: string
+  name: string
+  jerseyNumber: string | null
+  position: string | null
+  nickname: string | null
+  sortOrder: number
+  active: boolean
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type GameDayNote = {
+  id: string
+  tournamentId: string
+  date: string
+  hostClass: string | null
+  foodMenu: string | null
+  announcement: string | null
+  sponsorShoutout: string | null
+  active: boolean
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type TeamSummary = Pick<Team, 'id' | 'displayName' | 'classYearLabel' | 'divisionId' | 'division'> & { rosterEntries?: RosterEntry[] }
 
 export type RelatedGameSummary = {
   id: string
@@ -128,6 +155,35 @@ export type Sponsor = {
   tier: string | null
   active: boolean
   position: number
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type PredictionOption = {
+  teamId: string
+  displayName: string
+  classYearLabel: string
+  division: string | null
+  selected: boolean
+  votes: number | null
+  percent: number | null
+}
+
+export type PredictionPoll = {
+  id: string
+  tournamentId: string
+  gameId: string | null
+  pollType: 'game' | 'tournament'
+  question: string
+  status: 'open' | 'closed'
+  open: boolean
+  showResults: boolean
+  closesAt: string | null
+  totalVotes: number | null
+  resultsVisible: boolean
+  selectedTeamId: string | null
+  game?: RelatedGameSummary | null
+  options: PredictionOption[]
   createdAt?: string
   updatedAt?: string
 }

--- a/web/src/lib/urls.ts
+++ b/web/src/lib/urls.ts
@@ -1,0 +1,8 @@
+export function externalHref(value?: string | null) {
+  const url = value?.trim()
+  if (!url) return null
+  if (url.startsWith('//')) return `https:${url}`
+  if (/^[a-z][a-z0-9+.-]*:/i.test(url)) return url
+
+  return `https://${url}`
+}

--- a/web/src/lib/voter.ts
+++ b/web/src/lib/voter.ts
@@ -1,0 +1,14 @@
+const voterTokenKey = 'fd-alumni-voter-token'
+
+export function readOrCreateVoterToken() {
+  try {
+    const existing = window.localStorage.getItem(voterTokenKey)
+    if (existing) return existing
+
+    const token = window.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    window.localStorage.setItem(voterTokenKey, token)
+    return token
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+}

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -222,6 +222,7 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
   const [form, setForm] = useState({ name: '', jerseyNumber: '', position: '', nickname: '', sortOrder: String(entries.length + 1) })
   const [open, setOpen] = useState(false)
   const [message, setMessage] = useState('')
+  const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     setForm((current) => ({ ...current, sortOrder: String(entries.length + 1) }))
@@ -229,6 +230,9 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
 
   const submit = async (event: FormEvent) => {
     event.preventDefault()
+    if (saving) return
+
+    setSaving(true)
     setMessage('')
     try {
       await api.adminCreateRosterEntry({ teamId: team.id, name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || entries.length + 1), active: true }, team.tournamentId)
@@ -237,6 +241,8 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
       await onSaved()
     } catch (err) {
       setMessage(mutationErrorMessage(err, 'Unable to add roster player'))
+    } finally {
+      setSaving(false)
     }
   }
 
@@ -257,7 +263,7 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
               <Field label="Nickname"><input value={form.nickname} onChange={(event) => setForm({ ...form, nickname: event.target.value })} /></Field>
               <Field label="Sort order"><input type="number" value={form.sortOrder} onChange={(event) => setForm({ ...form, sortOrder: event.target.value })} /></Field>
             </FormGrid>
-            <button className="btn secondary small" type="submit">Add roster player</button>
+            <button className="btn secondary small" type="submit" disabled={saving}>{saving ? 'Adding player' : 'Add roster player'}</button>
           </form>
           {entries.length ? <div className="admin-list compact-admin-list">{entries.map((entry) => <EditableRosterEntry key={entry.id} entry={entry} tournamentId={team.tournamentId} onSaved={onSaved} />)}</div> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
         </div>

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -259,14 +259,14 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
             </FormGrid>
             <button className="btn secondary small" type="submit">Add roster player</button>
           </form>
-          {entries.length ? <div className="admin-list compact-admin-list">{entries.map((entry) => <EditableRosterEntry key={entry.id} entry={entry} onSaved={onSaved} />)}</div> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
+          {entries.length ? <div className="admin-list compact-admin-list">{entries.map((entry) => <EditableRosterEntry key={entry.id} entry={entry} tournamentId={team.tournamentId} onSaved={onSaved} />)}</div> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
         </div>
       )}
     </div>
   )
 }
 
-function EditableRosterEntry({ entry, onSaved }: { entry: RosterEntry; onSaved: () => Promise<void> }) {
+function EditableRosterEntry({ entry, tournamentId, onSaved }: { entry: RosterEntry; tournamentId: string; onSaved: () => Promise<void> }) {
   const [form, setForm] = useState({ name: entry.name, jerseyNumber: entry.jerseyNumber || '', position: entry.position || '', nickname: entry.nickname || '', sortOrder: String(entry.sortOrder), active: entry.active })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
@@ -275,7 +275,7 @@ function EditableRosterEntry({ entry, onSaved }: { entry: RosterEntry; onSaved: 
     setSaving(true)
     setError('')
     try {
-      await api.adminUpdateRosterEntry(entry.id, { name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || 0), active: form.active })
+      await api.adminUpdateRosterEntry(entry.id, { name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || 0), active: form.active }, tournamentId)
       await onSaved()
     } catch (err) {
       setError(mutationErrorMessage(err, 'Unable to save roster player'))
@@ -288,7 +288,7 @@ function EditableRosterEntry({ entry, onSaved }: { entry: RosterEntry; onSaved: 
     setSaving(true)
     setError('')
     try {
-      await api.adminDeleteRosterEntry(entry.id)
+      await api.adminDeleteRosterEntry(entry.id, tournamentId)
       await onSaved()
     } catch (err) {
       setError(mutationErrorMessage(err, 'Unable to remove roster player'))

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -9,9 +9,13 @@ import type { Division, RosterEntry, Team, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 
 const legacyPrefix = 'legacy:'
+type TeamSortOption = 'display' | 'class' | 'division' | 'roster'
 
 export function AdminDivisionsPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
+  const [teamQuery, setTeamQuery] = useState('')
+  const [divisionFilter, setDivisionFilter] = useState('')
+  const [teamSort, setTeamSort] = useState<TeamSortOption>('display')
   const { data, loading, error, reload } = useAsync(async () => {
     const [tournaments, teams, divisions] = await Promise.all([
       api.adminTournaments(),
@@ -25,29 +29,48 @@ export function AdminDivisionsPage() {
     if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
   }, [data?.tournaments, tournamentId, setTournamentId])
 
-  if (loading && !data) return <LoadingState label="Loading teams" />
-  if (error) return <ErrorState message={error} onRetry={reload} />
-
   const tournaments = data?.tournaments || []
   const tournament = selectedTournament(tournaments, tournamentId)
   const teams = data?.teams || []
   const divisions = data?.divisions || []
   const allDivisions = data?.allDivisions || []
+  const divisionOptions = useMemo(() => availableDivisionOptions(teams, divisions), [teams, divisions])
+  const visibleTeams = useMemo(() => filterAndSortTeams(teams, teamQuery, divisionFilter, teamSort), [teams, teamQuery, divisionFilter, teamSort])
+
+  if (loading && !data) return <LoadingState label="Loading teams" />
+  if (error) return <ErrorState message={error} onRetry={reload} />
 
   return (
     <div className="page-stack admin-page">
       <PageHeader
         eyebrow="Admin"
         title="Teams and divisions"
-        description="Configure the division list once, then assign each tournament team from a dropdown. New divisions can start with the selected tournament year so older tournaments keep their original setup."
+        description="Configure divisions, keep the team list clean, and manage optional public rosters without leaving the tournament workspace."
         actions={tournament && <Link className="btn primary" to={tournamentScopedPath('/admin/games', tournament.id)}>Build schedule</Link>}
       />
       <TournamentFilter tournaments={tournaments} value={tournament?.id || ''} onChange={setTournamentId} />
       <DivisionSettingsPanel tournament={tournament} divisions={divisions} allDivisions={allDivisions} onSaved={reload} />
       <CreateTeamPanel tournament={tournament} divisions={divisions} onSaved={reload} />
       <Panel>
-        <div className="section-heading"><h2>Teams</h2><span>{teams.length}</span></div>
-        {!teams.length ? <EmptyState title="No teams found" description="Add the teams that are playing in this tournament before building the schedule." /> : <div className="admin-list">{teams.map((team) => <EditableTeam key={team.id} team={team} divisions={divisions} onSaved={reload} />)}</div>}
+        <div className="section-heading">
+          <div>
+            <h2>Teams</h2>
+            <p className="muted">Cards are read-only until you choose to edit, so accidental changes are harder to make.</p>
+          </div>
+          <span>{visibleTeams.length} of {teams.length}</span>
+        </div>
+        <TeamToolbar
+          query={teamQuery}
+          division={divisionFilter}
+          sort={teamSort}
+          divisions={divisionOptions}
+          onQueryChange={setTeamQuery}
+          onDivisionChange={setDivisionFilter}
+          onSortChange={setTeamSort}
+        />
+        {!teams.length ? <EmptyState title="No teams found" description="Add the teams that are playing in this tournament before building the schedule." /> : null}
+        {teams.length > 0 && !visibleTeams.length ? <EmptyState title="No teams match those filters" description="Clear the search or division filter to see more teams." /> : null}
+        {visibleTeams.length > 0 && <div className="admin-list team-card-list">{visibleTeams.map((team) => <EditableTeam key={team.id} team={team} divisions={divisions} onSaved={reload} />)}</div>}
       </Panel>
     </div>
   )
@@ -167,6 +190,7 @@ function EditableDivision({ division, onSaved }: { division: Division; onSaved: 
 function CreateTeamPanel({ tournament, divisions, onSaved }: { tournament: Tournament | null; divisions: Division[]; onSaved: () => Promise<void> }) {
   const [form, setForm] = useState({ classYearLabel: '', displayName: '', divisionId: '' })
   const [message, setMessage] = useState('')
+  const [saving, setSaving] = useState(false)
 
   useEffect(() => {
     setForm((current) => ({ ...current, divisionId: divisions[0]?.id || '' }))
@@ -180,6 +204,7 @@ function CreateTeamPanel({ tournament, divisions, onSaved }: { tournament: Tourn
       return
     }
 
+    setSaving(true)
     try {
       await api.adminCreateTeam({
         tournamentId: tournament.id,
@@ -192,21 +217,41 @@ function CreateTeamPanel({ tournament, divisions, onSaved }: { tournament: Tourn
       await onSaved()
     } catch (err) {
       setMessage(mutationErrorMessage(err, 'Unable to create team'))
+    } finally {
+      setSaving(false)
     }
   }
 
-  return <Panel><div className="section-heading"><h2>Add team</h2>{message && <span>{message}</span>}</div>{!tournament ? <EmptyState title="Choose a tournament first" /> : <form onSubmit={submit}><p className="form-note">Tournament: {tournament.year}</p><FormGrid><Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} placeholder="Class of 2016/17" required /></Field><Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} placeholder="2016/17" required /></Field><Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} required /></Field></FormGrid><button className="btn primary" type="submit" disabled={!divisions.length}>Create team</button></form>}</Panel>
+  return <Panel><div className="section-heading"><h2>Add team</h2>{message && <span>{message}</span>}</div>{!tournament ? <EmptyState title="Choose a tournament first" /> : <form onSubmit={submit}><p className="form-note">Tournament: {tournament.year}</p><FormGrid><Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} placeholder="Class of 2016/17" required /></Field><Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} placeholder="2016/17" required /></Field><Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} required /></Field></FormGrid><button className="btn primary" type="submit" disabled={!divisions.length || saving}>{saving ? 'Creating' : 'Create team'}</button></form>}</Panel>
+}
+
+function TeamToolbar({ query, division, sort, divisions, onQueryChange, onDivisionChange, onSortChange }: { query: string; division: string; sort: TeamSortOption; divisions: string[]; onQueryChange: (value: string) => void; onDivisionChange: (value: string) => void; onSortChange: (value: TeamSortOption) => void }) {
+  return (
+    <div className="team-toolbar toolbar-panel">
+      <label><span>Search teams</span><input value={query} onChange={(event) => onQueryChange(event.target.value)} placeholder="Class year, display name, division" /></label>
+      <label><span>Division</span><select value={division} onChange={(event) => onDivisionChange(event.target.value)}><option value="">All divisions</option>{divisions.map((name) => <option key={name} value={name}>{name}</option>)}</select></label>
+      <label><span>Sort</span><select value={sort} onChange={(event) => onSortChange(event.target.value as TeamSortOption)}><option value="display">Display name</option><option value="class">Class label</option><option value="division">Division</option><option value="roster">Roster size</option></select></label>
+    </div>
+  )
 }
 
 function EditableTeam({ team, divisions, onSaved }: { team: Team; divisions: Division[]; onSaved: () => Promise<void> }) {
-  const [form, setForm] = useState({ classYearLabel: team.classYearLabel, displayName: team.displayName, divisionId: divisionValueFor(team, divisions) })
+  const [form, setForm] = useState(teamFormState(team, divisions))
+  const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
   const [saveError, setSaveError] = useState('')
+  const rosterCount = team.rosterEntries?.length || 0
+
+  useEffect(() => {
+    if (!editing) setForm(teamFormState(team, divisions))
+  }, [team, divisions, editing])
+
   const save = async () => {
     setSaving(true)
     setSaveError('')
     try {
-      await api.adminUpdateTeam(team.id, { classYearLabel: form.classYearLabel, displayName: form.displayName, ...divisionPayload(form.divisionId, divisions) })
+      await api.adminUpdateTeam(team.id, { classYearLabel: form.classYearLabel, displayName: form.displayName, ...divisionPayload(form.divisionId, divisions) }, team.tournamentId)
+      setEditing(false)
       await onSaved()
     } catch (err) {
       setSaveError(mutationErrorMessage(err, 'Unable to save team'))
@@ -215,74 +260,159 @@ function EditableTeam({ team, divisions, onSaved }: { team: Team; divisions: Div
     }
   }
 
-  return <article className="admin-row-card team-admin-card"><FormGrid><Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} /></Field><Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} /></Field><Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} currentName={team.division} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field></FormGrid>{saveError && <p className="form-error" role="alert">{saveError}</p>}<button className="btn secondary" onClick={save} disabled={saving}>{saving ? 'Saving' : 'Save team'}</button><RosterEditor team={team} entries={team.rosterEntries || []} onSaved={onSaved} /></article>
-}
-
-function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterEntry[]; onSaved: () => Promise<void> }) {
-  const [form, setForm] = useState({ name: '', jerseyNumber: '', position: '', nickname: '', sortOrder: String(entries.length + 1) })
-  const [open, setOpen] = useState(false)
-  const [message, setMessage] = useState('')
-  const [saving, setSaving] = useState(false)
-
-  useEffect(() => {
-    setForm((current) => ({ ...current, sortOrder: String(entries.length + 1) }))
-  }, [entries.length])
-
-  const submit = async (event: FormEvent) => {
-    event.preventDefault()
-    if (saving) return
+  const remove = async () => {
+    if (!window.confirm(`Remove ${team.displayName}? Teams with games cannot be deleted.`)) return
 
     setSaving(true)
-    setMessage('')
+    setSaveError('')
     try {
-      await api.adminCreateRosterEntry({ teamId: team.id, name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || entries.length + 1), active: true }, team.tournamentId)
-      setForm({ name: '', jerseyNumber: '', position: '', nickname: '', sortOrder: String(entries.length + 2) })
-      setMessage('Roster player added')
+      await api.adminDeleteTeam(team.id, team.tournamentId)
       await onSaved()
     } catch (err) {
-      setMessage(mutationErrorMessage(err, 'Unable to add roster player'))
+      setSaveError(mutationErrorMessage(err, 'Unable to remove team. If this team has games, remove or reassign those games first.'))
     } finally {
       setSaving(false)
     }
+  }
+
+  const cancel = () => {
+    setForm(teamFormState(team, divisions))
+    setSaveError('')
+    setEditing(false)
+  }
+
+  return (
+    <article className="admin-row-card team-admin-card team-summary-card">
+      <div className="team-card-header">
+        <div>
+          <span className="team-card-kicker">{team.division || 'No division'}</span>
+          <h3>{team.displayName}</h3>
+          <p>{team.classYearLabel} · {rosterCount} roster {rosterCount === 1 ? 'player' : 'players'}</p>
+        </div>
+        <div className="row-actions">
+          {!editing && <button className="btn secondary small" type="button" onClick={() => setEditing(true)}>Edit team</button>}
+          {!editing && <button className="btn danger small" type="button" onClick={remove} disabled={saving}>{saving ? 'Removing' : 'Delete'}</button>}
+        </div>
+      </div>
+
+      {editing ? (
+        <div className="team-edit-panel">
+          <FormGrid>
+            <Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} /></Field>
+            <Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} /></Field>
+            <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} currentName={team.division} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
+          </FormGrid>
+          {saveError && <p className="form-error" role="alert">{saveError}</p>}
+          <div className="row-actions">
+            <button className="btn secondary small" type="button" onClick={cancel} disabled={saving}>Cancel</button>
+            <button className="btn primary small" type="button" onClick={save} disabled={saving}>{saving ? 'Saving' : 'Save team'}</button>
+            <button className="btn danger small" type="button" onClick={remove} disabled={saving}>{saving ? 'Removing' : 'Delete team'}</button>
+          </div>
+        </div>
+      ) : (
+        <div className="team-facts-grid">
+          <div><span>Class label</span><strong>{team.classYearLabel}</strong></div>
+          <div><span>Display name</span><strong>{team.displayName}</strong></div>
+          <div><span>Division</span><strong>{team.division || 'Not assigned'}</strong></div>
+        </div>
+      )}
+      {!editing && saveError && <p className="form-error" role="alert">{saveError}</p>}
+      <RosterEditor team={team} entries={team.rosterEntries || []} onSaved={onSaved} />
+    </article>
+  )
+}
+
+function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterEntry[]; onSaved: () => Promise<void> }) {
+  const [open, setOpen] = useState(false)
+  const [message, setMessage] = useState('')
+  const [editingEntry, setEditingEntry] = useState<RosterEntry | null>(null)
+  const [adding, setAdding] = useState(false)
+
+  const closeModal = () => {
+    setEditingEntry(null)
+    setAdding(false)
   }
 
   return (
     <div className="roster-admin-panel">
       <div className="section-heading compact-heading">
         <div><h3>Roster</h3><p className="muted">Optional public roster for {team.displayName}.</p></div>
-        <button className="btn secondary small" type="button" onClick={() => setOpen((value) => !value)}>{open ? 'Hide roster' : `Edit roster (${entries.length})`}</button>
+        <button className="btn secondary small" type="button" onClick={() => setOpen((value) => !value)}>{open ? 'Hide roster' : `Manage roster (${entries.length})`}</button>
       </div>
       {message && <p className="form-note">{message}</p>}
       {open && (
-        <div className="collapsible-body">
-          <form onSubmit={submit}>
-            <FormGrid>
-              <Field label="Name"><input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} placeholder="Player name" required /></Field>
-              <Field label="Jersey #"><input value={form.jerseyNumber} onChange={(event) => setForm({ ...form, jerseyNumber: event.target.value })} /></Field>
-              <Field label="Position"><input value={form.position} onChange={(event) => setForm({ ...form, position: event.target.value })} placeholder="G / F / C" /></Field>
-              <Field label="Nickname"><input value={form.nickname} onChange={(event) => setForm({ ...form, nickname: event.target.value })} /></Field>
-              <Field label="Sort order"><input type="number" value={form.sortOrder} onChange={(event) => setForm({ ...form, sortOrder: event.target.value })} /></Field>
-            </FormGrid>
-            <button className="btn secondary small" type="submit" disabled={saving}>{saving ? 'Adding player' : 'Add roster player'}</button>
-          </form>
-          {entries.length ? <div className="admin-list compact-admin-list">{entries.map((entry) => <EditableRosterEntry key={entry.id} entry={entry} tournamentId={team.tournamentId} onSaved={onSaved} />)}</div> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
+        <div className="collapsible-body roster-manager-body">
+          <div className="row-actions"><button className="btn secondary small" type="button" onClick={() => setAdding(true)}>Add player</button></div>
+          {entries.length ? <RosterTable entries={entries} onEdit={setEditingEntry} /> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
         </div>
+      )}
+      {(adding || editingEntry) && (
+        <RosterEntryModal
+          team={team}
+          entry={editingEntry}
+          nextSortOrder={entries.length + 1}
+          onClose={closeModal}
+          onSaved={async (action) => {
+            setMessage(action)
+            closeModal()
+            await onSaved()
+          }}
+        />
       )}
     </div>
   )
 }
 
-function EditableRosterEntry({ entry, tournamentId, onSaved }: { entry: RosterEntry; tournamentId: string; onSaved: () => Promise<void> }) {
-  const [form, setForm] = useState({ name: entry.name, jerseyNumber: entry.jerseyNumber || '', position: entry.position || '', nickname: entry.nickname || '', sortOrder: String(entry.sortOrder), active: entry.active })
+function RosterTable({ entries, onEdit }: { entries: RosterEntry[]; onEdit: (entry: RosterEntry) => void }) {
+  return (
+    <div className="roster-table-wrap" role="region" aria-label="Roster entries" tabIndex={0}>
+      <table className="data-table roster-admin-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Jersey #</th>
+            <th>Position</th>
+            <th>Nickname</th>
+            <th>Public</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <tr key={entry.id}>
+              <td><strong>{entry.name}</strong></td>
+              <td>{entry.jerseyNumber || '—'}</td>
+              <td>{entry.position || '—'}</td>
+              <td>{entry.nickname || '—'}</td>
+              <td>{entry.active ? 'Yes' : 'Hidden'}</td>
+              <td><button className="btn secondary small" type="button" onClick={() => onEdit(entry)}>Edit</button></td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function RosterEntryModal({ team, entry, nextSortOrder, onClose, onSaved }: { team: Team; entry: RosterEntry | null; nextSortOrder: number; onClose: () => void; onSaved: (message: string) => Promise<void> }) {
+  const [form, setForm] = useState({ name: entry?.name || '', jerseyNumber: entry?.jerseyNumber || '', position: entry?.position || '', nickname: entry?.nickname || '', sortOrder: String(entry?.sortOrder ?? nextSortOrder), active: entry?.active ?? true })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const editing = Boolean(entry)
 
-  const save = async () => {
+  const save = async (event: FormEvent) => {
+    event.preventDefault()
     setSaving(true)
     setError('')
     try {
-      await api.adminUpdateRosterEntry(entry.id, { name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || 0), active: form.active }, tournamentId)
-      await onSaved()
+      const payload = { name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || 0), active: form.active }
+      if (entry) {
+        await api.adminUpdateRosterEntry(entry.id, payload, team.tournamentId)
+        await onSaved('Roster player saved')
+      } else {
+        await api.adminCreateRosterEntry({ teamId: team.id, ...payload }, team.tournamentId)
+        await onSaved('Roster player added')
+      }
     } catch (err) {
       setError(mutationErrorMessage(err, 'Unable to save roster player'))
     } finally {
@@ -291,11 +421,13 @@ function EditableRosterEntry({ entry, tournamentId, onSaved }: { entry: RosterEn
   }
 
   const remove = async () => {
+    if (!entry || !window.confirm(`Remove ${entry.name} from ${team.displayName}?`)) return
+
     setSaving(true)
     setError('')
     try {
-      await api.adminDeleteRosterEntry(entry.id, tournamentId)
-      await onSaved()
+      await api.adminDeleteRosterEntry(entry.id, team.tournamentId)
+      await onSaved('Roster player removed')
     } catch (err) {
       setError(mutationErrorMessage(err, 'Unable to remove roster player'))
       setSaving(false)
@@ -303,18 +435,32 @@ function EditableRosterEntry({ entry, tournamentId, onSaved }: { entry: RosterEn
   }
 
   return (
-    <article className="admin-row-card roster-admin-row">
-      <FormGrid>
-        <Field label="Name"><input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} required /></Field>
-        <Field label="Jersey #"><input value={form.jerseyNumber} onChange={(event) => setForm({ ...form, jerseyNumber: event.target.value })} /></Field>
-        <Field label="Position"><input value={form.position} onChange={(event) => setForm({ ...form, position: event.target.value })} /></Field>
-        <Field label="Nickname"><input value={form.nickname} onChange={(event) => setForm({ ...form, nickname: event.target.value })} /></Field>
-        <Field label="Order"><input type="number" value={form.sortOrder} onChange={(event) => setForm({ ...form, sortOrder: event.target.value })} /></Field>
-      </FormGrid>
-      <label className="check-field"><input type="checkbox" checked={form.active} onChange={(event) => setForm({ ...form, active: event.target.checked })} /> Public</label>
-      {error && <p className="form-error" role="alert">{error}</p>}
-      <div className="row-actions"><button className="btn secondary small" onClick={save} disabled={saving}>{saving ? 'Saving' : 'Save player'}</button><button className="btn danger small" onClick={remove} disabled={saving}>Remove</button></div>
-    </article>
+    <div className="modal-backdrop" role="presentation">
+      <div className="modal-card roster-modal" role="dialog" aria-modal="true" aria-label={editing ? `Edit ${entry?.name}` : `Add player to ${team.displayName}`}>
+        <div className="section-heading compact-heading">
+          <div>
+            <h2>{editing ? 'Edit roster player' : 'Add roster player'}</h2>
+            <p className="muted">{team.displayName}</p>
+          </div>
+          <button className="btn secondary small" type="button" onClick={onClose} disabled={saving}>Close</button>
+        </div>
+        <form onSubmit={save}>
+          <FormGrid>
+            <Field label="Name"><input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} placeholder="Player name" required /></Field>
+            <Field label="Jersey #"><input value={form.jerseyNumber} onChange={(event) => setForm({ ...form, jerseyNumber: event.target.value })} /></Field>
+            <Field label="Position"><input value={form.position} onChange={(event) => setForm({ ...form, position: event.target.value })} placeholder="G / F / C" /></Field>
+            <Field label="Nickname"><input value={form.nickname} onChange={(event) => setForm({ ...form, nickname: event.target.value })} /></Field>
+            <Field label="Sort order"><input type="number" value={form.sortOrder} onChange={(event) => setForm({ ...form, sortOrder: event.target.value })} /></Field>
+            <label className="check-field"><input type="checkbox" checked={form.active} onChange={(event) => setForm({ ...form, active: event.target.checked })} /> Public</label>
+          </FormGrid>
+          {error && <p className="form-error" role="alert">{error}</p>}
+          <div className="row-actions">
+            <button className="btn primary" type="submit" disabled={saving}>{saving ? 'Saving' : editing ? 'Save player' : 'Add player'}</button>
+            {entry && <button className="btn danger" type="button" onClick={remove} disabled={saving}>Remove player</button>}
+          </div>
+        </form>
+      </div>
+    </div>
   )
 }
 
@@ -329,6 +475,10 @@ function DivisionSelect({ value, divisions, currentName, onChange, required }: {
   )
 }
 
+function teamFormState(team: Team, divisions: Division[]) {
+  return { classYearLabel: team.classYearLabel, displayName: team.displayName, divisionId: divisionValueFor(team, divisions) }
+}
+
 function divisionValueFor(team: Team, divisions: Division[]) {
   if (team.divisionId) return team.divisionId
   const matchingDivision = divisions.find((division) => division.name === team.division)
@@ -341,4 +491,32 @@ function divisionPayload(value: string, divisions: Division[]) {
   if (value.startsWith(legacyPrefix)) return { divisionId: null, division: value.slice(legacyPrefix.length) }
 
   return { divisionId: value, division: divisionNameById(value, divisions) || null }
+}
+
+function availableDivisionOptions(teams: Team[], divisions: Division[]) {
+  const names = new Set<string>()
+  divisions.forEach((division) => names.add(division.name))
+  teams.forEach((team) => {
+    if (team.division) names.add(team.division)
+  })
+  return Array.from(names).sort((a, b) => a.localeCompare(b))
+}
+
+function filterAndSortTeams(teams: Team[], query: string, division: string, sort: TeamSortOption) {
+  const normalizedQuery = query.trim().toLowerCase()
+  return teams
+    .filter((team) => {
+      const matchesQuery = !normalizedQuery || [ team.classYearLabel, team.displayName, team.division || '' ].join(' ').toLowerCase().includes(normalizedQuery)
+      const matchesDivision = !division || team.division === division
+      return matchesQuery && matchesDivision
+    })
+    .slice()
+    .sort((a, b) => compareTeams(a, b, sort))
+}
+
+function compareTeams(a: Team, b: Team, sort: TeamSortOption) {
+  if (sort === 'class') return a.classYearLabel.localeCompare(b.classYearLabel, undefined, { numeric: true })
+  if (sort === 'division') return `${a.division || ''} ${a.displayName}`.localeCompare(`${b.division || ''} ${b.displayName}`, undefined, { numeric: true })
+  if (sort === 'roster') return (b.rosterEntries?.length || 0) - (a.rosterEntries?.length || 0) || a.displayName.localeCompare(b.displayName, undefined, { numeric: true })
+  return a.displayName.localeCompare(b.displayName, undefined, { numeric: true })
 }

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -231,7 +231,7 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
     event.preventDefault()
     setMessage('')
     try {
-      await api.adminCreateRosterEntry({ teamId: team.id, name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || entries.length + 1), active: true })
+      await api.adminCreateRosterEntry({ teamId: team.id, name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || entries.length + 1), active: true }, team.tournamentId)
       setForm({ name: '', jerseyNumber: '', position: '', nickname: '', sortOrder: String(entries.length + 2) })
       setMessage('Roster player added')
       await onSaved()

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -5,7 +5,7 @@ import { selectedTournament, tournamentScopedPath, useTournamentSelection } from
 import { mutationErrorMessage } from '../../lib/errors'
 import { useAsync } from '../../lib/hooks'
 import { divisionNameById } from '../../lib/games'
-import type { Division, Team, Tournament } from '../../lib/types'
+import type { Division, RosterEntry, Team, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 
 const legacyPrefix = 'legacy:'
@@ -215,7 +215,101 @@ function EditableTeam({ team, divisions, onSaved }: { team: Team; divisions: Div
     }
   }
 
-  return <article className="admin-row-card"><FormGrid><Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} /></Field><Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} /></Field><Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} currentName={team.division} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field></FormGrid>{saveError && <p className="form-error" role="alert">{saveError}</p>}<button className="btn secondary" onClick={save} disabled={saving}>{saving ? 'Saving' : 'Save team'}</button></article>
+  return <article className="admin-row-card team-admin-card"><FormGrid><Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} /></Field><Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} /></Field><Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} currentName={team.division} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field></FormGrid>{saveError && <p className="form-error" role="alert">{saveError}</p>}<button className="btn secondary" onClick={save} disabled={saving}>{saving ? 'Saving' : 'Save team'}</button><RosterEditor team={team} entries={team.rosterEntries || []} onSaved={onSaved} /></article>
+}
+
+function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterEntry[]; onSaved: () => Promise<void> }) {
+  const [form, setForm] = useState({ name: '', jerseyNumber: '', position: '', nickname: '', sortOrder: String(entries.length + 1) })
+  const [open, setOpen] = useState(false)
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    setForm((current) => ({ ...current, sortOrder: String(entries.length + 1) }))
+  }, [entries.length])
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    setMessage('')
+    try {
+      await api.adminCreateRosterEntry({ teamId: team.id, name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || entries.length + 1), active: true })
+      setForm({ name: '', jerseyNumber: '', position: '', nickname: '', sortOrder: String(entries.length + 2) })
+      setMessage('Roster player added')
+      await onSaved()
+    } catch (err) {
+      setMessage(mutationErrorMessage(err, 'Unable to add roster player'))
+    }
+  }
+
+  return (
+    <div className="roster-admin-panel">
+      <div className="section-heading compact-heading">
+        <div><h3>Roster</h3><p className="muted">Optional public roster for {team.displayName}.</p></div>
+        <button className="btn secondary small" type="button" onClick={() => setOpen((value) => !value)}>{open ? 'Hide roster' : `Edit roster (${entries.length})`}</button>
+      </div>
+      {message && <p className="form-note">{message}</p>}
+      {open && (
+        <div className="collapsible-body">
+          <form onSubmit={submit}>
+            <FormGrid>
+              <Field label="Name"><input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} placeholder="Player name" required /></Field>
+              <Field label="Jersey #"><input value={form.jerseyNumber} onChange={(event) => setForm({ ...form, jerseyNumber: event.target.value })} /></Field>
+              <Field label="Position"><input value={form.position} onChange={(event) => setForm({ ...form, position: event.target.value })} placeholder="G / F / C" /></Field>
+              <Field label="Nickname"><input value={form.nickname} onChange={(event) => setForm({ ...form, nickname: event.target.value })} /></Field>
+              <Field label="Sort order"><input type="number" value={form.sortOrder} onChange={(event) => setForm({ ...form, sortOrder: event.target.value })} /></Field>
+            </FormGrid>
+            <button className="btn secondary small" type="submit">Add roster player</button>
+          </form>
+          {entries.length ? <div className="admin-list compact-admin-list">{entries.map((entry) => <EditableRosterEntry key={entry.id} entry={entry} onSaved={onSaved} />)}</div> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function EditableRosterEntry({ entry, onSaved }: { entry: RosterEntry; onSaved: () => Promise<void> }) {
+  const [form, setForm] = useState({ name: entry.name, jerseyNumber: entry.jerseyNumber || '', position: entry.position || '', nickname: entry.nickname || '', sortOrder: String(entry.sortOrder), active: entry.active })
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  const save = async () => {
+    setSaving(true)
+    setError('')
+    try {
+      await api.adminUpdateRosterEntry(entry.id, { name: form.name, jerseyNumber: form.jerseyNumber, position: form.position, nickname: form.nickname, sortOrder: Number(form.sortOrder || 0), active: form.active })
+      await onSaved()
+    } catch (err) {
+      setError(mutationErrorMessage(err, 'Unable to save roster player'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const remove = async () => {
+    setSaving(true)
+    setError('')
+    try {
+      await api.adminDeleteRosterEntry(entry.id)
+      await onSaved()
+    } catch (err) {
+      setError(mutationErrorMessage(err, 'Unable to remove roster player'))
+      setSaving(false)
+    }
+  }
+
+  return (
+    <article className="admin-row-card roster-admin-row">
+      <FormGrid>
+        <Field label="Name"><input value={form.name} onChange={(event) => setForm({ ...form, name: event.target.value })} required /></Field>
+        <Field label="Jersey #"><input value={form.jerseyNumber} onChange={(event) => setForm({ ...form, jerseyNumber: event.target.value })} /></Field>
+        <Field label="Position"><input value={form.position} onChange={(event) => setForm({ ...form, position: event.target.value })} /></Field>
+        <Field label="Nickname"><input value={form.nickname} onChange={(event) => setForm({ ...form, nickname: event.target.value })} /></Field>
+        <Field label="Order"><input type="number" value={form.sortOrder} onChange={(event) => setForm({ ...form, sortOrder: event.target.value })} /></Field>
+      </FormGrid>
+      <label className="check-field"><input type="checkbox" checked={form.active} onChange={(event) => setForm({ ...form, active: event.target.checked })} /> Public</label>
+      {error && <p className="form-error" role="alert">{error}</p>}
+      <div className="row-actions"><button className="btn secondary small" onClick={save} disabled={saving}>{saving ? 'Saving' : 'Save player'}</button><button className="btn danger small" onClick={remove} disabled={saving}>Remove</button></div>
+    </article>
+  )
 }
 
 function DivisionSelect({ value, divisions, currentName, onChange, required }: { value: string; divisions: Division[]; currentName?: string | null; onChange: (value: string) => void; required?: boolean }) {

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -122,7 +122,7 @@ function PredictionAdminPanel({ tournament, games, polls, onSaved }: { tournamen
   const updatePoll = async (poll: PredictionPoll, payload: Partial<PredictionPoll>) => {
     setMessage('')
     try {
-      await api.adminUpdatePredictionPoll(poll.id, payload)
+      await api.adminUpdatePredictionPoll(poll.id, payload, poll.tournamentId)
       setMessage('Prediction poll updated')
       await onSaved()
     } catch (err) {

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -1,0 +1,173 @@
+import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { api } from '../../lib/api'
+import { selectedTournament, tournamentScopedPath, useTournamentSelection } from '../../lib/admin'
+import { formatGuamDateTime, toDateInputValue } from '../../lib/datetime'
+import { DEFAULT_GAME_VENUE } from '../../lib/games'
+import { mutationErrorMessage } from '../../lib/errors'
+import { useAsync } from '../../lib/hooks'
+import type { Game, GameDayNote, PredictionPoll, Tournament } from '../../lib/types'
+import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
+
+export function AdminGameDayPage() {
+  const [tournamentId, setTournamentId] = useTournamentSelection()
+  const [date, setDate] = useState('')
+  const { data, loading, error, reload } = useAsync(async () => {
+    const [tournaments, gameDay] = await Promise.all([
+      api.adminTournaments(),
+      api.adminGameDay({ tournamentId: tournamentId || null, date: date || null }),
+    ])
+    return { tournaments: tournaments.tournaments, gameDay }
+  }, [tournamentId, date])
+
+  useEffect(() => {
+    if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
+  }, [data?.tournaments, tournamentId, setTournamentId])
+
+  useEffect(() => {
+    if (!date && data?.gameDay.date) setDate(data.gameDay.date)
+  }, [data?.gameDay.date, date])
+
+  if (loading && !data) return <LoadingState label="Loading game-day controls" />
+  if (error) return <ErrorState message={error} onRetry={reload} />
+
+  const tournaments = data?.tournaments || []
+  const tournament = selectedTournament(tournaments, tournamentId) || data?.gameDay.tournament || null
+  const gameDay = data?.gameDay
+
+  return (
+    <div className="page-stack admin-page">
+      <PageHeader
+        eyebrow="Admin"
+        title="Game-day operations"
+        description="Maintain Today at The Jungle notes, roster readiness, and lightweight prediction voting for the selected tournament day."
+        actions={<Link className="btn secondary" to="/today">View Today page</Link>}
+      />
+
+      <Panel className="toolbar-panel">
+        <label><span>Tournament</span><select value={tournament?.id || ''} onChange={(event) => setTournamentId(event.target.value)}>{tournaments.map((item) => <option key={item.id} value={item.id}>{item.year} · {item.name}</option>)}</select></label>
+        <label><span>Game day</span><input type="date" value={date} onChange={(event) => setDate(event.target.value)} /></label>
+      </Panel>
+
+      <GameDayNoteForm tournament={tournament} date={date || gameDay?.date || ''} note={gameDay?.gameDayNote || null} onSaved={reload} />
+      <PredictionAdminPanel tournament={tournament} games={gameDay?.games || []} polls={gameDay?.predictionPolls || []} onSaved={reload} />
+    </div>
+  )
+}
+
+function GameDayNoteForm({ tournament, date, note, onSaved }: { tournament: Tournament | null; date: string; note: GameDayNote | null; onSaved: () => Promise<void> }) {
+  const [form, setForm] = useState({ hostClass: '', foodMenu: '', announcement: '', sponsorShoutout: '', active: true })
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    setForm({
+      hostClass: note?.hostClass || '',
+      foodMenu: note?.foodMenu || '',
+      announcement: note?.announcement || '',
+      sponsorShoutout: note?.sponsorShoutout || '',
+      active: note?.active ?? true,
+    })
+  }, [note?.id, note?.updatedAt])
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault()
+    setSaving(true)
+    setMessage('')
+    try {
+      if (!tournament) throw new Error('Choose a tournament first')
+      await api.adminSaveGameDayNote({ tournamentId: tournament.id, date: toDateInputValue(date), ...form })
+      setMessage('Game-day note saved')
+      await onSaved()
+    } catch (err) {
+      setMessage(mutationErrorMessage(err, 'Unable to save game-day note'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Panel>
+      <div className="section-heading"><h2>Today page facts</h2>{message && <span>{message}</span>}</div>
+      <form onSubmit={submit}>
+        <FormGrid>
+          <Field label="Host class"><input value={form.hostClass} onChange={(event) => setForm({ ...form, hostClass: event.target.value })} placeholder="Class of 2006" /></Field>
+          <Field label="Food / menu"><input value={form.foodMenu} onChange={(event) => setForm({ ...form, foodMenu: event.target.value })} placeholder="BBQ, drinks, concessions" /></Field>
+          <label className="check-field"><input type="checkbox" checked={form.active} onChange={(event) => setForm({ ...form, active: event.target.checked })} /> Show on public Today page</label>
+          <Field label="Announcement"><textarea value={form.announcement} onChange={(event) => setForm({ ...form, announcement: event.target.value })} placeholder="Parking, tipoff, door, or schedule notes" rows={3} /></Field>
+          <Field label="Sponsor shoutout"><textarea value={form.sponsorShoutout} onChange={(event) => setForm({ ...form, sponsorShoutout: event.target.value })} placeholder="Optional sponsor or partner note" rows={3} /></Field>
+        </FormGrid>
+        <button className="btn primary" type="submit" disabled={saving || !date}>{saving ? 'Saving' : 'Save Today info'}</button>
+      </form>
+    </Panel>
+  )
+}
+
+function PredictionAdminPanel({ tournament, games, polls, onSaved }: { tournament: Tournament | null; games: Game[]; polls: PredictionPoll[]; onSaved: () => Promise<void> }) {
+  const [message, setMessage] = useState('')
+  const tournamentPoll = polls.find((poll) => poll.pollType === 'tournament')
+  const gamePolls = useMemo(() => new Map(polls.filter((poll) => poll.pollType === 'game' && poll.gameId).map((poll) => [poll.gameId!, poll])), [polls])
+
+  const createPoll = async (payload: Partial<PredictionPoll>) => {
+    setMessage('')
+    try {
+      await api.adminCreatePredictionPoll(payload)
+      setMessage('Prediction poll opened')
+      await onSaved()
+    } catch (err) {
+      setMessage(mutationErrorMessage(err, 'Unable to create prediction poll'))
+    }
+  }
+
+  const updatePoll = async (poll: PredictionPoll, payload: Partial<PredictionPoll>) => {
+    setMessage('')
+    try {
+      await api.adminUpdatePredictionPoll(poll.id, payload)
+      setMessage('Prediction poll updated')
+      await onSaved()
+    } catch (err) {
+      setMessage(mutationErrorMessage(err, 'Unable to update prediction poll'))
+    }
+  }
+
+  return (
+    <Panel>
+      <div className="section-heading"><h2>Predictions</h2>{message && <span>{message}</span>}</div>
+      {!tournament ? <EmptyState title="Choose a tournament first" /> : (
+        <div className="admin-prediction-stack">
+          <article className="admin-row-card prediction-admin-row">
+            <div>
+              <strong>Tournament winner poll</strong>
+              <p className="muted">A no-sign-in fan vote for the overall champion.</p>
+            </div>
+            {tournamentPoll ? <PredictionPollControls poll={tournamentPoll} onUpdate={updatePoll} /> : <button className="btn secondary" onClick={() => createPoll({ tournamentId: tournament.id, pollType: 'tournament', question: 'Who wins the tournament?' })}>Open tournament poll</button>}
+          </article>
+
+          {!games.length ? <EmptyState title="No games on selected date" description="Game prediction controls appear once games exist for this date." /> : games.map((game) => {
+            const poll = gamePolls.get(game.id)
+            return (
+              <article className="admin-row-card prediction-admin-row" key={game.id}>
+                <div>
+                  <strong>{game.awayTeam?.displayName || 'Away team'} at {game.homeTeam?.displayName || 'Home team'}</strong>
+                  <p className="muted">{formatGuamDateTime(game.startTime)} · {game.venue || DEFAULT_GAME_VENUE}</p>
+                </div>
+                {poll ? <PredictionPollControls poll={poll} onUpdate={updatePoll} /> : <button className="btn secondary" onClick={() => createPoll({ tournamentId: tournament.id, gameId: game.id, pollType: 'game', question: 'Who wins this game?' })}>Open game poll</button>}
+              </article>
+            )
+          })}
+        </div>
+      )}
+    </Panel>
+  )
+}
+
+function PredictionPollControls({ poll, onUpdate }: { poll: PredictionPoll; onUpdate: (poll: PredictionPoll, payload: Partial<PredictionPoll>) => Promise<void> }) {
+  return (
+    <div className="prediction-admin-controls">
+      <StatusBadge status={poll.status} />
+      <span className="muted">{poll.totalVotes ?? 0} votes</span>
+      <button className="btn secondary small" onClick={() => onUpdate(poll, { status: poll.status === 'open' ? 'closed' : 'open' })}>{poll.status === 'open' ? 'Close voting' : 'Reopen voting'}</button>
+      <button className="btn secondary small" onClick={() => onUpdate(poll, { showResults: !poll.showResults })}>{poll.showResults ? 'Hide results' : 'Show results'}</button>
+    </div>
+  )
+}

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -9,6 +9,8 @@ import { useAsync } from '../../lib/hooks'
 import type { Game, GameDayNote, PredictionPoll, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 
+const gameDayRefreshIntervalMs = 10_000
+
 export function AdminGameDayPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
   const [date, setDate] = useState('')
@@ -28,8 +30,18 @@ export function AdminGameDayPage() {
     if (!date && data?.gameDay.date) setDate(data.gameDay.date)
   }, [data?.gameDay.date, date])
 
+  useEffect(() => {
+    if (!data) return undefined
+
+    const intervalId = window.setInterval(() => {
+      void reload()
+    }, gameDayRefreshIntervalMs)
+
+    return () => window.clearInterval(intervalId)
+  }, [data, reload])
+
   if (loading && !data) return <LoadingState label="Loading game-day controls" />
-  if (error) return <ErrorState message={error} onRetry={reload} />
+  if (error && !data) return <ErrorState message={error} onRetry={reload} />
 
   const tournaments = data?.tournaments || []
   const tournament = selectedTournament(tournaments, tournamentId) || data?.gameDay.tournament || null
@@ -169,7 +181,6 @@ function PredictionPollControls({ poll, onUpdate }: { poll: PredictionPoll; onUp
       <StatusBadge status={poll.status} />
       <span className="muted">{poll.totalVotes ?? 0} votes</span>
       <button className="btn secondary small" onClick={() => onUpdate(poll, { status: poll.status === 'open' ? 'closed' : 'open' })}>{poll.status === 'open' ? 'Close voting' : 'Reopen voting'}</button>
-      <button className="btn secondary small" onClick={() => onUpdate(poll, { showResults: !poll.showResults })}>{poll.showResults ? 'Hide results' : 'Show results'}</button>
     </div>
   )
 }

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -34,6 +34,8 @@ export function AdminGameDayPage() {
   const tournaments = data?.tournaments || []
   const tournament = selectedTournament(tournaments, tournamentId) || data?.gameDay.tournament || null
   const gameDay = data?.gameDay
+  const selectedDate = date || gameDay?.date || ''
+  const gameDayNote = gameDay?.date === selectedDate ? gameDay?.gameDayNote || null : null
 
   return (
     <div className="page-stack admin-page">
@@ -49,7 +51,7 @@ export function AdminGameDayPage() {
         <label><span>Game day</span><input type="date" value={date} onChange={(event) => setDate(event.target.value)} /></label>
       </Panel>
 
-      <GameDayNoteForm tournament={tournament} date={date || gameDay?.date || ''} note={gameDay?.gameDayNote || null} onSaved={reload} />
+      <GameDayNoteForm tournament={tournament} date={selectedDate} note={gameDayNote} onSaved={reload} />
       <PredictionAdminPanel tournament={tournament} games={gameDay?.games || []} polls={gameDay?.predictionPolls || []} onSaved={reload} />
     </div>
   )
@@ -68,7 +70,7 @@ function GameDayNoteForm({ tournament, date, note, onSaved }: { tournament: Tour
       sponsorShoutout: note?.sponsorShoutout || '',
       active: note?.active ?? true,
     })
-  }, [note?.id, note?.updatedAt])
+  }, [date, note?.id, note?.updatedAt])
 
   const submit = async (event: FormEvent) => {
     event.preventDefault()

--- a/web/src/pages/admin/AdminGamesPage.tsx
+++ b/web/src/pages/admin/AdminGamesPage.tsx
@@ -8,9 +8,15 @@ import type { Division, Game, Team, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 
 const legacyPrefix = 'legacy:'
+const commonTipoffTimes = ['18:00', '18:30', '19:00', '19:30', '20:00', '20:30']
+type GameSortOption = 'startAsc' | 'startDesc' | 'matchup' | 'status'
 
 export function AdminGamesPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
+  const [gameQuery, setGameQuery] = useState('')
+  const [statusFilter, setStatusFilter] = useState('')
+  const [divisionFilter, setDivisionFilter] = useState('')
+  const [gameSort, setGameSort] = useState<GameSortOption>('startAsc')
   const { data, loading, error, reload } = useAsync(async () => {
     const [tournaments, teams, games, divisions] = await Promise.all([
       api.adminTournaments(),
@@ -25,12 +31,15 @@ export function AdminGamesPage() {
     if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
   }, [data?.tournaments, tournamentId, setTournamentId])
 
-  if (loading && !data) return <LoadingState label="Loading games" />
-  if (error) return <ErrorState message={error} onRetry={reload} />
-
   const tournaments = data?.tournaments || []
   const currentTournament = selectedTournament(tournaments, tournamentId)
   const divisions = data?.divisions || []
+  const games = data?.games || []
+  const visibleGames = useMemo(() => filterAndSortGames(games, gameQuery, statusFilter, divisionFilter, gameSort), [games, gameQuery, statusFilter, divisionFilter, gameSort])
+  const divisionOptions = useMemo(() => Array.from(new Set([ ...divisions.map((division) => division.name), ...games.map((game) => game.division).filter((division): division is string => Boolean(division)) ])).sort((a, b) => a.localeCompare(b)), [divisions, games])
+
+  if (loading && !data) return <LoadingState label="Loading games" />
+  if (error) return <ErrorState message={error} onRetry={reload} />
 
   return (
     <div className="page-stack admin-page">
@@ -38,10 +47,13 @@ export function AdminGamesPage() {
       <TournamentFilter tournaments={tournaments} value={currentTournament?.id || ''} onChange={setTournamentId} />
       <CreateGamePanel tournament={currentTournament} teams={data?.teams || []} divisions={divisions} onSaved={reload} />
       <Panel>
-        <div className="section-heading"><h2>Game list</h2><span>{data?.games.length || 0} games</span></div>
-        {!data?.games.length ? <EmptyState title="No games found" description="Add teams first, then create each matchup in the schedule." /> : (
-          <div className="admin-list">
-            {data.games.map((game) => <EditableGame key={game.id} game={game} divisions={divisions} onSaved={reload} />)}
+        <div className="section-heading"><h2>Game list</h2><span>{visibleGames.length} of {games.length} games</span></div>
+        <GameToolbar query={gameQuery} status={statusFilter} division={divisionFilter} sort={gameSort} divisions={divisionOptions} onQueryChange={setGameQuery} onStatusChange={setStatusFilter} onDivisionChange={setDivisionFilter} onSortChange={setGameSort} />
+        {!games.length ? <EmptyState title="No games found" description="Add teams first, then create each matchup in the schedule." /> : null}
+        {games.length > 0 && !visibleGames.length ? <EmptyState title="No games match those filters" description="Clear the search or status filter to see more games." /> : null}
+        {visibleGames.length > 0 && (
+          <div className="admin-list game-admin-list">
+            {visibleGames.map((game) => <EditableGame key={game.id} game={game} divisions={divisions} onSaved={reload} />)}
           </div>
         )}
       </Panel>
@@ -57,8 +69,19 @@ function TournamentFilter({ tournaments, value, onChange }: { tournaments: Tourn
   )
 }
 
+function GameToolbar({ query, status, division, sort, divisions, onQueryChange, onStatusChange, onDivisionChange, onSortChange }: { query: string; status: string; division: string; sort: GameSortOption; divisions: string[]; onQueryChange: (value: string) => void; onStatusChange: (value: string) => void; onDivisionChange: (value: string) => void; onSortChange: (value: GameSortOption) => void }) {
+  return (
+    <div className="game-toolbar toolbar-panel">
+      <label><span>Search games</span><input value={query} onChange={(event) => onQueryChange(event.target.value)} placeholder="Team, bracket, ticket, stream" /></label>
+      <label><span>Status</span><select value={status} onChange={(event) => onStatusChange(event.target.value)}><option value="">All statuses</option><option value="scheduled">Scheduled</option><option value="live">Live</option><option value="final">Final</option></select></label>
+      <label><span>Division</span><select value={division} onChange={(event) => onDivisionChange(event.target.value)}><option value="">All divisions</option>{divisions.map((name) => <option key={name} value={name}>{name}</option>)}</select></label>
+      <label><span>Sort</span><select value={sort} onChange={(event) => onSortChange(event.target.value as GameSortOption)}><option value="startAsc">Start time · earliest</option><option value="startDesc">Start time · latest</option><option value="matchup">Matchup</option><option value="status">Status</option></select></label>
+    </div>
+  )
+}
+
 function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament: Tournament | null; teams: Team[]; divisions: Division[]; onSaved: () => Promise<void> }) {
-  const [form, setForm] = useState({ homeTeamId: '', awayTeamId: '', startTime: '', divisionId: '', bracketCode: '', ticketUrl: '', streamUrl: '', status: 'scheduled' as Game['status'] })
+  const [form, setForm] = useState({ homeTeamId: '', awayTeamId: '', startDate: guamTodayInputValue(), startTime: '18:30', divisionId: '', bracketCode: '', ticketUrl: '', streamUrl: '', status: 'scheduled' as Game['status'] })
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState('')
   const availableTeams = useMemo(() => teams.filter((team) => !tournament || team.tournamentId === tournament.id), [teams, tournament])
@@ -88,10 +111,10 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
         bracketCode: form.bracketCode,
         ticketUrl: form.ticketUrl || null,
         streamUrl: form.streamUrl || null,
-        startTime: guamLocalDateTimeInputToIso(form.startTime),
+        startTime: guamLocalDateTimeInputToIso(`${form.startDate}T${form.startTime}`),
         ...divisionAttrs,
       })
-      setForm((current) => ({ ...current, homeTeamId: '', awayTeamId: '', startTime: '', divisionId: '', bracketCode: '', ticketUrl: '', streamUrl: '' }))
+      setForm((current) => ({ ...current, homeTeamId: '', awayTeamId: '', startTime: '18:30', divisionId: '', bracketCode: '', ticketUrl: '', streamUrl: '' }))
       setMessage('Game created')
       await onSaved()
     } catch (err) {
@@ -110,7 +133,8 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
           <FormGrid>
             <Field label="Away team"><select value={form.awayTeamId} onChange={(event) => setForm({ ...form, awayTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
             <Field label="Home team"><select value={form.homeTeamId} onChange={(event) => setForm({ ...form, homeTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
-            <Field label="Start time (Guam)"><input type="datetime-local" value={form.startTime} onChange={(event) => setForm({ ...form, startTime: event.target.value })} required /></Field>
+            <Field label="Game date (Guam)"><input type="date" value={form.startDate} onChange={(event) => setForm({ ...form, startDate: event.target.value })} required /></Field>
+            <Field label="Tipoff time"><select value={form.startTime} onChange={(event) => setForm({ ...form, startTime: event.target.value })} required>{commonTipoffTimes.map((time) => <option key={time} value={time}>{timeLabel(time)}</option>)}</select><small className="field-help">Guam time. Use game details after creation for unusual times.</small></Field>
             <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
             <Field label="Bracket / round"><input value={form.bracketCode} onChange={(event) => setForm({ ...form, bracketCode: event.target.value })} placeholder="Pool A, Semifinal, Final" /></Field>
             <Field label="Ticket URL"><input value={form.ticketUrl} onChange={(event) => setForm({ ...form, ticketUrl: event.target.value })} placeholder="GuamTime link" /></Field>
@@ -309,4 +333,52 @@ function derivedDivisionPayload(homeTeamId: string, awayTeamId: string, teams: T
   const sourceTeam = homeTeam?.division ? homeTeam : awayTeam?.division ? awayTeam : null
 
   return { divisionId: sourceTeam?.divisionId || null, division: sourceTeam ? teamDivision(sourceTeam.id, teams) || null : null }
+}
+
+function guamTodayInputValue() {
+  return new Intl.DateTimeFormat('sv-SE', {
+    timeZone: 'Pacific/Guam',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(new Date())
+}
+
+function timeLabel(value: string) {
+  const [hour, minute] = value.split(':').map(Number)
+  const period = hour >= 12 ? 'PM' : 'AM'
+  const twelveHour = hour % 12 || 12
+  return `${twelveHour}:${String(minute).padStart(2, '0')} ${period}`
+}
+
+function filterAndSortGames(games: Game[], query: string, status: string, division: string, sort: GameSortOption) {
+  const normalizedQuery = query.trim().toLowerCase()
+  return games
+    .filter((game) => {
+      const searchable = [
+        game.awayTeam?.displayName,
+        game.homeTeam?.displayName,
+        game.division,
+        game.bracketCode,
+        game.ticketUrl,
+        game.streamUrl,
+      ].filter(Boolean).join(' ').toLowerCase()
+      const matchesQuery = !normalizedQuery || searchable.includes(normalizedQuery)
+      const matchesStatus = !status || game.status === status
+      const matchesDivision = !division || game.division === division
+      return matchesQuery && matchesStatus && matchesDivision
+    })
+    .slice()
+    .sort((a, b) => compareGames(a, b, sort))
+}
+
+function compareGames(a: Game, b: Game, sort: GameSortOption) {
+  if (sort === 'startDesc') return new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
+  if (sort === 'matchup') return gameMatchup(a).localeCompare(gameMatchup(b), undefined, { numeric: true })
+  if (sort === 'status') return `${a.status} ${gameMatchup(a)}`.localeCompare(`${b.status} ${gameMatchup(b)}`, undefined, { numeric: true })
+  return new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+}
+
+function gameMatchup(game: Game) {
+  return `${game.awayTeam?.displayName || ''} at ${game.homeTeam?.displayName || ''}`
 }

--- a/web/src/pages/admin/AdminGamesPage.tsx
+++ b/web/src/pages/admin/AdminGamesPage.tsx
@@ -4,6 +4,7 @@ import { selectedTournament, useTournamentSelection } from '../../lib/admin'
 import { useAsync } from '../../lib/hooks'
 import { formatGuamDateTime, guamLocalDateTimeInputToIso, toLocalDateTimeInputValue } from '../../lib/datetime'
 import { DEFAULT_GAME_VENUE, divisionNameById, gameResultLabel, teamDivision } from '../../lib/games'
+import { externalHref } from '../../lib/urls'
 import type { Division, Game, Team, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 
@@ -109,8 +110,8 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
         status: form.status,
         venue: DEFAULT_GAME_VENUE,
         bracketCode: form.bracketCode,
-        ticketUrl: form.ticketUrl || null,
-        streamUrl: form.streamUrl || null,
+        ticketUrl: externalHref(form.ticketUrl),
+        streamUrl: externalHref(form.streamUrl),
         startTime: guamLocalDateTimeInputToIso(`${form.startDate}T${form.startTime}`),
         ...divisionAttrs,
       })
@@ -214,8 +215,8 @@ function EditableGame({ game, divisions, onSaved }: { game: Game; divisions: Div
         status: form.status,
         startTime: guamLocalDateTimeInputToIso(form.startTime),
         bracketCode: form.bracketCode,
-        ticketUrl: form.ticketUrl || null,
-        streamUrl: form.streamUrl || null,
+        ticketUrl: externalHref(form.ticketUrl),
+        streamUrl: externalHref(form.streamUrl),
         notes: form.notes || null,
         venue: game.venue || DEFAULT_GAME_VENUE,
         ...divisionPayload(form.divisionId, divisions),
@@ -287,8 +288,8 @@ function GameDetailsSummary({ game }: { game: Game }) {
     <dl className="game-detail-summary">
       <div><dt>Division</dt><dd>{game.division || 'Use team division'}</dd></div>
       <div><dt>Bracket</dt><dd>{game.bracketCode || 'Not set'}</dd></div>
-      <div><dt>Tickets</dt><dd>{game.ticketUrl ? <a href={game.ticketUrl} target="_blank" rel="noreferrer">Open ticket link</a> : 'Not posted'}</dd></div>
-      <div><dt>Stream</dt><dd>{game.streamUrl ? <a href={game.streamUrl} target="_blank" rel="noreferrer">Open stream link</a> : 'Not posted'}</dd></div>
+      <div><dt>Tickets</dt><dd>{game.ticketUrl ? <a href={externalHref(game.ticketUrl) || undefined} target="_blank" rel="noreferrer">Open ticket link</a> : 'Not posted'}</dd></div>
+      <div><dt>Stream</dt><dd>{game.streamUrl ? <a href={externalHref(game.streamUrl) || undefined} target="_blank" rel="noreferrer">Open stream link</a> : 'Not posted'}</dd></div>
     </dl>
   )
 }

--- a/web/src/pages/admin/AdminGamesPage.tsx
+++ b/web/src/pages/admin/AdminGamesPage.tsx
@@ -8,7 +8,7 @@ import type { Division, Game, Team, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 
 const legacyPrefix = 'legacy:'
-const commonTipoffTimes = ['18:00', '18:30', '19:00', '19:30', '20:00', '20:30']
+const tipoffQuickTimes = ['11:00', '12:00', '13:15', '13:30', '18:00', '18:30', '19:00', '19:30', '20:00', '20:30']
 type GameSortOption = 'startAsc' | 'startDesc' | 'matchup' | 'status'
 
 export function AdminGamesPage() {
@@ -134,7 +134,7 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
             <Field label="Away team"><select value={form.awayTeamId} onChange={(event) => setForm({ ...form, awayTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
             <Field label="Home team"><select value={form.homeTeamId} onChange={(event) => setForm({ ...form, homeTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
             <Field label="Game date (Guam)"><input type="date" value={form.startDate} onChange={(event) => setForm({ ...form, startDate: event.target.value })} required /></Field>
-            <Field label="Tipoff time"><select value={form.startTime} onChange={(event) => setForm({ ...form, startTime: event.target.value })} required>{commonTipoffTimes.map((time) => <option key={time} value={time}>{timeLabel(time)}</option>)}</select><small className="field-help">Guam time. Use game details after creation for unusual times.</small></Field>
+            <TipoffTimeField value={form.startTime} onChange={(startTime) => setForm({ ...form, startTime })} />
             <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
             <Field label="Bracket / round"><input value={form.bracketCode} onChange={(event) => setForm({ ...form, bracketCode: event.target.value })} placeholder="Pool A, Semifinal, Final" /></Field>
             <Field label="Ticket URL"><input value={form.ticketUrl} onChange={(event) => setForm({ ...form, ticketUrl: event.target.value })} placeholder="GuamTime link" /></Field>
@@ -144,6 +144,23 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
         </form>
       )}
     </Panel>
+  )
+}
+
+function TipoffTimeField({ value, onChange }: { value: string; onChange: (value: string) => void }) {
+  return (
+    <div className="field tipoff-field">
+      <label htmlFor="create-game-tipoff-time">Tipoff time (Guam)</label>
+      <input id="create-game-tipoff-time" type="time" value={value} onChange={(event) => onChange(event.target.value)} step={60} required />
+      <small className="field-help">Type any Guam tipoff time, or use a shortcut below for common weekday and weekend starts.</small>
+      <div className="time-shortcuts" aria-label="Common tipoff time shortcuts">
+        {tipoffQuickTimes.map((time) => (
+          <button key={time} type="button" className={value === time ? 'time-chip selected' : 'time-chip'} onClick={() => onChange(time)}>
+            {timeLabel(time)}
+          </button>
+        ))}
+      </div>
+    </div>
   )
 }
 

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -3,6 +3,7 @@ import { api } from '../../lib/api'
 import { selectedTournament, useTournamentSelection } from '../../lib/admin'
 import { useAsync } from '../../lib/hooks'
 import { formatGuamDateTime } from '../../lib/datetime'
+import { externalHref } from '../../lib/urls'
 import type { Game, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel } from '../../components/ui'
 
@@ -28,7 +29,7 @@ export function AdminLinksPage() {
   const save = async () => {
     const updates = (data?.games || [])
       .filter((game) => drafts[game.id] && (drafts[game.id].ticketUrl !== (game.ticketUrl || '') || drafts[game.id].streamUrl !== (game.streamUrl || '')))
-      .map((game) => ({ id: game.id, ticketUrl: drafts[game.id].ticketUrl || null, streamUrl: drafts[game.id].streamUrl || null }))
+      .map((game) => ({ id: game.id, ticketUrl: externalHref(drafts[game.id].ticketUrl), streamUrl: externalHref(drafts[game.id].streamUrl) }))
 
     if (!updates.length) {
       setMessage('No link changes to save')

--- a/web/src/pages/public/HomePage.tsx
+++ b/web/src/pages/public/HomePage.tsx
@@ -1,17 +1,56 @@
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
 import { useAsync } from '../../lib/hooks'
+import { externalHref } from '../../lib/urls'
+import { readOrCreateVoterToken } from '../../lib/voter'
 import { formatGuamDateTime } from '../../lib/datetime'
 import { DEFAULT_GAME_VENUE, formatTournamentWindow } from '../../lib/games'
 import { EmptyState, ErrorState, LoadingState, Panel, StatCard } from '../../components/ui'
 import { IconArrowRight, IconCalendar, IconPlay, IconTrophy } from '../../components/Icons'
-import type { Game, GameDayNote } from '../../lib/types'
+import { PredictionPollCard } from '../../components/PredictionPollCard'
+import type { Game, GameDayNote, PredictionPoll } from '../../lib/types'
+
+const homeRefreshIntervalMs = 15_000
 
 export function HomePage() {
-  const { data, loading, error, reload } = useAsync(() => api.publicHome(), [])
+  const [voterToken] = useState(readOrCreateVoterToken)
+  const [pollOverrides, setPollOverrides] = useState<Record<string, PredictionPoll>>({})
+  const [voteError, setVoteError] = useState('')
+  const { data, loading, error, reload } = useAsync(() => api.publicHome(voterToken), [voterToken])
 
-  if (loading) return <LoadingState />
-  if (error) return <ErrorState message={error} onRetry={reload} />
+  useEffect(() => {
+    setPollOverrides({})
+  }, [data])
+
+  useEffect(() => {
+    if (!data) return undefined
+
+    const intervalId = window.setInterval(() => {
+      void reload()
+    }, homeRefreshIntervalMs)
+
+    return () => window.clearInterval(intervalId)
+  }, [data, reload])
+
+  const homePolls = useMemo(() => {
+    const base = data?.predictionPolls || []
+    return base.map((poll) => pollOverrides[poll.id] || poll)
+  }, [data?.predictionPolls, pollOverrides])
+  const featuredPoll = useMemo(() => featuredPollForHome(homePolls), [homePolls])
+
+  const vote = async (poll: PredictionPoll, teamId: string) => {
+    setVoteError('')
+    try {
+      const result = await api.publicVotePrediction(poll.id, { teamId, voterToken })
+      setPollOverrides((current) => ({ ...current, [poll.id]: result.predictionPoll }))
+    } catch (err) {
+      setVoteError(err instanceof Error ? err.message : 'Unable to save prediction')
+    }
+  }
+
+  if (loading && !data) return <LoadingState />
+  if (error && !data) return <ErrorState message={error} onRetry={reload} />
   if (!data) return <EmptyState title="Tournament data unavailable" />
 
   const tournamentLabel = data.tournament ? `${data.tournament.name} ${data.tournament.year}` : 'FD Alumni Tournament Hub'
@@ -71,6 +110,22 @@ export function HomePage() {
               {gameDayNote.sponsorShoutout && <small>{gameDayNote.sponsorShoutout}</small>}
             </div>
           )}
+          {featuredPoll ? (
+            <div className="home-poll-callout">
+              <div className="home-poll-copy">
+                <span>Fan prediction</span>
+                <strong>{featuredPoll.pollType === 'tournament' ? 'Vote on the tournament winner.' : 'Vote on today’s matchup.'}</strong>
+                <small>No sign-in required. Results refresh automatically.</small>
+              </div>
+              {voteError && <p className="form-error" role="alert">{voteError}</p>}
+              <PredictionPollCard poll={featuredPoll} onVote={vote} compact />
+            </div>
+          ) : (
+            <div className="home-poll-teaser">
+              <strong>Fan predictions</strong>
+              <span>Polls open from the Today guide on game day. Vote with one tap when matchups are ready.</span>
+            </div>
+          )}
           {featuredGames.length === 0 ? (
             <EmptyState title="No games scheduled for today" description="Open the Today guide for game-day notes, or check the full schedule for upcoming matchups." action={<Link className="btn secondary" to="/today">See what’s posted today <IconArrowRight /></Link>} />
           ) : (
@@ -105,11 +160,11 @@ export function HomePage() {
       </section>
 
       <section className="partner-strip">
-        <a href={import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net'} target="_blank" rel="noreferrer">
+        <a href={externalHref(import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net') || undefined} target="_blank" rel="noreferrer">
           <span>Tickets</span>
           <strong>Buy through GuamTime when game tickets are available.</strong>
         </a>
-        <a href={import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com'} target="_blank" rel="noreferrer">
+        <a href={externalHref(import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com') || undefined} target="_blank" rel="noreferrer">
           <span>Streams</span>
           <strong>Watch live through Clutch or the approved stream partner for each game.</strong>
         </a>
@@ -120,6 +175,10 @@ export function HomePage() {
       </section>
     </div>
   )
+}
+
+function featuredPollForHome(polls: PredictionPoll[]) {
+  return polls.find((poll) => poll.open && poll.pollType === 'game') || polls.find((poll) => poll.open) || polls[0] || null
 }
 
 function featuredGamesForHome(liveGames: Game[], todayGames: Game[]) {

--- a/web/src/pages/public/HomePage.tsx
+++ b/web/src/pages/public/HomePage.tsx
@@ -5,6 +5,7 @@ import { formatGuamDateTime } from '../../lib/datetime'
 import { DEFAULT_GAME_VENUE, formatTournamentWindow } from '../../lib/games'
 import { EmptyState, ErrorState, LoadingState, Panel, StatCard } from '../../components/ui'
 import { IconArrowRight, IconCalendar, IconPlay, IconTrophy } from '../../components/Icons'
+import type { Game, GameDayNote } from '../../lib/types'
 
 export function HomePage() {
   const { data, loading, error, reload } = useAsync(() => api.publicHome(), [])
@@ -14,7 +15,9 @@ export function HomePage() {
   if (!data) return <EmptyState title="Tournament data unavailable" />
 
   const tournamentLabel = data.tournament ? `${data.tournament.name} ${data.tournament.year}` : 'FD Alumni Tournament Hub'
-  const featuredGames = [...data.liveGames, ...data.todayGames].slice(0, 6)
+  const featuredGames = featuredGamesForHome(data.liveGames, data.todayGames)
+  const gameDayNote = data.gameDayNote
+  const hasGameDayNote = hasHomeGameDayNote(gameDayNote)
   const heroTournament = data.upcomingOrLiveTournament || data.tournament
   const heroStatus = heroTournament ? `${heroTournament.year} · ${heroTournament.status}` : 'Schedule pending'
   const heroDates = heroTournament ? formatTournamentWindow(heroTournament) : 'Dates will appear once organizers publish them.'
@@ -51,13 +54,29 @@ export function HomePage() {
 
       <section className="split-grid">
         <Panel>
-          <div className="section-heading"><h2>Today and live</h2><Link to="/schedule">Full schedule</Link></div>
+          <div className="section-heading home-today-heading">
+            <h2>Today at The Jungle</h2>
+            <div className="section-actions">
+              <Link className="btn secondary small" to="/today">Open Today guide <IconArrowRight /></Link>
+              <Link to="/schedule">Full schedule</Link>
+            </div>
+          </div>
+          {hasGameDayNote && (
+            <div className="home-today-note">
+              <div className="home-today-note-grid">
+                {gameDayNote.hostClass && <div><span>Host class</span><strong>{gameDayNote.hostClass}</strong></div>}
+                {gameDayNote.foodMenu && <div><span>Food / menu</span><strong>{gameDayNote.foodMenu}</strong></div>}
+              </div>
+              {gameDayNote.announcement && <p>{gameDayNote.announcement}</p>}
+              {gameDayNote.sponsorShoutout && <small>{gameDayNote.sponsorShoutout}</small>}
+            </div>
+          )}
           {featuredGames.length === 0 ? (
-            <EmptyState title="No games scheduled for today" description="Check the full schedule for upcoming matchups, ticket links, and stream links." />
+            <EmptyState title="No games scheduled for today" description="Open the Today guide for game-day notes, or check the full schedule for upcoming matchups." action={<Link className="btn secondary" to="/today">See what’s posted today <IconArrowRight /></Link>} />
           ) : (
             <div className="compact-list">
               {featuredGames.map((game) => (
-                <Link key={game.id} to="/schedule" className="compact-row">
+                <Link key={game.id} to="/today" className="compact-row">
                   <span>{formatGuamDateTime(game.startTime)}</span>
                   <strong>{game.awayTeam?.displayName || 'Away team'} at {game.homeTeam?.displayName || 'Home team'}</strong>
                   <small>{game.venue || DEFAULT_GAME_VENUE}</small>
@@ -101,4 +120,19 @@ export function HomePage() {
       </section>
     </div>
   )
+}
+
+function featuredGamesForHome(liveGames: Game[], todayGames: Game[]) {
+  const seenGameIds = new Set<string>()
+
+  return [...liveGames, ...todayGames].filter((game) => {
+    if (seenGameIds.has(game.id)) return false
+
+    seenGameIds.add(game.id)
+    return true
+  }).slice(0, 6)
+}
+
+function hasHomeGameDayNote(note: GameDayNote | null): note is GameDayNote {
+  return Boolean(note?.hostClass || note?.foodMenu || note?.announcement || note?.sponsorShoutout)
 }

--- a/web/src/pages/public/HomePage.tsx
+++ b/web/src/pages/public/HomePage.tsx
@@ -27,7 +27,8 @@ export function HomePage() {
           <h1>Schedules, scores, streams, and stories from The Jungle.</h1>
           <p>{tournamentLabel}. A clean guide for alumni, families, and fans to follow the tournament while routing tickets, streams, and coverage to the right partners.</p>
           <div className="hero-actions">
-            <Link className="btn primary" to="/schedule"><IconCalendar /> View schedule <IconArrowRight /></Link>
+            <Link className="btn primary" to="/today"><IconCalendar /> Today at The Jungle <IconArrowRight /></Link>
+            <Link className="btn secondary" to="/schedule">Schedule</Link>
             <Link className="btn secondary" to="/standings"><IconTrophy /> Standings</Link>
             <Link className="btn secondary" to="/watch"><IconPlay /> Watch</Link>
           </div>

--- a/web/src/pages/public/SchedulePage.tsx
+++ b/web/src/pages/public/SchedulePage.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'react-router-dom'
 import { useMemo, useState } from 'react'
 import { api } from '../../lib/api'
 import { formatGuamDateTime, guamDayLabel, isPastGuamGame } from '../../lib/datetime'
@@ -5,7 +6,7 @@ import { useAsync } from '../../lib/hooks'
 import { DEFAULT_GAME_VENUE } from '../../lib/games'
 import type { Game } from '../../lib/types'
 import { EmptyState, ErrorState, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
-import { IconExternal } from '../../components/Icons'
+import { IconArrowRight, IconExternal } from '../../components/Icons'
 
 export function SchedulePage() {
   const [division, setDivision] = useState('')
@@ -24,6 +25,14 @@ export function SchedulePage() {
         title="Tournament schedule"
         description="Game times are shown for Guam. Ticket and stream buttons route to partner platforms when links are available."
       />
+
+      <Panel className="watch-hero today-schedule-callout">
+        <div>
+          <h2>Today at The Jungle</h2>
+          <p>Mobile-first game-day info, roster notes, live links, and fan predictions.</p>
+        </div>
+        <Link className="btn primary" to="/today">Open Today <IconArrowRight /></Link>
+      </Panel>
 
       <Panel className="toolbar-panel">
         <label><span>Division</span><select value={division} onChange={(event) => setDivision(event.target.value)}><option value="">All divisions</option>{data?.divisions.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>

--- a/web/src/pages/public/SchedulePage.tsx
+++ b/web/src/pages/public/SchedulePage.tsx
@@ -4,6 +4,7 @@ import { api } from '../../lib/api'
 import { formatGuamDateTime, guamDayLabel, isPastGuamGame } from '../../lib/datetime'
 import { useAsync } from '../../lib/hooks'
 import { DEFAULT_GAME_VENUE } from '../../lib/games'
+import { externalHref } from '../../lib/urls'
 import type { Game } from '../../lib/types'
 import { EmptyState, ErrorState, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 import { IconArrowRight, IconExternal } from '../../components/Icons'
@@ -75,8 +76,8 @@ function GameCard({ game }: { game: Game }) {
         {game.bracketCode && <span>{game.bracketCode}</span>}
       </div>
       <div className="game-actions">
-        {game.ticketUrl ? <a className="btn secondary small" href={game.ticketUrl} target="_blank" rel="noreferrer">Tickets <IconExternal /></a> : <span className="link-muted">Ticket link pending</span>}
-        {game.streamUrl ? <a className="btn secondary small" href={game.streamUrl} target="_blank" rel="noreferrer">Stream <IconExternal /></a> : <span className="link-muted">Stream link pending</span>}
+        {game.ticketUrl ? <a className="btn secondary small" href={externalHref(game.ticketUrl) || undefined} target="_blank" rel="noreferrer">Tickets <IconExternal /></a> : <span className="link-muted">Ticket link pending</span>}
+        {game.streamUrl ? <a className="btn secondary small" href={externalHref(game.streamUrl) || undefined} target="_blank" rel="noreferrer">Stream <IconExternal /></a> : <span className="link-muted">Stream link pending</span>}
       </div>
     </article>
   )

--- a/web/src/pages/public/TodayPage.tsx
+++ b/web/src/pages/public/TodayPage.tsx
@@ -89,7 +89,7 @@ export function TodayPage() {
 
 function TodayGameCard({ game, poll, onVote }: { game: Game; poll?: PredictionPoll; onVote: (poll: PredictionPoll, teamId: string) => Promise<void> }) {
   return (
-    <article className="today-game-card">
+    <article className={poll ? 'today-game-card' : 'today-game-card today-game-card--no-poll'}>
       <div className="today-game-main">
         <div className="game-card-top">
           <span>{formatGuamDateTime(game.startTime)}</span>
@@ -103,7 +103,7 @@ function TodayGameCard({ game, poll, onVote }: { game: Game; poll?: PredictionPo
         </div>
         <RosterDetails game={game} />
       </div>
-      {poll ? <PredictionPollCard poll={poll} onVote={onVote} compact /> : <div className="prediction-empty">Predictions will appear here when voting opens.</div>}
+      {poll && <PredictionPollCard poll={poll} onVote={onVote} compact />}
     </article>
   )
 }

--- a/web/src/pages/public/TodayPage.tsx
+++ b/web/src/pages/public/TodayPage.tsx
@@ -55,7 +55,7 @@ export function TodayPage() {
           <span>Food / menu</span>
           <strong>{data?.gameDayNote?.foodMenu || 'Food notes pending'}</strong>
         </Panel>
-        <Panel className="today-brief-card wide">
+        <Panel className="today-brief-card today-brief-card--wide">
           <span>Announcements</span>
           <strong>{data?.gameDayNote?.announcement || 'No announcements posted yet.'}</strong>
           {data?.lastUpdatedAt && <small>Last updated {formatGuamDateTime(data.lastUpdatedAt)}</small>}

--- a/web/src/pages/public/TodayPage.tsx
+++ b/web/src/pages/public/TodayPage.tsx
@@ -21,8 +21,8 @@ export function TodayPage() {
     return base.map((poll) => pollOverrides[poll.id] || poll)
   }, [data?.predictionPolls, pollOverrides])
 
-  const tournamentPolls = polls.filter((poll) => poll.pollType === 'tournament')
-  const gamePolls = new Map(polls.filter((poll) => poll.pollType === 'game' && poll.gameId).map((poll) => [poll.gameId!, poll]))
+  const tournamentPolls = useMemo(() => polls.filter((poll) => poll.pollType === 'tournament'), [polls])
+  const gamePolls = useMemo(() => new Map(polls.filter((poll) => poll.pollType === 'game' && poll.gameId).map((poll) => [poll.gameId!, poll])), [polls])
 
   const vote = async (poll: PredictionPoll, teamId: string) => {
     setVoteError('')

--- a/web/src/pages/public/TodayPage.tsx
+++ b/web/src/pages/public/TodayPage.tsx
@@ -1,0 +1,178 @@
+import { useMemo, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { api } from '../../lib/api'
+import { formatGuamDate, formatGuamDateTime } from '../../lib/datetime'
+import { DEFAULT_GAME_VENUE } from '../../lib/games'
+import { useAsync } from '../../lib/hooks'
+import type { Game, PredictionPoll, RosterEntry } from '../../lib/types'
+import { EmptyState, ErrorState, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
+import { IconArrowRight, IconExternal } from '../../components/Icons'
+
+const voterTokenKey = 'fd-alumni-voter-token'
+
+export function TodayPage() {
+  const [voterToken] = useState(readOrCreateVoterToken)
+  const [pollOverrides, setPollOverrides] = useState<Record<string, PredictionPoll>>({})
+  const [voteError, setVoteError] = useState('')
+  const { data, loading, error, reload } = useAsync(() => api.publicToday({}, voterToken), [voterToken])
+
+  const polls = useMemo(() => {
+    const base = data?.predictionPolls || []
+    return base.map((poll) => pollOverrides[poll.id] || poll)
+  }, [data?.predictionPolls, pollOverrides])
+
+  const tournamentPolls = polls.filter((poll) => poll.pollType === 'tournament')
+  const gamePolls = new Map(polls.filter((poll) => poll.pollType === 'game' && poll.gameId).map((poll) => [poll.gameId!, poll]))
+
+  const vote = async (poll: PredictionPoll, teamId: string) => {
+    setVoteError('')
+    try {
+      const result = await api.publicVotePrediction(poll.id, { teamId, voterToken })
+      setPollOverrides((current) => ({ ...current, [poll.id]: result.predictionPoll }))
+    } catch (err) {
+      setVoteError(err instanceof Error ? err.message : 'Unable to save prediction')
+    }
+  }
+
+  if (loading && !data) return <LoadingState label="Loading today at The Jungle" />
+  if (error) return <ErrorState message={error} onRetry={reload} />
+
+  return (
+    <div className="page-stack today-page">
+      <PageHeader
+        eyebrow="Today at The Jungle"
+        title="Game-day guide"
+        description={data?.date ? `${formatGuamDate(data.date, { weekday: 'long' })} · live info, ticket links, stream links, rosters, and fan predictions.` : 'Live game-day info, ticket links, stream links, rosters, and fan predictions.'}
+        actions={<Link className="btn secondary" to="/schedule">Full schedule <IconArrowRight /></Link>}
+      />
+
+      <section className="today-brief-grid">
+        <Panel className="today-brief-card">
+          <span>Host class</span>
+          <strong>{data?.gameDayNote?.hostClass || 'Host details pending'}</strong>
+        </Panel>
+        <Panel className="today-brief-card">
+          <span>Food / menu</span>
+          <strong>{data?.gameDayNote?.foodMenu || 'Food notes pending'}</strong>
+        </Panel>
+        <Panel className="today-brief-card wide">
+          <span>Announcements</span>
+          <strong>{data?.gameDayNote?.announcement || 'No announcements posted yet.'}</strong>
+          {data?.lastUpdatedAt && <small>Last updated {formatGuamDateTime(data.lastUpdatedAt)}</small>}
+        </Panel>
+      </section>
+
+      {data?.gameDayNote?.sponsorShoutout && <Panel className="notice-panel">{data.gameDayNote.sponsorShoutout}</Panel>}
+
+      {voteError && <p className="form-error" role="alert">{voteError}</p>}
+
+      {tournamentPolls.length > 0 && (
+        <Panel>
+          <div className="section-heading"><h2>Tournament predictions</h2><span>{tournamentPolls.length}</span></div>
+          <div className="prediction-grid">
+            {tournamentPolls.map((poll) => <PredictionPollCard key={poll.id} poll={poll} onVote={vote} />)}
+          </div>
+        </Panel>
+      )}
+
+      <Panel>
+        <div className="section-heading"><h2>Games today</h2><span>{data?.games.length || 0}</span></div>
+        {!data?.games.length ? <EmptyState title="No games scheduled today" description="Check the full schedule for the next matchup at The Jungle." /> : (
+          <div className="today-game-list">
+            {data.games.map((game) => <TodayGameCard key={game.id} game={game} poll={gamePolls.get(game.id)} onVote={vote} />)}
+          </div>
+        )}
+      </Panel>
+    </div>
+  )
+}
+
+function TodayGameCard({ game, poll, onVote }: { game: Game; poll?: PredictionPoll; onVote: (poll: PredictionPoll, teamId: string) => Promise<void> }) {
+  return (
+    <article className="today-game-card">
+      <div className="today-game-main">
+        <div className="game-card-top">
+          <span>{formatGuamDateTime(game.startTime)}</span>
+          <StatusBadge status={game.status} />
+        </div>
+        <h2>{game.awayTeam?.displayName || 'Away team'} at {game.homeTeam?.displayName || 'Home team'}</h2>
+        <p>{game.venue || DEFAULT_GAME_VENUE}</p>
+        <div className="game-actions">
+          {game.ticketUrl ? <a className="btn secondary small" href={game.ticketUrl} target="_blank" rel="noreferrer">Tickets <IconExternal /></a> : <span className="link-muted">Tickets pending</span>}
+          {game.streamUrl ? <a className="btn primary small" href={game.streamUrl} target="_blank" rel="noreferrer">Stream <IconExternal /></a> : <span className="link-muted">Stream pending</span>}
+        </div>
+        <RosterDetails game={game} />
+      </div>
+      {poll ? <PredictionPollCard poll={poll} onVote={onVote} compact /> : <div className="prediction-empty">Predictions will appear here when voting opens.</div>}
+    </article>
+  )
+}
+
+function RosterDetails({ game }: { game: Game }) {
+  const awayRoster = activeRoster(game.awayTeam?.rosterEntries)
+  const homeRoster = activeRoster(game.homeTeam?.rosterEntries)
+  if (!awayRoster.length && !homeRoster.length) return null
+
+  return (
+    <details className="roster-details">
+      <summary>Rosters</summary>
+      <div className="roster-columns">
+        <RosterList title={game.awayTeam?.displayName || 'Away team'} entries={awayRoster} />
+        <RosterList title={game.homeTeam?.displayName || 'Home team'} entries={homeRoster} />
+      </div>
+    </details>
+  )
+}
+
+function RosterList({ title, entries }: { title: string; entries: RosterEntry[] }) {
+  return <div><h3>{title}</h3>{entries.length ? <ul>{entries.map((entry) => <li key={entry.id}>{entry.jerseyNumber && <span>#{entry.jerseyNumber}</span>}<strong>{entry.name}</strong>{entry.nickname && <small>“{entry.nickname}”</small>}{entry.position && <small>{entry.position}</small>}</li>)}</ul> : <p className="muted">Roster pending</p>}</div>
+}
+
+function PredictionPollCard({ poll, onVote, compact = false }: { poll: PredictionPoll; onVote: (poll: PredictionPoll, teamId: string) => Promise<void>; compact?: boolean }) {
+  const [savingTeamId, setSavingTeamId] = useState<string | null>(null)
+
+  const choose = async (teamId: string) => {
+    setSavingTeamId(teamId)
+    try {
+      await onVote(poll, teamId)
+    } finally {
+      setSavingTeamId(null)
+    }
+  }
+
+  return (
+    <div className={`prediction-card ${compact ? 'compact' : ''}`}>
+      <div className="prediction-card-head">
+        <span>{poll.open ? 'Voting open' : 'Voting closed'}</span>
+        <strong>{poll.question}</strong>
+      </div>
+      <div className="prediction-options">
+        {poll.options.map((option) => (
+          <button key={option.teamId} type="button" className={option.selected ? 'selected' : ''} onClick={() => choose(option.teamId)} disabled={!poll.open || savingTeamId !== null}>
+            <span>{option.displayName}</span>
+            {poll.resultsVisible && <small>{option.percent ?? 0}% · {option.votes ?? 0} votes</small>}
+            {!poll.resultsVisible && <small>Vote to reveal</small>}
+          </button>
+        ))}
+      </div>
+      {poll.selectedTeamId && poll.open && <small className="prediction-note">Vote saved. Tap another team to change it.</small>}
+    </div>
+  )
+}
+
+function activeRoster(entries?: RosterEntry[]) {
+  return (entries || []).filter((entry) => entry.active)
+}
+
+function readOrCreateVoterToken() {
+  try {
+    const existing = window.localStorage.getItem(voterTokenKey)
+    if (existing) return existing
+
+    const token = window.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    window.localStorage.setItem(voterTokenKey, token)
+    return token
+  } catch {
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  }
+}

--- a/web/src/pages/public/TodayPage.tsx
+++ b/web/src/pages/public/TodayPage.tsx
@@ -1,20 +1,37 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { api } from '../../lib/api'
 import { formatGuamDate, formatGuamDateTime } from '../../lib/datetime'
 import { DEFAULT_GAME_VENUE } from '../../lib/games'
 import { useAsync } from '../../lib/hooks'
+import { externalHref } from '../../lib/urls'
+import { readOrCreateVoterToken } from '../../lib/voter'
 import type { Game, PredictionPoll, RosterEntry } from '../../lib/types'
 import { EmptyState, ErrorState, LoadingState, PageHeader, Panel, StatusBadge } from '../../components/ui'
 import { IconArrowRight, IconExternal } from '../../components/Icons'
+import { PredictionPollCard } from '../../components/PredictionPollCard'
 
-const voterTokenKey = 'fd-alumni-voter-token'
+const todayRefreshIntervalMs = 10_000
 
 export function TodayPage() {
   const [voterToken] = useState(readOrCreateVoterToken)
   const [pollOverrides, setPollOverrides] = useState<Record<string, PredictionPoll>>({})
   const [voteError, setVoteError] = useState('')
   const { data, loading, error, reload } = useAsync(() => api.publicToday({}, voterToken), [voterToken])
+
+  useEffect(() => {
+    setPollOverrides({})
+  }, [data])
+
+  useEffect(() => {
+    if (!data) return undefined
+
+    const intervalId = window.setInterval(() => {
+      void reload()
+    }, todayRefreshIntervalMs)
+
+    return () => window.clearInterval(intervalId)
+  }, [data, reload])
 
   const polls = useMemo(() => {
     const base = data?.predictionPolls || []
@@ -35,7 +52,7 @@ export function TodayPage() {
   }
 
   if (loading && !data) return <LoadingState label="Loading today at The Jungle" />
-  if (error) return <ErrorState message={error} onRetry={reload} />
+  if (error && !data) return <ErrorState message={error} onRetry={reload} />
 
   return (
     <div className="page-stack today-page">
@@ -98,8 +115,8 @@ function TodayGameCard({ game, poll, onVote }: { game: Game; poll?: PredictionPo
         <h2>{game.awayTeam?.displayName || 'Away team'} at {game.homeTeam?.displayName || 'Home team'}</h2>
         <p>{game.venue || DEFAULT_GAME_VENUE}</p>
         <div className="game-actions">
-          {game.ticketUrl ? <a className="btn secondary small" href={game.ticketUrl} target="_blank" rel="noreferrer">Tickets <IconExternal /></a> : <span className="link-muted">Tickets pending</span>}
-          {game.streamUrl ? <a className="btn primary small" href={game.streamUrl} target="_blank" rel="noreferrer">Stream <IconExternal /></a> : <span className="link-muted">Stream pending</span>}
+          {game.ticketUrl ? <a className="btn secondary small" href={externalHref(game.ticketUrl) || undefined} target="_blank" rel="noreferrer">Tickets <IconExternal /></a> : <span className="link-muted">Tickets pending</span>}
+          {game.streamUrl ? <a className="btn primary small" href={externalHref(game.streamUrl) || undefined} target="_blank" rel="noreferrer">Stream <IconExternal /></a> : <span className="link-muted">Stream pending</span>}
         </div>
         <RosterDetails game={game} />
       </div>
@@ -128,51 +145,6 @@ function RosterList({ title, entries }: { title: string; entries: RosterEntry[] 
   return <div><h3>{title}</h3>{entries.length ? <ul>{entries.map((entry) => <li key={entry.id}>{entry.jerseyNumber && <span>#{entry.jerseyNumber}</span>}<strong>{entry.name}</strong>{entry.nickname && <small>“{entry.nickname}”</small>}{entry.position && <small>{entry.position}</small>}</li>)}</ul> : <p className="muted">Roster pending</p>}</div>
 }
 
-function PredictionPollCard({ poll, onVote, compact = false }: { poll: PredictionPoll; onVote: (poll: PredictionPoll, teamId: string) => Promise<void>; compact?: boolean }) {
-  const [savingTeamId, setSavingTeamId] = useState<string | null>(null)
-
-  const choose = async (teamId: string) => {
-    setSavingTeamId(teamId)
-    try {
-      await onVote(poll, teamId)
-    } finally {
-      setSavingTeamId(null)
-    }
-  }
-
-  return (
-    <div className={`prediction-card ${compact ? 'compact' : ''}`}>
-      <div className="prediction-card-head">
-        <span>{poll.open ? 'Voting open' : 'Voting closed'}</span>
-        <strong>{poll.question}</strong>
-      </div>
-      <div className="prediction-options">
-        {poll.options.map((option) => (
-          <button key={option.teamId} type="button" className={option.selected ? 'selected' : ''} onClick={() => choose(option.teamId)} disabled={!poll.open || savingTeamId !== null}>
-            <span>{option.displayName}</span>
-            {poll.resultsVisible && <small>{option.percent ?? 0}% · {option.votes ?? 0} votes</small>}
-            {!poll.resultsVisible && <small>Vote to reveal</small>}
-          </button>
-        ))}
-      </div>
-      {poll.selectedTeamId && poll.open && <small className="prediction-note">Vote saved. Tap another team to change it.</small>}
-    </div>
-  )
-}
-
 function activeRoster(entries?: RosterEntry[]) {
   return (entries || []).filter((entry) => entry.active)
-}
-
-function readOrCreateVoterToken() {
-  try {
-    const existing = window.localStorage.getItem(voterTokenKey)
-    if (existing) return existing
-
-    const token = window.crypto?.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`
-    window.localStorage.setItem(voterTokenKey, token)
-    return token
-  } catch {
-    return `${Date.now()}-${Math.random().toString(36).slice(2)}`
-  }
 }

--- a/web/src/pages/public/WatchPage.tsx
+++ b/web/src/pages/public/WatchPage.tsx
@@ -2,6 +2,7 @@ import { api } from '../../lib/api'
 import { useAsync } from '../../lib/hooks'
 import { formatGuamDateTime } from '../../lib/datetime'
 import { DEFAULT_GAME_VENUE } from '../../lib/games'
+import { externalHref } from '../../lib/urls'
 import { EmptyState, ErrorState, LoadingState, PageHeader, Panel } from '../../components/ui'
 import { IconExternal, IconPlay } from '../../components/Icons'
 
@@ -28,7 +29,7 @@ export function WatchPage() {
           <h2>Live links appear as games are confirmed</h2>
           <p>When a stream is ready, the game card below takes you straight to the live broadcast source.</p>
         </div>
-        <a className="btn primary" href={import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com'} target="_blank" rel="noreferrer">Open Clutch <IconExternal /></a>
+        <a className="btn primary" href={externalHref(import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com') || undefined} target="_blank" rel="noreferrer">Open Clutch <IconExternal /></a>
       </Panel>
 
       {streamGames.length === 0 ? (
@@ -40,7 +41,7 @@ export function WatchPage() {
               <span>{formatGuamDateTime(game.startTime)}</span>
               <h2>{game.awayTeam?.displayName || 'Away team'} at {game.homeTeam?.displayName || 'Home team'}</h2>
               <p>{game.venue || DEFAULT_GAME_VENUE}</p>
-              <a className="btn primary" href={game.streamUrl || '#'} target="_blank" rel="noreferrer">Watch stream <IconExternal /></a>
+              <a className="btn primary" href={externalHref(game.streamUrl) || '#'} target="_blank" rel="noreferrer">Watch stream <IconExternal /></a>
             </article>
           ))}
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -126,6 +126,12 @@ button:disabled { opacity: .62; cursor: progress; }
 .home-today-note strong { color: var(--ink); line-height: 1.2; }
 .home-today-note p { margin: 0; color: var(--ink); font-weight: 850; line-height: 1.35; }
 .home-today-note small { color: var(--fd-maroon); font-weight: 900; }
+.home-poll-callout, .home-poll-teaser { display: grid; gap: .7rem; margin-bottom: .85rem; padding: .9rem; border-radius: 1rem; border: 1px solid var(--line); background: var(--surface-strong); }
+.home-poll-callout { border-color: rgba(111,29,53,.18); background: linear-gradient(135deg, #fff, #fff8ea); }
+.home-poll-copy { display: grid; gap: .18rem; }
+.home-poll-copy span { color: var(--fd-maroon); font-size: .72rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+.home-poll-copy strong, .home-poll-teaser strong { color: var(--ink); line-height: 1.2; }
+.home-poll-copy small, .home-poll-teaser span { color: var(--muted); font-weight: 750; line-height: 1.35; }
 .partner-strip { display: grid; grid-template-columns: repeat(3, 1fr); gap: .8rem; }
 .partner-strip div, .partner-strip a { padding: 1.1rem; border-radius: 1.25rem; background: var(--surface-strong); border: 1px solid var(--line); transition: transform .16s ease, border-color .16s ease; }
 .partner-strip a:hover { transform: translateY(-1px); border-color: rgba(111,29,53,.32); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -226,6 +226,42 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .watch-hero svg { color: var(--fd-maroon); }
 .watch-hero h2 { margin: 0; }
 .watch-hero p { margin: .25rem 0 0; color: var(--muted); }
+.today-schedule-callout { grid-template-columns: minmax(0, 1fr) auto; }
+.today-brief-grid { display: grid; grid-template-columns: minmax(0, .8fr) minmax(0, .9fr) minmax(0, 1.3fr); gap: .8rem; }
+.today-brief-card { display: grid; gap: .35rem; }
+.today-brief-card span, .prediction-card-head span { color: var(--fd-maroon); font-size: .76rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+.today-brief-card strong { font-size: clamp(1.1rem, 2vw, 1.45rem); line-height: 1.2; }
+.today-brief-card small { color: var(--muted); }
+.today-game-list { display: grid; gap: 1rem; }
+.today-game-card { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, .72fr); gap: 1rem; padding: 1rem; border: 1px solid var(--line); border-radius: 1.2rem; background: #fff; box-shadow: 0 12px 34px rgba(66,16,31,.06); }
+.today-game-main { display: grid; align-content: start; gap: .75rem; }
+.today-game-main h2 { margin: 0; font-size: clamp(1.35rem, 3vw, 2rem); letter-spacing: -.045em; }
+.today-game-main p { margin: 0; color: var(--muted); font-weight: 700; }
+.roster-details { border-top: 1px solid var(--line); padding-top: .75rem; }
+.roster-details summary { color: var(--fd-maroon); cursor: pointer; font-weight: 900; }
+.roster-columns { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; margin-top: .7rem; }
+.roster-columns h3 { margin: 0 0 .4rem; font-size: .95rem; }
+.roster-columns ul { display: grid; gap: .35rem; list-style: none; margin: 0; padding: 0; }
+.roster-columns li { display: flex; flex-wrap: wrap; gap: .35rem; align-items: baseline; padding: .45rem .55rem; border-radius: .7rem; background: var(--surface-strong); }
+.roster-columns li span { color: var(--fd-maroon); font-weight: 900; }
+.roster-columns li small { color: var(--muted); }
+.prediction-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
+.prediction-card, .prediction-empty { display: grid; gap: .7rem; align-content: start; padding: .9rem; border-radius: 1rem; background: var(--surface-strong); border: 1px solid var(--line); }
+.prediction-card.compact { background: #fffaf3; }
+.prediction-card-head { display: grid; gap: .25rem; }
+.prediction-card-head strong { font-size: 1rem; line-height: 1.25; }
+.prediction-options { display: grid; gap: .5rem; }
+.prediction-options button { width: 100%; display: grid; gap: .2rem; text-align: left; border: 1px solid var(--line); border-radius: .85rem; background: #fff; color: var(--ink); padding: .65rem .75rem; cursor: pointer; }
+.prediction-options button:hover:not(:disabled), .prediction-options button.selected { border-color: rgba(111,29,53,.45); background: var(--fd-maroon-50); }
+.prediction-options button:disabled { cursor: not-allowed; }
+.prediction-options button span { font-weight: 900; }
+.prediction-options button small, .prediction-note, .prediction-empty { color: var(--muted); }
+.team-admin-card, .roster-admin-panel, .admin-prediction-stack { display: grid; gap: .85rem; }
+.roster-admin-panel { padding-top: .8rem; border-top: 1px solid var(--line); }
+.roster-admin-row { gap: .65rem; background: var(--surface-strong); }
+.prediction-admin-row { grid-template-columns: minmax(0, 1fr) auto; align-items: center; }
+.prediction-admin-row p { margin: .25rem 0 0; }
+.prediction-admin-controls { display: flex; flex-wrap: wrap; gap: .55rem; align-items: center; justify-content: flex-end; }
 
 .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
 .admin-shell { min-height: 100vh; background: radial-gradient(circle at top right, rgba(200,155,60,.14), transparent 28rem), var(--paper); }
@@ -321,7 +357,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 @media (max-width: 980px) {
   .desktop-nav, .admin-link { display: none; }
   .mobile-only { display: grid; }
-  .hero-card, .split-grid { grid-template-columns: 1fr; }
+  .hero-card, .split-grid, .today-game-card, .prediction-admin-row { grid-template-columns: 1fr; }
   .admin-sidebar-desktop { display: none; }
   .admin-mobile-topbar { position: sticky; top: 0; z-index: 35; display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .75rem 1rem; border-bottom: 1px solid rgba(111,29,53,.12); background: rgba(255,250,245,.94); backdrop-filter: blur(16px); }
   .admin-mobile-topbar div { display: grid; text-align: center; line-height: 1.1; }
@@ -334,7 +370,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-mobile-close { position: absolute; top: .9rem; right: .85rem; z-index: 2; display: grid; place-items: center; width: 2.35rem; height: 2.35rem; border: 1px solid rgba(255,255,255,.14); border-radius: .85rem; color: rgba(255,255,255,.8); background: rgba(255,255,255,.08); }
   .admin-content, .admin-content.sidebar-collapsed { margin-left: 0; padding: 1rem clamp(.85rem, 3vw, 1.25rem) 2.5rem; }
   .admin-topbar { display: none; }
-  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .archive-card-grid, .archive-media-strip { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .archive-card-grid, .archive-media-strip, .today-brief-grid, .prediction-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .form-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .game-detail-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .compact-admin-row { grid-template-columns: 1fr; }
@@ -361,7 +397,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .hero-actions .btn, .watch-hero .btn { width: 100%; }
   .section-heading { align-items: flex-start; flex-wrap: wrap; }
   .panel, .state-card, .stat-card { border-radius: 1.1rem; }
-  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .form-grid, .health-grid, .archive-card-grid, .archive-media-strip, .archive-hero { grid-template-columns: 1fr; }
+  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .form-grid, .health-grid, .archive-card-grid, .archive-media-strip, .archive-hero, .today-brief-grid, .today-game-card, .prediction-grid, .roster-columns, .prediction-admin-row { grid-template-columns: 1fr; }
   .archive-hero img { justify-self: start; }
   .timeline-link-row { grid-template-columns: 1fr auto; }
   .timeline-link-row .timeline-year { grid-column: 1 / -1; }
@@ -373,6 +409,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-content, .admin-content.sidebar-collapsed { padding: .75rem .75rem 2rem; }
   .admin-page .page-header h1 { font-size: clamp(2rem, 11vw, 3rem); }
   .admin-row-head { align-items: flex-start; }
+  .prediction-admin-controls { justify-content: flex-start; }
   .row-actions .btn, .game-actions .btn { width: 100%; }
   .game-detail-summary, .score-entry-panel .form-grid { grid-template-columns: 1fr; }
   .compact-admin-row, .media-admin-row, .sponsor-admin-row { grid-template-columns: 1fr; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -321,8 +321,30 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .admin-shortcuts { display: flex; flex-wrap: wrap; gap: .65rem; }
 .admin-shortcuts a { padding: .75rem .95rem; border-radius: 999px; background: var(--fd-maroon-50); color: var(--fd-maroon); font-weight: 900; }
 .admin-list { display: grid; gap: .85rem; }
+.team-card-list, .game-admin-list { margin-top: 1rem; }
+.team-toolbar, .game-toolbar { margin-bottom: 1rem; padding: .8rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface-strong); }
+.team-toolbar label:first-child, .game-toolbar label:first-child { flex: 1 1 18rem; }
 .compact-admin-list { margin-top: 1rem; }
 .admin-row-card { padding: 1rem; border: 1px solid var(--line); border-radius: 1.15rem; background: #fff; display: grid; gap: .85rem; }
+.team-summary-card { position: relative; overflow: hidden; border-color: rgba(111,29,53,.16); box-shadow: 0 16px 38px rgba(66,16,31,.07); }
+.team-summary-card::before { content: ""; position: absolute; inset: 0 auto 0 0; width: .32rem; background: linear-gradient(180deg, var(--fd-maroon), var(--fd-gold)); }
+.team-card-header { display: flex; justify-content: space-between; gap: 1rem; align-items: flex-start; padding: .2rem 0 .75rem .55rem; border-bottom: 1px solid var(--line); }
+.team-card-header h3 { margin: .15rem 0 .2rem; font-size: clamp(1.25rem, 2vw, 1.7rem); letter-spacing: -.05em; }
+.team-card-header p { margin: 0; color: var(--muted); font-weight: 800; }
+.team-card-kicker { display: inline-flex; width: fit-content; border-radius: 999px; background: var(--fd-maroon-50); color: var(--fd-maroon); padding: .32rem .55rem; font-size: .72rem; font-weight: 950; letter-spacing: .08em; text-transform: uppercase; }
+.team-facts-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .7rem; }
+.team-facts-grid div { min-width: 0; padding: .85rem; border: 1px solid var(--line); border-radius: .95rem; background: var(--surface-strong); }
+.team-facts-grid span { display: block; color: var(--muted); font-size: .72rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.team-facts-grid strong { display: block; margin-top: .15rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.team-edit-panel { display: grid; gap: .7rem; padding: .9rem; border: 1px dashed rgba(111,29,53,.22); border-radius: 1rem; background: #fffaf3; }
+.team-edit-panel .form-grid { margin-bottom: 0; }
+.roster-manager-body { gap: .8rem; }
+.roster-table-wrap { max-height: 20rem; overflow: auto; border: 1px solid var(--line); border-radius: 1rem; background: #fff; }
+.roster-admin-table { min-width: 760px; }
+.roster-admin-table td, .roster-admin-table th { white-space: nowrap; }
+.modal-backdrop { position: fixed; inset: 0; z-index: 100; display: grid; place-items: center; padding: 1rem; background: rgba(23,20,26,.42); backdrop-filter: blur(6px); }
+.modal-card { width: min(42rem, 100%); max-height: min(90vh, 48rem); overflow: auto; border: 1px solid rgba(255,255,255,.74); border-radius: 1.25rem; background: var(--surface); box-shadow: 0 30px 90px rgba(23,20,26,.28); padding: 1.1rem; }
+.roster-modal form { display: grid; gap: .75rem; }
 .compact-admin-row { grid-template-columns: minmax(0, 1fr) auto auto; align-items: end; }
 .compact-admin-row .form-grid { margin: 0; }
 .admin-row-head { display: flex; justify-content: space-between; gap: 1rem; align-items: center; }
@@ -373,7 +395,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-topbar { display: none; }
   .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .archive-card-grid, .archive-media-strip, .today-brief-grid, .prediction-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .form-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .game-detail-summary { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .game-detail-summary, .team-facts-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .compact-admin-row { grid-template-columns: 1fr; }
 }
 
@@ -412,7 +434,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-row-head { align-items: flex-start; }
   .prediction-admin-controls { justify-content: flex-start; }
   .row-actions .btn, .game-actions .btn { width: 100%; }
-  .game-detail-summary, .score-entry-panel .form-grid { grid-template-columns: 1fr; }
+  .game-detail-summary, .score-entry-panel .form-grid, .team-facts-grid { grid-template-columns: 1fr; }
   .compact-admin-row, .media-admin-row, .sponsor-admin-row { grid-template-columns: 1fr; }
   .compact-admin-row .form-grid, .media-admin-row .form-grid, .sponsor-admin-row .form-grid, .media-admin-row .row-actions, .sponsor-admin-row .row-actions, .media-admin-row .form-error, .sponsor-admin-row .form-error { grid-column: auto; }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -227,8 +227,9 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .watch-hero h2 { margin: 0; }
 .watch-hero p { margin: .25rem 0 0; color: var(--muted); }
 .today-schedule-callout { grid-template-columns: minmax(0, 1fr) auto; }
-.today-brief-grid { display: grid; grid-template-columns: minmax(0, .8fr) minmax(0, .9fr) minmax(0, 1.3fr); gap: .8rem; }
+.today-brief-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
 .today-brief-card { display: grid; gap: .35rem; }
+.today-brief-card--wide { grid-column: 1 / -1; }
 .today-brief-card span, .prediction-card-head span { color: var(--fd-maroon); font-size: .76rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
 .today-brief-card strong { font-size: clamp(1.1rem, 2vw, 1.45rem); line-height: 1.2; }
 .today-brief-card small { color: var(--muted); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -118,6 +118,14 @@ button:disabled { opacity: .62; cursor: progress; }
 .compact-row:hover { border-color: rgba(111,29,53,.32); }
 .compact-row span { color: var(--fd-maroon); font-weight: 900; font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; }
 .compact-row small, .compact-row p { color: var(--muted); }
+.section-actions { display: flex; flex-wrap: wrap; gap: .55rem; align-items: center; justify-content: flex-end; }
+.home-today-note { display: grid; gap: .65rem; margin-bottom: .85rem; padding: .9rem; border: 1px solid rgba(200,155,60,.42); border-radius: 1rem; background: linear-gradient(135deg, #fffaf0, #fff); }
+.home-today-note-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .55rem; }
+.home-today-note-grid div { display: grid; gap: .18rem; }
+.home-today-note span { color: var(--fd-maroon); font-size: .72rem; font-weight: 900; letter-spacing: .1em; text-transform: uppercase; }
+.home-today-note strong { color: var(--ink); line-height: 1.2; }
+.home-today-note p { margin: 0; color: var(--ink); font-weight: 850; line-height: 1.35; }
+.home-today-note small { color: var(--fd-maroon); font-weight: 900; }
 .partner-strip { display: grid; grid-template-columns: repeat(3, 1fr); gap: .8rem; }
 .partner-strip div, .partner-strip a { padding: 1.1rem; border-radius: 1.25rem; background: var(--surface-strong); border: 1px solid var(--line); transition: transform .16s ease, border-color .16s ease; }
 .partner-strip a:hover { transform: translateY(-1px); border-color: rgba(111,29,53,.32); }
@@ -126,7 +134,7 @@ button:disabled { opacity: .62; cursor: progress; }
 
 .toolbar-panel { display: flex; gap: 1rem; flex-wrap: wrap; align-items: end; }
 .toolbar-panel label, .field { display: grid; align-content: start; align-self: start; gap: .35rem; min-width: min(100%, 12rem); }
-.field span, .toolbar-panel label span { font-size: .78rem; color: var(--muted); font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
+.field span, .field > label, .toolbar-panel label span { font-size: .78rem; color: var(--muted); font-weight: 900; text-transform: uppercase; letter-spacing: .08em; }
 input, select, textarea { width: 100%; min-height: 2.75rem; border: 1px solid var(--line); border-radius: .85rem; background: #fff; padding: .75rem .85rem; color: var(--ink); }
 input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.26); border-color: var(--fd-gold); }
 .form-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); align-items: start; gap: .85rem; margin-bottom: 1rem; }
@@ -135,6 +143,10 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .form-error { margin: -.25rem 0 .2rem; color: var(--danger); font-weight: 800; }
 .form-note { margin: -.25rem 0 .2rem; color: var(--success); font-weight: 900; }
 .field-help { color: var(--muted); font-size: .76rem; font-weight: 700; line-height: 1.35; }
+.tipoff-field { min-width: min(100%, 16rem); }
+.time-shortcuts { display: flex; flex-wrap: wrap; gap: .4rem; }
+.time-chip { min-height: 2rem; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--fd-maroon); padding: .38rem .58rem; font-size: .78rem; font-weight: 900; cursor: pointer; transition: background .16s ease, border-color .16s ease, transform .16s ease; }
+.time-chip:hover, .time-chip.selected { transform: translateY(-1px); border-color: rgba(111,29,53,.38); background: var(--fd-maroon-50); }
 .image-url-upload { display: grid; gap: .45rem; }
 .image-url-upload input[type="file"] { min-height: 2.4rem; padding: .55rem; border-style: dashed; background: var(--surface-strong); color: var(--fd-maroon); font-weight: 800; }
 .image-url-upload input[type="file"]:disabled { cursor: not-allowed; opacity: .58; }
@@ -235,6 +247,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .today-brief-card small { color: var(--muted); }
 .today-game-list { display: grid; gap: 1rem; }
 .today-game-card { display: grid; grid-template-columns: minmax(0, 1fr) minmax(18rem, .72fr); gap: 1rem; padding: 1rem; border: 1px solid var(--line); border-radius: 1.2rem; background: #fff; box-shadow: 0 12px 34px rgba(66,16,31,.06); }
+.today-game-card--no-poll { grid-template-columns: 1fr; }
 .today-game-main { display: grid; align-content: start; gap: .75rem; }
 .today-game-main h2 { margin: 0; font-size: clamp(1.35rem, 3vw, 2rem); letter-spacing: -.045em; }
 .today-game-main p { margin: 0; color: var(--muted); font-weight: 700; }
@@ -419,8 +432,9 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .hero-panel-rule { width: 100%; height: 1px; min-height: 0; }
   .hero-actions .btn, .watch-hero .btn { width: 100%; }
   .section-heading { align-items: flex-start; flex-wrap: wrap; }
+  .section-actions { width: 100%; justify-content: flex-start; }
   .panel, .state-card, .stat-card { border-radius: 1.1rem; }
-  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .form-grid, .health-grid, .archive-card-grid, .archive-media-strip, .archive-hero, .today-brief-grid, .today-game-card, .prediction-grid, .roster-columns, .prediction-admin-row { grid-template-columns: 1fr; }
+  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .form-grid, .health-grid, .archive-card-grid, .archive-media-strip, .archive-hero, .home-today-note-grid, .today-brief-grid, .today-game-card, .prediction-grid, .roster-columns, .prediction-admin-row { grid-template-columns: 1fr; }
   .archive-hero img { justify-self: start; }
   .timeline-link-row { grid-template-columns: 1fr auto; }
   .timeline-link-row .timeline-year { grid-column: 1 / -1; }


### PR DESCRIPTION
## Summary
- Add Phase B game-day/fan-engagement foundation for the Rails API + React/Vite app.
- Add a public `Today at The Jungle` page with game-day notes, today’s games, ticket/stream links, optional rosters, tournament/game predictions, sponsor shoutouts, and last-updated context.
- Add admin game-day controls for daily host/menu/announcement/sponsor notes and prediction poll open/close/result visibility.
- Add optional roster management to the existing admin Teams page.
- Add anonymous prediction voting with local device tokens, server-side token hashing, vote updates, and admin-closeable polls.
- Surface Today from the public nav, homepage hero, schedule callout, admin sidebar, and sitemap.

## Backend
- New tables/models:
  - `game_day_notes`
  - `roster_entries`
  - `prediction_polls`
  - `prediction_votes`
- New public endpoints:
  - `GET /api/v1/public/today`
  - `POST /api/v1/public/prediction-polls/:prediction_poll_id/vote`
- New admin endpoints:
  - `GET/POST/PATCH /api/v1/admin/game-day-notes`
  - `GET/POST/PATCH /api/v1/admin/prediction-polls`
  - `POST/PATCH/DELETE /api/v1/admin/roster-entries`

## Frontend
- New public page: `/today`
- New admin page: `/admin/game-day`
- Admin Teams page now supports optional roster entry add/edit/remove.
- Prediction UI is one-tap and allows changing votes while a poll is open.

## Verification
- `npm run web:build`
- `cd api && bin/rails test`
- `cd api && bin/rubocop --no-color`
- `./scripts/gate.sh`

## Notes
- This remains additive to the Rails/Vite side-by-side app. It does not cut production over from the current Next app.
- Prediction voting is intentionally lightweight and anonymous; it is one-device/local-token based, not fraud-proof polling.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Phase B game-day and fan-engagement features: a public `/today` page with game notes, rosters, ticket/stream links, and prediction polls; an admin game-day management page; optional team roster entries; and an anonymous device-token-based prediction voting system backed by four new tables and corresponding API endpoints.

- **Backend**: Adds `game_day_notes`, `roster_entries`, `prediction_polls`, and `prediction_votes` tables with proper cascade foreign keys; new public and admin controllers follow the existing scoping conventions; URL normalization moved to the model layer via `external_url`.
- **Frontend**: New `TodayPage`, `AdminGameDayPage`, `PredictionPollCard`; roster management inline in `AdminDivisionsPage`; voter token persisted to `localStorage` and hashed server-side before storage.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. All new admin endpoints are correctly scoped to the active tournament, and the public vote endpoint gates on poll open/closed status through model validation.

All four new tables have proper cascade foreign keys and unique indexes. The upsert vote path handles the race-condition retry correctly. Admin controllers scope lookups through `admin_tournament` consistently. The only findings are efficiency notes (missing `inverse_of` causing redundant SQL on vote saves) rather than correctness problems.

No files require special attention. The `inverse_of` additions in `prediction_poll.rb` and `prediction_vote.rb` are the only suggested changes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/app/controllers/api/v1/public/prediction_votes_controller.rb | Public vote endpoint; upsert-with-retry pattern correctly handles race conditions; plain voter token travels in request body (by design); `persist_vote` retry on RecordNotUnique is safe for PostgreSQL. |
| api/app/models/prediction_poll.rb | Well-structured model with memoized option_teams and preload-aware vote totals; missing `inverse_of` on prediction_votes means extra SQL during validation; `show_results` column absent (tracked in prior review threads). |
| api/app/models/prediction_vote.rb | Correct validation logic for open-poll and valid-team checks; `team_is_valid_option` triggers additional SQL queries per save because the poll association isn't linked via `inverse_of`. |
| api/app/controllers/api/v1/admin/prediction_polls_controller.rb | Create correctly scoped via admin_tournament.prediction_polls.build; update scoped through admin_tournament; RecordNotUnique rescued with 422. |
| api/app/controllers/api/v1/admin/roster_entries_controller.rb | Create resolves team through admin_tournament scope; update and destroy use roster_entry_scope which joins on tournament_id; all cross-tournament access prevented. |
| api/db/migrate/20260615000001_add_game_day_rosters_and_predictions.rb | All four tables created with appropriate null constraints, cascade foreign keys, unique indexes on game-poll and vote token, and composite indexes for common query patterns. |
| api/db/migrate/20260615000002_add_unique_tournament_prediction_poll_index.rb | Adds partial unique index for tournament-type polls; correctly replaces the earlier non-partial index and provides reversible down migration. |
| web/src/lib/voter.ts | Correctly creates and persists a UUID voter token in localStorage with a fallback for private browsing; lazy initialization via useState initializer is correct React usage. |
| web/src/pages/public/TodayPage.tsx | Polls, game cards, roster collapsibles, and optimistic vote overrides all implemented correctly; 10-second auto-refresh; externalHref applied client-side over already-normalized server URLs (idempotent). |
| web/src/pages/admin/AdminGameDayPage.tsx | Admin upsert form, prediction poll open/close controls, and 10-second auto-refresh implemented cleanly; tournament context and date selector wired correctly. |
| api/app/models/game.rb | Adds external_url normalization helper and optional roster inclusion in api_json; URL normalization is idempotent and handles protocol-relative and bare-domain URLs correctly. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Browser
    participant VoterStorage as localStorage
    participant PublicAPI as Rails Public API
    participant AdminAPI as Rails Admin API
    participant DB

    Note over Browser,DB: Page Load – Today
    Browser->>VoterStorage: readOrCreateVoterToken()
    VoterStorage-->>Browser: voterToken (UUID)
    Browser->>PublicAPI: GET /public/today (X-FD-Voter-Token header)
    PublicAPI->>DB: games, game_day_notes, prediction_polls + votes
    DB-->>PublicAPI: records
    PublicAPI->>PublicAPI: SHA256(voterToken) → selectedTeamId lookup
    PublicAPI-->>Browser: "{gameDayNote, games+rosters, predictionPolls, sponsors}"

    Note over Browser,DB: Anonymous Vote
    Browser->>PublicAPI: "POST /public/prediction-polls/:id/vote {teamId, voterToken}"
    PublicAPI->>PublicAPI: "token_hash = SHA256(voterToken)"
    PublicAPI->>DB: find_or_initialize_by voter_token_hash
    DB-->>PublicAPI: existing or new PredictionVote
    PublicAPI->>DB: vote.save (validates poll_is_open + team_is_valid_option)
    DB-->>PublicAPI: saved
    PublicAPI-->>Browser: "{predictionPoll with updated counts + selectedTeamId}"

    Note over Browser,DB: Admin – Game Day Controls
    Browser->>AdminAPI: "GET /admin/game-day-notes?tournamentId=&date="
    AdminAPI->>DB: tournament scoped notes, games, polls
    DB-->>AdminAPI: records
    AdminAPI-->>Browser: "{gameDayNote, games, predictionPolls}"
    Browser->>AdminAPI: POST /admin/game-day-notes (upsert by date)
    AdminAPI->>DB: find_or_initialize_by(date:).update(attrs)
    DB-->>AdminAPI: saved
    Browser->>AdminAPI: PATCH /admin/prediction-polls/:id (open/close)
    AdminAPI->>DB: poll.update(status:)
    DB-->>AdminAPI: updated poll
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Browser
    participant VoterStorage as localStorage
    participant PublicAPI as Rails Public API
    participant AdminAPI as Rails Admin API
    participant DB

    Note over Browser,DB: Page Load – Today
    Browser->>VoterStorage: readOrCreateVoterToken()
    VoterStorage-->>Browser: voterToken (UUID)
    Browser->>PublicAPI: GET /public/today (X-FD-Voter-Token header)
    PublicAPI->>DB: games, game_day_notes, prediction_polls + votes
    DB-->>PublicAPI: records
    PublicAPI->>PublicAPI: SHA256(voterToken) → selectedTeamId lookup
    PublicAPI-->>Browser: "{gameDayNote, games+rosters, predictionPolls, sponsors}"

    Note over Browser,DB: Anonymous Vote
    Browser->>PublicAPI: "POST /public/prediction-polls/:id/vote {teamId, voterToken}"
    PublicAPI->>PublicAPI: "token_hash = SHA256(voterToken)"
    PublicAPI->>DB: find_or_initialize_by voter_token_hash
    DB-->>PublicAPI: existing or new PredictionVote
    PublicAPI->>DB: vote.save (validates poll_is_open + team_is_valid_option)
    DB-->>PublicAPI: saved
    PublicAPI-->>Browser: "{predictionPoll with updated counts + selectedTeamId}"

    Note over Browser,DB: Admin – Game Day Controls
    Browser->>AdminAPI: "GET /admin/game-day-notes?tournamentId=&date="
    AdminAPI->>DB: tournament scoped notes, games, polls
    DB-->>AdminAPI: records
    AdminAPI-->>Browser: "{gameDayNote, games, predictionPolls}"
    Browser->>AdminAPI: POST /admin/game-day-notes (upsert by date)
    AdminAPI->>DB: find_or_initialize_by(date:).update(attrs)
    DB-->>AdminAPI: saved
    Browser->>AdminAPI: PATCH /admin/prediction-polls/:id (open/close)
    AdminAPI->>DB: poll.update(status:)
    DB-->>AdminAPI: updated poll
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/app/models/prediction_poll.rb`, line 431 ([link](https://github.com/shimizu-technology/fd-alumni-hub/blob/9aa537db825626829ee96b632d2e3b3b52f35013/api/app/models/prediction_poll.rb#L431)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`group(:team_id).count` bypasses the preloaded association**

   `prediction_votes.group(:team_id).count` adds a scope clause, which causes ActiveRecord to issue a new `SELECT team_id, COUNT(*) … GROUP BY team_id` query even when `prediction_votes` was already eager-loaded via `includes(:prediction_votes, …)`. With N polls on the `today` or admin game-day page, this produces N extra round-trips on every render. Since the association is already loaded you can compute the same result in Ruby: `prediction_votes.group_by(&:team_id).transform_values(&:count)`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: api/app/models/prediction_poll.rb
   Line: 431

   Comment:
   **`group(:team_id).count` bypasses the preloaded association**

   `prediction_votes.group(:team_id).count` adds a scope clause, which causes ActiveRecord to issue a new `SELECT team_id, COUNT(*) … GROUP BY team_id` query even when `prediction_votes` was already eager-loaded via `includes(:prediction_votes, …)`. With N polls on the `today` or admin game-day page, this produces N extra round-trips on every render. Since the association is already loaded you can compute the same result in Ruby: `prediction_votes.group_by(&:team_id).transform_values(&:count)`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (17): Last reviewed commit: ["Remove dead poll result visibility field"](https://github.com/shimizu-technology/fd-alumni-hub/commit/a834bd1a349318195742e9ad4f3fb83d71d111d4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37626136)</sub>

<!-- /greptile_comment -->