### PR TITLE
Import 2026 pool play schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,5 +91,10 @@ cp web/.env.example web/.env.local
 npm run web:dev
 ```
 
-Rails public routes include home, tournaments, schedule, standings, articles, media assets, and sponsors.
-Rails admin routes now cover dashboard, tournaments, teams, games, standings recompute, articles, media assets, sponsors, ingest review, bulk links, and missing-link/data-health checks.
+Rails public routes include home, today/game-day, tournaments, schedule, standings, articles, media assets, sponsors, and anonymous prediction voting.
+Rails admin routes now cover dashboard, tournaments, teams/rosters, games, game-day notes/polls, standings recompute, articles, media assets, sponsors, ingest review, bulk links, and missing-link/data-health checks.
+
+Deployment/schedule planning doc:
+- `docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md`
+
+The Rails seed path now idempotently imports the 2026 organizer pool-play schedule from `data/schedules/fd-2026-pool-play-2026-06-27.json` unless `FD_SEED_2026_SCHEDULE=0` is set.

--- a/api/README.md
+++ b/api/README.md
@@ -16,6 +16,8 @@ bin/rails db:seed
 bin/rails server -p 3001
 ```
 
+`db:seed` imports the 2026 organizer pool-play schedule by default. Set `FD_SEED_2026_SCHEDULE=0` only for special blank-database testing.
+
 Optional local demo seed:
 
 ```bash
@@ -40,6 +42,8 @@ curl http://localhost:3001/health
 ## Public endpoints
 
 - `GET /api/v1/public/home`
+- `GET /api/v1/public/today`
+- `POST /api/v1/public/prediction-polls/:prediction_poll_id/vote`
 - `GET /api/v1/public/tournaments`
 - `GET /api/v1/public/schedule`
 - `GET /api/v1/public/standings`
@@ -71,6 +75,16 @@ Local admin testing should use real Clerk sign-in with an allowlisted email. See
 - `GET /api/v1/admin/teams`
 - `POST /api/v1/admin/teams`
 - `PATCH /api/v1/admin/teams/:id`
+- `DELETE /api/v1/admin/teams/:id`
+- `POST /api/v1/admin/roster-entries`
+- `PATCH /api/v1/admin/roster-entries/:id`
+- `DELETE /api/v1/admin/roster-entries/:id`
+- `GET /api/v1/admin/game-day-notes`
+- `POST /api/v1/admin/game-day-notes`
+- `PATCH /api/v1/admin/game-day-notes/:id`
+- `GET /api/v1/admin/prediction-polls`
+- `POST /api/v1/admin/prediction-polls`
+- `PATCH /api/v1/admin/prediction-polls/:id`
 - `GET /api/v1/admin/games`
 - `GET /api/v1/admin/games/:id`
 - `POST /api/v1/admin/games`
@@ -110,3 +124,13 @@ Use the operator-run migration path in `docs/RAILS-DATA-MIGRATION-RUNBOOK.md`:
 - validate with `bin/rails fd:migration:validate_next_snapshot[...]`
 
 Production data import/cutover must remain an explicit operator-run step.
+
+## 2026 schedule import
+
+Structured schedule data lives in `../data/schedules/fd-2026-pool-play-2026-06-27.json`.
+
+```bash
+bin/rails fd:schedule:import_2026
+```
+
+The import is idempotent and also runs from `db:seed` unless `FD_SEED_2026_SCHEDULE=0` is set. Normal seed runs create missing games and preserve existing game edits. To intentionally apply a revised source schedule over existing games, run `FD_SCHEDULE_IMPORT_OVERWRITE=1 bin/rails fd:schedule:import_2026`. It imports confirmed pool/father-son schedule rows and intentionally skips rows without a confirmed time/team matchup.

--- a/api/README.md
+++ b/api/README.md
@@ -133,4 +133,4 @@ Structured schedule data lives in `../data/schedules/fd-2026-pool-play-2026-06-2
 bin/rails fd:schedule:import_2026
 ```
 
-The import is idempotent and also runs from `db:seed` unless `FD_SEED_2026_SCHEDULE=0` is set. Normal seed runs create missing games and preserve existing game edits. To intentionally apply a revised source schedule over existing games, run `FD_SCHEDULE_IMPORT_OVERWRITE=1 bin/rails fd:schedule:import_2026`. It imports confirmed pool/father-son schedule rows and intentionally skips rows without a confirmed time/team matchup.
+The import is idempotent and also runs from `db:seed` unless `FD_SEED_2026_SCHEDULE=0` is set. Normal seed runs create missing games and preserve existing tournament, team, and game edits. To intentionally apply a revised source schedule over existing records, run `FD_SCHEDULE_IMPORT_OVERWRITE=1 bin/rails fd:schedule:import_2026`. It imports confirmed pool/father-son schedule rows and intentionally skips rows without a confirmed time/team matchup.

--- a/api/app/models/game.rb
+++ b/api/app/models/game.rb
@@ -37,7 +37,8 @@ class Game < ApplicationRecord
   end
 
   def fatherson_phase?
-    bracket_code == "FS" || home_team&.display_name.to_s.match?(/\bFS\b/i) || away_team&.display_name.to_s.match?(/\bFS\b/i)
+    notes.to_s.include?("phase=fatherson") || bracket_code.to_s.start_with?("FS") ||
+      home_team&.display_name.to_s.match?(/\bFS\b/i) || away_team&.display_name.to_s.match?(/\bFS\b/i)
   end
 
   def summary_json

--- a/api/app/services/data_import/fd_2026_schedule_import.rb
+++ b/api/app/services/data_import/fd_2026_schedule_import.rb
@@ -1,0 +1,146 @@
+require "json"
+
+module DataImport
+  class Fd2026ScheduleImport
+    DEFAULT_PATH = Rails.root.join("..", "data", "schedules", "fd-2026-pool-play-2026-06-27.json").expand_path.freeze
+    SOURCE_NOTE = "source=fd-2026-pool-play-2026-06-27".freeze
+
+    def self.call(path: nil, overwrite: false)
+      new(path: path, overwrite: overwrite).call
+    end
+
+    def initialize(path: nil, overwrite: false)
+      @path = Pathname(path.presence || DEFAULT_PATH)
+      @overwrite = overwrite
+    end
+
+    def call
+      payload = JSON.parse(path.read)
+      games = payload.fetch("games")
+      source = payload.fetch("source")
+
+      ActiveRecord::Base.transaction do
+        tournament = upsert_tournament(payload.fetch("tournament"))
+        teams = upsert_teams(tournament, games)
+        import_games(tournament, teams, games, source)
+        Standings::Recompute.call(tournament)
+
+        {
+          tournamentId: tournament.id.to_s,
+          tournamentYear: tournament.year,
+          teams: teams.length,
+          games: games.length,
+          skippedRows: payload.fetch("skippedRows", []).length,
+          overwrite: overwrite?,
+          source: source.slice("title", "scheduleAsOf", "sourceFile")
+        }
+      end
+    end
+
+    private
+
+    attr_reader :path
+
+    def overwrite?
+      @overwrite == true
+    end
+
+    def upsert_tournament(attrs)
+      tournament = Tournament.find_by(year: attrs.fetch("year")) || Tournament.new(year: attrs.fetch("year"))
+      tournament.name = attrs.fetch("name") if tournament.name.blank?
+      tournament.legacy_id ||= "fd-#{attrs.fetch("year")}-tournament"
+      tournament.start_date = Date.iso8601(attrs.fetch("startDate"))
+      tournament.end_date = Date.iso8601(attrs.fetch("endDate"))
+      tournament.status = attrs.fetch("status") if tournament.new_record?
+      tournament.save!
+      tournament
+    end
+
+    def upsert_teams(tournament, games)
+      labels = games.flat_map { |game| [ game.fetch("awayTeam"), game.fetch("homeTeam") ] }.uniq
+
+      labels.index_with { |label| upsert_team(tournament, label) }
+    end
+
+    def upsert_team(tournament, label)
+      legacy_id = team_legacy_id(label)
+      team = Team.find_by(legacy_id: legacy_id) || tournament.teams.find_by(display_name: label) || tournament.teams.build
+      team.legacy_id ||= legacy_id
+      team.class_year_label = label
+      team.display_name = label
+      team.save!
+      team
+    end
+
+    def import_games(tournament, teams, games, source)
+      games.each do |entry|
+        away_team = teams.fetch(entry.fetch("awayTeam"))
+        home_team = teams.fetch(entry.fetch("homeTeam"))
+        start_time = guam_start_time(entry.fetch("date"), entry.fetch("time"))
+        game = game_for_import(tournament, entry, away_team, home_team, start_time)
+
+        game.legacy_id ||= game_legacy_id(entry.fetch("gameNumber"))
+        game.status = "scheduled" if game.new_record?
+        assign_schedule_fields(game, entry, away_team, home_team, start_time, source) if game.new_record? || overwrite?
+        preserve_schedule_metadata(game, entry, source) unless game.new_record? || overwrite?
+        game.save!
+      end
+    end
+
+    def assign_schedule_fields(game, entry, away_team, home_team, start_time, source)
+      game.away_team = away_team
+      game.home_team = home_team
+      game.start_time = start_time
+      game.venue = source.fetch("venue", "The Jungle")
+      game.bracket_code = entry.fetch("gameNumber")
+      game.notes = imported_notes(game.notes, entry.fetch("phase"), source.fetch("scheduleAsOf"))
+    end
+
+    def preserve_schedule_metadata(game, entry, source)
+      game.venue = source.fetch("venue", "The Jungle") if game.venue.blank?
+      game.bracket_code = entry.fetch("gameNumber") if game.bracket_code.blank?
+      game.notes = imported_notes(game.notes, entry.fetch("phase"), source.fetch("scheduleAsOf")) unless game.notes.to_s.include?("phase=")
+    end
+
+    def game_for_import(tournament, entry, away_team, home_team, start_time)
+      legacy_id = game_legacy_id(entry.fetch("gameNumber"))
+      Game.find_by(legacy_id: legacy_id) ||
+        tournament.games.find_by(start_time: start_time, away_team: away_team, home_team: home_team) ||
+        tournament.games.build(legacy_id: legacy_id)
+    end
+
+    def imported_notes(current_notes, phase, schedule_as_of)
+      manual_notes = current_notes.to_s.split(";").map(&:strip).reject do |part|
+        part.blank? || part.start_with?("phase=") || part == SOURCE_NOTE || part.start_with?("schedule_as_of=")
+      end
+
+      ([ "phase=#{phase}", SOURCE_NOTE, "schedule_as_of=#{schedule_as_of}" ] + manual_notes).join("; ")
+    end
+
+    def guam_start_time(date_value, time_value)
+      date = Date.iso8601(date_value)
+      match = time_value.match(/\A(\d{1,2}):(\d{2})(am|pm)\z/i)
+      raise ArgumentError, "Invalid schedule time: #{time_value}" unless match
+
+      hour = match[1].to_i
+      minute = match[2].to_i
+      meridiem = match[3].downcase
+      hour = 0 if meridiem == "am" && hour == 12
+      hour += 12 if meridiem == "pm" && hour < 12
+
+      Time.find_zone!("Pacific/Guam").local(date.year, date.month, date.day, hour, minute, 0)
+    end
+
+    def team_legacy_id(label)
+      "fd-2026-team-#{stable_slug(label)}"
+    end
+
+    def game_legacy_id(game_number)
+      "fd-2026-schedule-#{stable_slug(game_number)}"
+    end
+
+    def stable_slug(value)
+      value.to_s.downcase.gsub(/[^a-z0-9]+/, "-").gsub(/\A-|\-\z/, "")
+    end
+  end
+end

--- a/api/app/services/data_import/fd_2026_schedule_import.rb
+++ b/api/app/services/data_import/fd_2026_schedule_import.rb
@@ -49,8 +49,10 @@ module DataImport
       tournament = Tournament.find_by(year: attrs.fetch("year")) || Tournament.new(year: attrs.fetch("year"))
       tournament.name = attrs.fetch("name") if tournament.name.blank?
       tournament.legacy_id ||= "fd-#{attrs.fetch("year")}-tournament"
-      tournament.start_date = Date.iso8601(attrs.fetch("startDate"))
-      tournament.end_date = Date.iso8601(attrs.fetch("endDate"))
+      source_start_date = Date.iso8601(attrs.fetch("startDate"))
+      source_end_date = Date.iso8601(attrs.fetch("endDate"))
+      tournament.start_date = source_start_date if tournament.new_record? || overwrite? || tournament.start_date.blank?
+      tournament.end_date = source_end_date if tournament.new_record? || overwrite? || tournament.end_date.blank?
       tournament.status = attrs.fetch("status") if tournament.new_record?
       tournament.save!
       tournament
@@ -66,8 +68,8 @@ module DataImport
       legacy_id = team_legacy_id(label)
       team = Team.find_by(legacy_id: legacy_id) || tournament.teams.find_by(display_name: label) || tournament.teams.build
       team.legacy_id ||= legacy_id
-      team.class_year_label = label
-      team.display_name = label
+      team.class_year_label = label if team.new_record? || overwrite? || team.class_year_label.blank?
+      team.display_name = label if team.new_record? || overwrite? || team.display_name.blank?
       team.save!
       team
     end

--- a/api/db/seeds.rb
+++ b/api/db/seeds.rb
@@ -16,6 +16,11 @@ if ENV["FD_ADMIN_EMAIL"].present?
   end
 end
 
+if ENV.fetch("FD_SEED_2026_SCHEDULE", "1") == "1"
+  result = DataImport::Fd2026ScheduleImport.call
+  puts "Seeded 2026 schedule: #{result[:games]} games, #{result[:teams]} teams, #{result[:skippedRows]} skipped source rows"
+end
+
 if ENV["FD_SEED_DEMO"] == "1"
   tournament = Tournament.find_or_create_by!(year: 2026, name: "FD Alumni Basketball Tournament") do |record|
     record.start_date = Date.new(2026, 7, 3)

--- a/api/lib/tasks/fd_schedule.rake
+++ b/api/lib/tasks/fd_schedule.rake
@@ -1,0 +1,10 @@
+namespace :fd do
+  namespace :schedule do
+    desc "Import the 2026 FDMSAA Alumni Basketball pool-play schedule"
+    task import_2026: :environment do
+      overwrite = ENV["FD_SCHEDULE_IMPORT_OVERWRITE"] == "1"
+      result = DataImport::Fd2026ScheduleImport.call(path: ENV["SCHEDULE_PATH"], overwrite: overwrite)
+      puts JSON.pretty_generate(result)
+    end
+  end
+end

--- a/api/test/controllers/public_schedule_controller_test.rb
+++ b/api/test/controllers/public_schedule_controller_test.rb
@@ -29,6 +29,14 @@ class PublicScheduleControllerTest < ActionDispatch::IntegrationTest
       division: "Gold",
       notes: "phase=playoff"
     )
+    tournament.games.create!(
+      home_team: maroon_home,
+      away_team: gold_home,
+      start_time: Time.zone.local(2026, 7, 5, 18, 0),
+      status: "scheduled",
+      bracket_code: "FS01",
+      notes: "phase=fatherson"
+    )
 
     get "/api/v1/public/schedule", params: { year: 2026, division: "Maroon", phase: "pool" }
 
@@ -36,7 +44,7 @@ class PublicScheduleControllerTest < ActionDispatch::IntegrationTest
     body = JSON.parse(response.body)
     assert_equal "2026", body.dig("tournament", "year").to_s
     assert_equal [ "Gold", "Maroon" ], body["divisions"]
-    assert_equal [ "pool", "playoff" ], body["phases"]
+    assert_equal [ "pool", "playoff", "fatherson" ], body["phases"]
     assert_equal 1, body["games"].length
     assert_equal "Class of 2016", body.dig("games", 0, "homeTeam", "displayName")
   end

--- a/api/test/services/fd_2026_schedule_import_test.rb
+++ b/api/test/services/fd_2026_schedule_import_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class Fd2026ScheduleImportTest < ActiveSupport::TestCase
+  test "imports the organizer 2026 pool-play schedule idempotently" do
+    result = DataImport::Fd2026ScheduleImport.call
+
+    tournament = Tournament.find_by!(year: 2026)
+    assert_equal "FD Alumni Basketball Tournament", tournament.name
+    assert_equal Date.new(2026, 7, 3), tournament.start_date
+    assert_equal Date.new(2026, 7, 24), tournament.end_date
+    assert_equal 61, result[:games]
+    assert_equal 3, result[:skippedRows]
+    assert_equal 32, tournament.teams.count
+    assert_equal 61, tournament.games.count
+
+    opener = Game.find_by!(legacy_id: "fd-2026-schedule-1")
+    assert_equal "79/80", opener.away_team.display_name
+    assert_equal "84/85", opener.home_team.display_name
+    assert_equal "The Jungle", opener.venue
+    assert_equal "1", opener.bracket_code
+    assert_includes opener.notes, "phase=pool"
+    assert_equal Time.find_zone!("Pacific/Guam").local(2026, 7, 3, 18, 0), opener.start_time
+
+    father_son = Game.find_by!(legacy_id: "fd-2026-schedule-fs01")
+    assert_equal "FS1", father_son.away_team.display_name
+    assert_equal "FS2", father_son.home_team.display_name
+    assert_includes father_son.notes, "phase=fatherson"
+
+    assert_nil Game.find_by(legacy_id: "fd-2026-schedule-60sfs")
+
+    assert_no_difference -> { Tournament.count } do
+      assert_no_difference -> { Team.count } do
+        assert_no_difference -> { Game.count } do
+          DataImport::Fd2026ScheduleImport.call
+        end
+      end
+    end
+  end
+
+  test "does not overwrite scores or status on later seed runs" do
+    DataImport::Fd2026ScheduleImport.call
+    game = Game.find_by!(legacy_id: "fd-2026-schedule-1")
+    adjusted_tipoff = Time.find_zone!("Pacific/Guam").local(2026, 7, 3, 18, 10)
+    game.update!(status: "final", away_score: 70, home_score: 68, start_time: adjusted_tipoff, notes: "phase=pool; scorer note")
+
+    DataImport::Fd2026ScheduleImport.call
+
+    game.reload
+    assert_equal "final", game.status
+    assert_equal 70, game.away_score
+    assert_equal 68, game.home_score
+    assert_equal adjusted_tipoff, game.start_time
+    assert_includes game.notes, "scorer note"
+    assert_includes game.notes, "phase=pool"
+
+    DataImport::Fd2026ScheduleImport.call(overwrite: true)
+
+    assert_equal Time.find_zone!("Pacific/Guam").local(2026, 7, 3, 18, 0), game.reload.start_time
+  end
+end

--- a/api/test/services/fd_2026_schedule_import_test.rb
+++ b/api/test/services/fd_2026_schedule_import_test.rb
@@ -37,15 +37,28 @@ class Fd2026ScheduleImportTest < ActiveSupport::TestCase
     end
   end
 
-  test "does not overwrite scores or status on later seed runs" do
+  test "does not overwrite admin edits on later seed runs" do
     DataImport::Fd2026ScheduleImport.call
+    tournament = Tournament.find_by!(year: 2026)
+    team = Team.find_by!(legacy_id: "fd-2026-team-79-80")
     game = Game.find_by!(legacy_id: "fd-2026-schedule-1")
+    adjusted_start_date = Date.new(2026, 7, 4)
+    adjusted_end_date = Date.new(2026, 7, 25)
     adjusted_tipoff = Time.find_zone!("Pacific/Guam").local(2026, 7, 3, 18, 10)
+
+    tournament.update!(start_date: adjusted_start_date, end_date: adjusted_end_date)
+    team.update!(class_year_label: "1979/1980", display_name: "Class of 1979/1980")
     game.update!(status: "final", away_score: 70, home_score: 68, start_time: adjusted_tipoff, notes: "phase=pool; scorer note")
 
     DataImport::Fd2026ScheduleImport.call
 
+    tournament.reload
+    team.reload
     game.reload
+    assert_equal adjusted_start_date, tournament.start_date
+    assert_equal adjusted_end_date, tournament.end_date
+    assert_equal "1979/1980", team.class_year_label
+    assert_equal "Class of 1979/1980", team.display_name
     assert_equal "final", game.status
     assert_equal 70, game.away_score
     assert_equal 68, game.home_score
@@ -55,6 +68,13 @@ class Fd2026ScheduleImportTest < ActiveSupport::TestCase
 
     DataImport::Fd2026ScheduleImport.call(overwrite: true)
 
-    assert_equal Time.find_zone!("Pacific/Guam").local(2026, 7, 3, 18, 0), game.reload.start_time
+    tournament.reload
+    team.reload
+    game.reload
+    assert_equal Date.new(2026, 7, 3), tournament.start_date
+    assert_equal Date.new(2026, 7, 24), tournament.end_date
+    assert_equal "79/80", team.class_year_label
+    assert_equal "79/80", team.display_name
+    assert_equal Time.find_zone!("Pacific/Guam").local(2026, 7, 3, 18, 0), game.start_time
   end
 end

--- a/data/schedules/fd-2026-pool-play-2026-06-27.json
+++ b/data/schedules/fd-2026-pool-play-2026-06-27.json
@@ -1,0 +1,524 @@
+{
+  "source": {
+    "title": "2026 FDMSAA Alumni Basketball Tournament - Pool Play",
+    "scheduleAsOf": "2026-06-27",
+    "sourceFile": "2026 FDMSAA Alumni Basketball_POOL PLAY_final_v01_27JUN26.pdf",
+    "timezone": "Pacific/Guam",
+    "venue": "The Jungle",
+    "notes": "Imported from organizer PDF. Single-elimination bracket placeholders and rows without a confirmed time are intentionally excluded until confirmed."
+  },
+  "tournament": {
+    "name": "FD Alumni Basketball Tournament",
+    "year": 2026,
+    "startDate": "2026-07-03",
+    "endDate": "2026-07-24",
+    "status": "upcoming"
+  },
+  "games": [
+    {
+      "gameNumber": "1",
+      "date": "2026-07-03",
+      "time": "6:00pm",
+      "awayTeam": "79/80",
+      "homeTeam": "84/85",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "2",
+      "date": "2026-07-03",
+      "time": "7:10pm",
+      "awayTeam": "99/01/03",
+      "homeTeam": "2026",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "3",
+      "date": "2026-07-03",
+      "time": "8:20pm",
+      "awayTeam": "2025",
+      "homeTeam": "12 Pack",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "4",
+      "date": "2026-07-04",
+      "time": "12:10pm",
+      "awayTeam": "2023",
+      "homeTeam": "2024",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "5",
+      "date": "2026-07-04",
+      "time": "1:20pm",
+      "awayTeam": "91",
+      "homeTeam": "96/97",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "6",
+      "date": "2026-07-04",
+      "time": "2:30pm",
+      "awayTeam": "88",
+      "homeTeam": "89/90",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "7",
+      "date": "2026-07-04",
+      "time": "3:40pm",
+      "awayTeam": "435",
+      "homeTeam": "815",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "8",
+      "date": "2026-07-04",
+      "time": "4:50pm",
+      "awayTeam": "02/04",
+      "homeTeam": "GAMETIME",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "9",
+      "date": "2026-07-04",
+      "time": "6:00pm",
+      "awayTeam": "2006",
+      "homeTeam": "MMX",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "10",
+      "date": "2026-07-04",
+      "time": "7:10pm",
+      "awayTeam": "2019",
+      "homeTeam": "2020",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "11",
+      "date": "2026-07-04",
+      "time": "8:20pm",
+      "awayTeam": "2021",
+      "homeTeam": "2022",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "12",
+      "date": "2026-07-05",
+      "time": "1:20pm",
+      "awayTeam": "2019",
+      "homeTeam": "2026",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "13",
+      "date": "2026-07-05",
+      "time": "2:30pm",
+      "awayTeam": "2024",
+      "homeTeam": "2025",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "FS01",
+      "date": "2026-07-05",
+      "time": "3:40pm",
+      "awayTeam": "FS1",
+      "homeTeam": "FS2",
+      "phase": "fatherson"
+    },
+    {
+      "gameNumber": "14",
+      "date": "2026-07-05",
+      "time": "4:50pm",
+      "awayTeam": "2013",
+      "homeTeam": "2018",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "15",
+      "date": "2026-07-05",
+      "time": "6:00pm",
+      "awayTeam": "12 Pack",
+      "homeTeam": "2016",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "16",
+      "date": "2026-07-05",
+      "time": "7:10pm",
+      "awayTeam": "75",
+      "homeTeam": "82/86/AD7",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "17",
+      "date": "2026-07-05",
+      "time": "8:20pm",
+      "awayTeam": "2023",
+      "homeTeam": "2026",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "18",
+      "date": "2026-07-06",
+      "time": "6:00pm",
+      "awayTeam": "96/97",
+      "homeTeam": "2020",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "19",
+      "date": "2026-07-06",
+      "time": "7:10pm",
+      "awayTeam": "91",
+      "homeTeam": "435",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "20",
+      "date": "2026-07-06",
+      "time": "8:20pm",
+      "awayTeam": "2022",
+      "homeTeam": "99/01/03",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "21",
+      "date": "2026-07-07",
+      "time": "6:00pm",
+      "awayTeam": "79/80",
+      "homeTeam": "89/90",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "22",
+      "date": "2026-07-07",
+      "time": "7:10pm",
+      "awayTeam": "84/85",
+      "homeTeam": "88",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "23",
+      "date": "2026-07-07",
+      "time": "8:20pm",
+      "awayTeam": "GAMETIME",
+      "homeTeam": "815",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "24",
+      "date": "2026-07-08",
+      "time": "6:00pm",
+      "awayTeam": "2019",
+      "homeTeam": "2018",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "25",
+      "date": "2026-07-08",
+      "time": "7:10pm",
+      "awayTeam": "91",
+      "homeTeam": "98/00",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "26",
+      "date": "2026-07-08",
+      "time": "8:20pm",
+      "awayTeam": "2006",
+      "homeTeam": "2005",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "27",
+      "date": "2026-07-09",
+      "time": "6:00pm",
+      "awayTeam": "75",
+      "homeTeam": "89/90",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "28",
+      "date": "2026-07-09",
+      "time": "7:10pm",
+      "awayTeam": "MMX",
+      "homeTeam": "2026",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "29",
+      "date": "2026-07-09",
+      "time": "8:20pm",
+      "awayTeam": "2021",
+      "homeTeam": "2024",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "30",
+      "date": "2026-07-10",
+      "time": "6:00pm",
+      "awayTeam": "2005",
+      "homeTeam": "815",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "31",
+      "date": "2026-07-10",
+      "time": "7:10pm",
+      "awayTeam": "79/80",
+      "homeTeam": "82/86/AD7",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "32",
+      "date": "2026-07-10",
+      "time": "8:20pm",
+      "awayTeam": "2006",
+      "homeTeam": "2016",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "33",
+      "date": "2026-07-11",
+      "time": "1:20pm",
+      "awayTeam": "2020",
+      "homeTeam": "2023",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "FS02",
+      "date": "2026-07-11",
+      "time": "2:30pm",
+      "awayTeam": "FS2",
+      "homeTeam": "FS3",
+      "phase": "fatherson"
+    },
+    {
+      "gameNumber": "34",
+      "date": "2026-07-11",
+      "time": "3:40pm",
+      "awayTeam": "99/01/03",
+      "homeTeam": "98/00",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "35",
+      "date": "2026-07-11",
+      "time": "4:50pm",
+      "awayTeam": "84/85",
+      "homeTeam": "89/90",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "36",
+      "date": "2026-07-11",
+      "time": "6:00pm",
+      "awayTeam": "2022",
+      "homeTeam": "2025",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "37",
+      "date": "2026-07-11",
+      "time": "7:10pm",
+      "awayTeam": "2024",
+      "homeTeam": "2018",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "38",
+      "date": "2026-07-11",
+      "time": "8:20pm",
+      "awayTeam": "2019",
+      "homeTeam": "2021",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "39",
+      "date": "2026-07-12",
+      "time": "1:20pm",
+      "awayTeam": "2020",
+      "homeTeam": "2021",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "40",
+      "date": "2026-07-12",
+      "time": "2:30pm",
+      "awayTeam": "2005",
+      "homeTeam": "GAMETIME",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "41",
+      "date": "2026-07-12",
+      "time": "3:40pm",
+      "awayTeam": "75",
+      "homeTeam": "88",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "42",
+      "date": "2026-07-12",
+      "time": "4:50pm",
+      "awayTeam": "MMX",
+      "homeTeam": "2013",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "43",
+      "date": "2026-07-12",
+      "time": "6:00pm",
+      "awayTeam": "12 Pack",
+      "homeTeam": "2022",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "44",
+      "date": "2026-07-12",
+      "time": "7:10pm",
+      "awayTeam": "02/04",
+      "homeTeam": "2006",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "45",
+      "date": "2026-07-12",
+      "time": "8:20pm",
+      "awayTeam": "2023",
+      "homeTeam": "2025",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "46",
+      "date": "2026-07-13",
+      "time": "6:00pm",
+      "awayTeam": "435",
+      "homeTeam": "96/97",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "47",
+      "date": "2026-07-13",
+      "time": "7:10pm",
+      "awayTeam": "82/86/AD7",
+      "homeTeam": "84/85",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "48",
+      "date": "2026-07-13",
+      "time": "8:20pm",
+      "awayTeam": "2016",
+      "homeTeam": "2018",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "49",
+      "date": "2026-07-14",
+      "time": "6:00pm",
+      "awayTeam": "96/97",
+      "homeTeam": "02/04",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "50",
+      "date": "2026-07-14",
+      "time": "7:10pm",
+      "awayTeam": "815",
+      "homeTeam": "98/00",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "51",
+      "date": "2026-07-14",
+      "time": "8:20pm",
+      "awayTeam": "12 Pack",
+      "homeTeam": "2013",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "52",
+      "date": "2026-07-15",
+      "time": "6:00pm",
+      "awayTeam": "75",
+      "homeTeam": "79/80",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "53",
+      "date": "2026-07-15",
+      "time": "7:10pm",
+      "awayTeam": "91",
+      "homeTeam": "99/01/03",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "54",
+      "date": "2026-07-15",
+      "time": "8:20pm",
+      "awayTeam": "MMX",
+      "homeTeam": "GAMETIME",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "55",
+      "date": "2026-07-16",
+      "time": "6:00pm",
+      "awayTeam": "2005",
+      "homeTeam": "02/04",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "56",
+      "date": "2026-07-16",
+      "time": "7:10pm",
+      "awayTeam": "82/86/AD7",
+      "homeTeam": "88",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "57",
+      "date": "2026-07-16",
+      "time": "8:20pm",
+      "awayTeam": "2013",
+      "homeTeam": "2016",
+      "phase": "pool"
+    },
+    {
+      "gameNumber": "FS03",
+      "date": "2026-07-17",
+      "time": "6:00pm",
+      "awayTeam": "FS1",
+      "homeTeam": "FS3",
+      "phase": "fatherson"
+    },
+    {
+      "gameNumber": "58",
+      "date": "2026-07-17",
+      "time": "7:10pm",
+      "awayTeam": "435",
+      "homeTeam": "98/00",
+      "phase": "pool"
+    }
+  ],
+  "skippedRows": [
+    {
+      "date": "2026-07-11",
+      "raw": "60sFS 60s FS vs. 60s FS",
+      "reason": "Time is missing in the source row; do not infer until confirmed."
+    },
+    {
+      "date": "2026-07-17",
+      "raw": "SINGLE ELIMINATION PLAYOFFS BEGIN!!!",
+      "reason": "Single-elimination placeholder has no teams yet."
+    },
+    {
+      "date": "2026-07-17",
+      "raw": "8:20pm vs.",
+      "reason": "Single-elimination placeholder has no teams yet."
+    }
+  ]
+}

--- a/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
+++ b/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
@@ -163,7 +163,7 @@ The importer is safe to run repeatedly:
 - Creates/updates the 2026 tournament.
 - Creates/updates schedule teams using stable `legacy_id`s.
 - Creates missing games using stable `legacy_id`s.
-- Preserves existing game status, scores, teams, and tipoff times on normal seed runs so later deploys do not accidentally revert organizer/admin edits.
+- Preserves existing tournament dates, team display labels, game status, scores, teams, and tipoff times on normal seed runs so later deploys do not accidentally revert organizer/admin edits.
 - Recomputes standings after import.
 
 If the source schedule JSON is intentionally revised and should overwrite existing game matchups/times, run:

--- a/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
+++ b/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
@@ -1,0 +1,215 @@
+# FD Alumni Hub Rails/Vite Deployment + 2026 Schedule Plan
+
+_Last updated: 2026-06-27_
+
+This documents the path from the current production Next.js app to the Rails API + React/Vite app, plus how the confirmed 2026 pool-play schedule is loaded.
+
+## Current decision summary
+
+- Keep the current Netlify/Next.js production site as the fallback until Rails/Vite staging is validated.
+- Deploy the Rails API separately to Render.
+- Deploy the React/Vite frontend separately to a new Netlify site first, then cut over only after organizer/mobile review.
+- Use a new Rails-owned Neon database; do not point Rails at the existing Next/Prisma database.
+- Seed/import the 2026 organizer schedule idempotently so a fresh Rails DB has the current tournament schedule immediately.
+- Keep Missing Links/Data Health for admin QA.
+- Do not give team reps full admin access by default; use central roster updates short-term and consider scoped team-manager access later.
+
+## 1. Missing Links / Data Health
+
+The `/admin/missing-links` page is intentionally useful and should stay for now.
+
+It answers:
+
+- Which games are missing GuamTime ticket links?
+- Which games are missing Clutch/partner stream links?
+- Which final games are missing scores?
+
+This becomes more useful after the 2026 schedule import because all new games start without ticket/stream links. Admins can use this page as a punch list while partner links arrive.
+
+Future rename option: **Data Health** or **Link Gaps**. No behavior change is needed before staging.
+
+## 2. Deployment plan
+
+### Do not delete the existing production Netlify site yet
+
+The current production app is still `apps/web` Next.js. It remains the public fallback until Rails/Vite is proven.
+
+### Rails API on Render
+
+Recommended Render service:
+
+- Name: `fd-alumni-hub-api`
+- Root directory: `api`
+- Branch: `main`
+- Runtime: Ruby
+- Build command:
+
+```bash
+bundle install && bundle exec rails db:migrate db:seed
+```
+
+- Start command:
+
+```bash
+bundle exec rails server -b 0.0.0.0 -p $PORT
+```
+
+Important Render env vars:
+
+```bash
+RAILS_ENV=production
+DATABASE_URL=<new Rails-owned Neon pooled connection string>
+SECRET_KEY_BASE=<rails secret output>
+ALLOWED_ORIGINS=https://<vite-netlify-site>.netlify.app,https://<future-custom-domain>
+CLERK_JWKS_URL=<production Clerk JWKS URL>
+CLERK_SECRET_KEY=<production Clerk secret key>
+```
+
+Optional image upload env vars when S3 is ready:
+
+```bash
+S3_BUCKET=
+S3_REGION=
+S3_ACCESS_KEY_ID=
+S3_SECRET_ACCESS_KEY=
+S3_PUBLIC_BASE_URL=
+```
+
+### React/Vite on Netlify
+
+Create a **new Netlify site** first instead of replacing the current production site.
+
+Recommended Netlify build settings:
+
+```bash
+Base directory: .
+Build command: npm ci --include=optional && npm run web:build
+Publish directory: web/dist
+```
+
+Important Netlify env vars:
+
+```bash
+VITE_API_BASE_URL=https://<render-api>.onrender.com/api/v1
+VITE_CLERK_PUBLISHABLE_KEY=<production Clerk publishable key>
+VITE_CLERK_JWT_TEMPLATE=
+VITE_GUAMTIME_URL=https://guamtime.net
+VITE_CLUTCH_URL=https://www.clutchguam.com
+VITE_PUBLIC_POSTHOG_KEY=
+VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+VITE_ENABLE_ANALYTICS_IN_DEV=false
+```
+
+After staging review, we can either:
+
+1. Update the existing Netlify production site to build `web/dist`, or
+2. Move the production domain to the new Vite Netlify site.
+
+Do this only after validating migrated data, Clerk admin auth, mobile UX, and rollback.
+
+## 3. Neon database decision
+
+Create a new Neon database for Rails.
+
+Do **not** reuse the old Next/Prisma database directly because:
+
+- Rails uses a different schema and bigint IDs.
+- The existing Prisma DB should remain a read-only source/fallback until cutover.
+- The Rails import path uses `legacy_id` to map old records safely.
+
+Recommended databases:
+
+- `fd-alumni-hub-rails-staging`
+- later: `fd-alumni-hub-rails-production`
+
+Use the pooled connection string for the Rails app. Use explicit operator-run imports for old production data snapshots as documented in `docs/RAILS-DATA-MIGRATION-RUNBOOK.md`.
+
+## 4. 2026 schedule import
+
+Source PDF on Leon's Desktop:
+
+```text
+2026 FDMSAA Alumni Basketball_POOL PLAY_final_v01_27JUN26.pdf
+```
+
+Structured import data lives at:
+
+```text
+data/schedules/fd-2026-pool-play-2026-06-27.json
+```
+
+Importer:
+
+```bash
+cd api
+bin/rails fd:schedule:import_2026
+```
+
+Seed behavior:
+
+```bash
+cd api
+bin/rails db:seed
+```
+
+By default, `db:seed` imports the 2026 schedule idempotently. To skip it for a special environment:
+
+```bash
+FD_SEED_2026_SCHEDULE=0 bin/rails db:seed
+```
+
+The importer is safe to run repeatedly:
+
+- Creates/updates the 2026 tournament.
+- Creates/updates schedule teams using stable `legacy_id`s.
+- Creates missing games using stable `legacy_id`s.
+- Preserves existing game status, scores, teams, and tipoff times on normal seed runs so later deploys do not accidentally revert organizer/admin edits.
+- Recomputes standings after import.
+
+If the source schedule JSON is intentionally revised and should overwrite existing game matchups/times, run:
+
+```bash
+FD_SCHEDULE_IMPORT_OVERWRITE=1 bin/rails fd:schedule:import_2026
+```
+
+Imported scope:
+
+- 61 scheduled pool/father-son rows.
+- Venue defaults to `The Jungle`.
+- Times are interpreted in `Pacific/Guam`.
+- `notes` includes `phase=pool` or `phase=fatherson` for schedule filtering.
+
+Known source gaps intentionally excluded until confirmed:
+
+- `60sFS 60s FS vs. 60s FS` has no confirmed time in the extracted/source row.
+- Friday July 17 single-elimination `8:20pm vs.` placeholder has no teams yet.
+
+## 5. Team roster access decision
+
+Short-term recommendation: keep roster updates with trusted admins/organizers.
+
+Do **not** give all team reps full staff/admin access yet because current staff/admin access can reach broader tournament operations.
+
+Future scoped options:
+
+1. `team_manager` role with explicit `team_assignments` table.
+   - Can edit roster entries only for assigned team(s).
+   - Cannot edit schedule, scores, links, sponsors, media, or polls.
+2. Magic roster-edit links per team.
+   - Lower friction.
+   - Good for one-time roster collection.
+   - Requires expiration/audit trail.
+
+Build this only if roster delegation becomes necessary for launch. It should be a separate PR because it touches auth, role policy, admin navigation, tests, and UX.
+
+## 6. Recommended next steps
+
+1. Merge the 2026 schedule import PR.
+2. Create Rails staging Neon DB.
+3. Deploy Rails API staging to Render.
+4. Deploy React/Vite staging to a new Netlify site.
+5. Run Rails migrations and seed/import schedule.
+6. Import/validate old Next/Prisma snapshot if archive/news/history data is needed in staging.
+7. Smoke test public pages, `/today`, admin auth, Games, Game Day, Links, Missing Links/Data Health.
+8. Organizer/mobile review.
+9. Prepare production cutover and rollback plan.

--- a/web/README.md
+++ b/web/README.md
@@ -29,6 +29,7 @@ npm run web:build
 
 Public parity:
 - `/`
+- `/today`
 - `/schedule`
 - `/standings`
 - `/watch`
@@ -40,6 +41,7 @@ Public parity:
 Admin parity:
 - `/admin`
 - `/admin/games`
+- `/admin/game-day`
 - `/admin/standings`
 - `/admin/divisions`
 - `/admin/links`
@@ -48,3 +50,5 @@ Admin parity:
 - `/admin/media`
 - `/admin/sponsors`
 - `/admin/ingest`
+
+Deployment planning for the Rails/Vite cutover lives in `docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md`.


### PR DESCRIPTION
## Summary
- document the Rails/Vite deployment, Neon DB, Missing Links/Data Health, schedule import, and team roster access decisions
- add structured 2026 FDMSAA pool-play schedule data from the organizer PDF
- add an idempotent Rails importer/rake task and seed hook so a fresh Rails DB auto-populates the 2026 schedule
- preserve existing game edits on normal seed runs, with an explicit overwrite mode for future revised schedules

## Schedule import details
- Source data: `data/schedules/fd-2026-pool-play-2026-06-27.json`
- Task: `cd api && bin/rails fd:schedule:import_2026`
- Seed behavior: `cd api && bin/rails db:seed` imports the schedule by default
- Skip seed import: `FD_SEED_2026_SCHEDULE=0 bin/rails db:seed`
- Force schedule overwrite for an intentional source revision: `FD_SCHEDULE_IMPORT_OVERWRITE=1 bin/rails fd:schedule:import_2026`

Imported:
- 61 confirmed pool/father-son scheduled rows
- 32 teams
- Guam timezone tipoff times
- `phase=pool` / `phase=fatherson` metadata for schedule filtering

Intentionally skipped until confirmed:
- `60sFS 60s FS vs. 60s FS` because the source row has no confirmed time
- Friday July 17 single-elimination `8:20pm vs.` placeholder because teams are not set yet

## Verification
- [x] `cd api && bin/rails test`
- [x] `cd api && bin/rubocop --no-color`
- [x] `npm run web:build`
- [x] `./scripts/gate.sh`

## Notes
This does not cut over production. Current production Next.js remains the fallback while Rails API + React/Vite staging are deployed and validated separately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR imports the confirmed 2026 FDMSAA pool-play schedule into the Rails app via a new idempotent service (`DataImport::Fd2026ScheduleImport`), a rake task (`fd:schedule:import_2026`), and a seed hook. It also ships the structured JSON source file and updates `Game#fatherson_phase?` to recognize the new `FS01/FS02/FS03` bracket codes.

- **Idempotent importer**: tournament, teams, and games are found-or-built using stable `legacy_id` slugs; all three record types guard against overwriting admin edits with `new_record? || overwrite? || field.blank?` conditions — previous review feedback on this has been addressed.
- **Preserve-or-overwrite duality**: normal seed runs call `preserve_schedule_metadata` (keeps start times, scores, status untouched); `FD_SCHEDULE_IMPORT_OVERWRITE=1` calls `assign_schedule_fields` instead, while still retaining manual free-text notes via the `imported_notes` filter.
- **`fatherson_phase?` broadened**: the check shifts from `bracket_code == "FS"` to `bracket_code.to_s.start_with?("FS")` and adds a `notes.include?("phase=fatherson")` primary guard, correctly classifying all three father-son games.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the importer is idempotent, all record fields are properly guarded, and the changes are additive with no risk to existing data.

The importer correctly guards every mutable field against accidental overwrite on re-runs, the 12-hour Guam time parser handles all edge cases, legacy_id-based deduplication is sound, and the test suite covers idempotency, admin-edit preservation, and overwrite mode end-to-end. No issues found that affect current behavior.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/app/services/data_import/fd_2026_schedule_import.rb | New idempotent schedule importer: correctly guards tournament dates, team display names, and game fields with `new_record? || overwrite? || field.blank?` — previous review concerns have been addressed. Logic flow, 12-hour time parsing, and stable-slug key generation all look correct. |
| api/app/models/game.rb | Updated `fatherson_phase?` to check `notes` first and broadened `bracket_code` match from exact `"FS"` to `start_with?("FS")` to cover the new FS01/FS02/FS03 game numbers. |
| api/db/seeds.rb | Adds schedule import to the seed path with a safe `FD_SEED_2026_SCHEDULE` env-var guard; runs before the demo seed, which safely finds the existing tournament via `find_or_create_by!`. |
| api/test/services/fd_2026_schedule_import_test.rb | Solid coverage: idempotency assertion with `assert_no_difference`, admin-edit preservation test, and overwrite-mode verification — all three code paths are exercised. |
| data/schedules/fd-2026-pool-play-2026-06-27.json | Source schedule data: 61 games (58 pool + 3 father-son) across 32 teams with well-formed ISO dates, 12-hour Guam times, and clearly documented skipped rows. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Seed as db:seed / rake task
    participant Importer as Fd2026ScheduleImport
    participant DB as Database
    participant Standings as Standings::Recompute

    Seed->>Importer: call(path:, overwrite:)
    Importer->>Importer: JSON.parse(path.read)
    Importer->>DB: upsert_tournament (find_by year, guard dates)
    Importer->>DB: upsert_teams (find_by legacy_id / display_name)
    loop each game entry
        Importer->>DB: game_for_import (find_by legacy_id → start_time+matchup → build)
        alt new_record? OR overwrite?
            Importer->>DB: assign_schedule_fields (teams, time, venue, notes)
        else existing + preserve
            Importer->>DB: preserve_schedule_metadata (fill blanks, add phase if absent)
        end
        Importer->>DB: game.save!
    end
    Importer->>Standings: Recompute.call(tournament)
    Importer-->>Seed: "{ games:, teams:, skippedRows:, ... }"
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Seed as db:seed / rake task
    participant Importer as Fd2026ScheduleImport
    participant DB as Database
    participant Standings as Standings::Recompute

    Seed->>Importer: call(path:, overwrite:)
    Importer->>Importer: JSON.parse(path.read)
    Importer->>DB: upsert_tournament (find_by year, guard dates)
    Importer->>DB: upsert_teams (find_by legacy_id / display_name)
    loop each game entry
        Importer->>DB: game_for_import (find_by legacy_id → start_time+matchup → build)
        alt new_record? OR overwrite?
            Importer->>DB: assign_schedule_fields (teams, time, venue, notes)
        else existing + preserve
            Importer->>DB: preserve_schedule_metadata (fill blanks, add phase if absent)
        end
        Importer->>DB: game.save!
    end
    Importer->>Standings: Recompute.call(tournament)
    Importer-->>Seed: "{ games:, teams:, skippedRows:, ... }"
```

</a>

<sub>Reviews (3): Last reviewed commit: ["Expose father-son schedule phase"](https://github.com/shimizu-technology/fd-alumni-hub/commit/c11e234001e075d2d35be5bba8012f87a348ecf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40258853)</sub>

<!-- /greptile_comment -->