### PR TITLE
Polish 2026 launch admin and mobile UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ npm run web:dev
 Rails public routes include home, today/game-day, tournaments, schedule, standings, articles, media assets, sponsors, and anonymous prediction voting.
 Rails admin routes now cover dashboard, tournaments, teams/rosters, games, game-day notes/polls, standings recompute, articles, media assets, sponsors, ingest review, bulk links, and missing-link/data-health checks.
 
-Deployment/schedule planning doc:
+Deployment/schedule planning docs:
 - `docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md`
+- `docs/projects/fd-2026-launch-polish-notes.md`
 
 The Rails seed path now idempotently imports the 2026 organizer pool-play schedule from `data/schedules/fd-2026-pool-play-2026-06-27.json` unless `FD_SEED_2026_SCHEDULE=0` is set.

--- a/api/README.md
+++ b/api/README.md
@@ -77,6 +77,7 @@ Local admin testing should use real Clerk sign-in with an allowlisted email. See
 - `PATCH /api/v1/admin/teams/:id`
 - `DELETE /api/v1/admin/teams/:id`
 - `POST /api/v1/admin/roster-entries`
+- `POST /api/v1/admin/roster-entries/bulk`
 - `PATCH /api/v1/admin/roster-entries/:id`
 - `DELETE /api/v1/admin/roster-entries/:id`
 - `GET /api/v1/admin/game-day-notes`

--- a/api/app/controllers/api/v1/admin/roster_entries_controller.rb
+++ b/api/app/controllers/api/v1/admin/roster_entries_controller.rb
@@ -14,6 +14,44 @@ module Api
           end
         end
 
+        def bulk
+          entries_payload = bulk_roster_entry_params
+          return render json: { errors: [ "rosterEntries must be an array" ] }, status: :bad_request unless entries_payload
+
+          created = []
+          errors = []
+
+          RosterEntry.transaction do
+            entries_payload.each_with_index do |payload, index|
+              attrs = roster_entry_attrs(payload)
+              team_id = attrs.delete(:team_id)
+              team = team_id.present? ? admin_tournament.teams.find_by(id: team_id) : nil
+
+              if team.nil?
+                errors << { index: index, errors: [ "Team not found" ] }
+                next
+              end
+
+              roster_entry = team.roster_entries.build(attrs)
+              if roster_entry.valid?
+                created << roster_entry
+              else
+                errors << { index: index, errors: roster_entry.errors.full_messages }
+              end
+            end
+
+            raise ActiveRecord::Rollback if errors.any?
+
+            created.each(&:save!)
+          end
+
+          if errors.any?
+            render json: { errors: errors }, status: :unprocessable_entity
+          else
+            render json: { created: created.length, rosterEntries: created.map(&:api_json) }, status: :created
+          end
+        end
+
         def update
           roster_entry = roster_entry_scope.find(params[:id])
 
@@ -37,8 +75,23 @@ module Api
 
         def roster_entry_params
           raw = params.fetch(:rosterEntry, params.fetch(:roster_entry, params))
-          permitted = raw.permit(:team_id, :teamId, :name, :jersey_number, :jerseyNumber, :position, :nickname, :sort_order, :sortOrder, :active)
+          roster_entry_attrs(permit_roster_entry(raw))
+        end
 
+        def bulk_roster_entry_params
+          raw_entries = params[:rosterEntries] || params[:roster_entries]
+          return unless raw_entries.is_a?(Array)
+
+          raw_entries.map { |entry| permit_roster_entry(entry) }
+        end
+
+        def permit_roster_entry(raw_entry)
+          raw_hash = raw_entry.respond_to?(:to_unsafe_h) ? raw_entry.to_unsafe_h : raw_entry
+          raw_hash = {} unless raw_hash.is_a?(Hash)
+          ActionController::Parameters.new(raw_hash).permit(:team_id, :teamId, :name, :jersey_number, :jerseyNumber, :position, :nickname, :sort_order, :sortOrder, :active)
+        end
+
+        def roster_entry_attrs(permitted)
           attrs = {}
           assign_param(attrs, permitted, :team_id, :team_id, :teamId)
           assign_param(attrs, permitted, :name, :name)

--- a/api/app/controllers/api/v1/admin/roster_entries_controller.rb
+++ b/api/app/controllers/api/v1/admin/roster_entries_controller.rb
@@ -21,34 +21,46 @@ module Api
           created = []
           errors = []
 
-          RosterEntry.transaction do
-            entries_payload.each_with_index do |payload, index|
-              attrs = roster_entry_attrs(payload)
-              team_id = attrs.delete(:team_id)
-              team = team_id.present? ? admin_tournament.teams.find_by(id: team_id) : nil
+          begin
+            RosterEntry.transaction do
+              entries_payload.each_with_index do |payload, index|
+                attrs = roster_entry_attrs(payload)
+                team_id = attrs.delete(:team_id)
+                team = team_id.present? ? admin_tournament.teams.find_by(id: team_id) : nil
 
-              if team.nil?
-                errors << { index: index, errors: [ "Team not found" ] }
-                next
+                if team.nil?
+                  errors << { index: index, errors: [ "Team not found" ] }
+                  next
+                end
+
+                roster_entry = team.roster_entries.build(attrs)
+                if roster_entry.valid?
+                  created << { index: index, roster_entry: roster_entry }
+                else
+                  errors << { index: index, errors: roster_entry.errors.full_messages }
+                end
               end
 
-              roster_entry = team.roster_entries.build(attrs)
-              if roster_entry.valid?
-                created << roster_entry
-              else
-                errors << { index: index, errors: roster_entry.errors.full_messages }
+              raise ActiveRecord::Rollback if errors.any?
+
+              created.each do |entry|
+                roster_entry = entry[:roster_entry]
+                next if roster_entry.save
+
+                errors << { index: entry[:index], errors: roster_entry.errors.full_messages.presence || [ "Unable to save roster entry" ] }
+                raise ActiveRecord::Rollback
               end
             end
-
-            raise ActiveRecord::Rollback if errors.any?
-
-            created.each(&:save!)
+          rescue ActiveRecord::ActiveRecordError => e
+            Rails.logger.warn("Bulk roster entry save failed: #{e.class}: #{e.message}")
+            errors << { index: nil, errors: [ "Unable to save roster entries" ] } if errors.empty?
           end
 
           if errors.any?
             render json: { errors: errors }, status: :unprocessable_entity
           else
-            render json: { created: created.length, rosterEntries: created.map(&:api_json) }, status: :created
+            roster_entries = created.map { |entry| entry[:roster_entry] }
+            render json: { created: roster_entries.length, rosterEntries: roster_entries.map(&:api_json) }, status: :created
           end
         end
 

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -27,7 +27,9 @@ Rails.application.routes.draw do
         end
         resources :divisions, only: [ :index, :create, :update ]
         resources :teams, only: [ :index, :create, :update, :destroy ]
-        resources :roster_entries, path: "roster-entries", only: [ :create, :update, :destroy ]
+        resources :roster_entries, path: "roster-entries", only: [ :create, :update, :destroy ] do
+          post :bulk, on: :collection
+        end
         resources :game_day_notes, path: "game-day-notes", only: [ :index, :create, :update ]
         resources :prediction_polls, path: "prediction-polls", only: [ :index, :create, :update ]
         resources :games, only: [ :index, :show, :create, :update ]

--- a/api/test/controllers/admin_game_day_controller_test.rb
+++ b/api/test/controllers/admin_game_day_controller_test.rb
@@ -46,6 +46,36 @@ class AdminGameDayControllerTest < ActionDispatch::IntegrationTest
     assert_equal "10", @home.roster_entries.first.jersey_number
   end
 
+  test "staff can bulk add roster entries atomically" do
+    assert_difference -> { @home.roster_entries.count }, 2 do
+      post "/api/v1/admin/roster-entries/bulk?tournamentId=#{@tournament.id}",
+        params: { rosterEntries: [
+          { teamId: @home.id, name: "Juan Duenas", jerseyNumber: "10", position: "G", sortOrder: 1 },
+          { teamId: @home.id, name: "Jose Cruz", jerseyNumber: "23", position: "F", sortOrder: 2 }
+        ] },
+        headers: auth_headers,
+        as: :json
+    end
+
+    assert_response :created
+    body = JSON.parse(response.body)
+    assert_equal 2, body["created"]
+    assert_equal [ "Juan Duenas", "Jose Cruz" ], @home.roster_entries.ordered.pluck(:name)
+
+    assert_no_difference -> { @home.roster_entries.count } do
+      post "/api/v1/admin/roster-entries/bulk?tournamentId=#{@tournament.id}",
+        params: { rosterEntries: [
+          { teamId: @home.id, name: "Valid Player", sortOrder: 3 },
+          { teamId: @home.id, name: "", sortOrder: 4 }
+        ] },
+        headers: auth_headers,
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body).dig("errors", 0, "errors").join, "Name can't be blank"
+  end
+
   test "admin updates and deletes are scoped to selected tournament" do
     other_tournament, other_home, other_game = build_other_tournament_context
     other_note = other_tournament.game_day_notes.create!(date: Date.new(2025, 7, 3), host_class: "Other host")

--- a/docs/projects/fd-2026-launch-polish-notes.md
+++ b/docs/projects/fd-2026-launch-polish-notes.md
@@ -11,7 +11,7 @@ Implemented direction:
 - Keep Add Team and Add Game available, but collapsed by default once records exist.
 - Use the schedule importer as the primary way to populate a season schedule.
 - Keep manual game/team creation for late organizer changes, playoff placeholders, make-up games, or emergency corrections.
-- Support bulk roster entry from pasted team lists so organizers are not forced to open the single-player modal repeatedly.
+- Support atomic bulk roster entry from pasted team lists so organizers are not forced to open the single-player modal repeatedly and failed batches do not partially write players.
 - Support applying one common GuamTime ticket link across the schedule, then manually overriding championship or special-session games later.
 
 ## Ticket link guidance

--- a/docs/projects/fd-2026-launch-polish-notes.md
+++ b/docs/projects/fd-2026-launch-polish-notes.md
@@ -26,11 +26,7 @@ Public copy should avoid hard-coding prices unless organizers provide final publ
 
 ## By-laws review summary
 
-Source reviewed locally:
-
-```text
-/Users/leonshimizu/Desktop/2026 FD Alumni By-Laws_Basketball.pdf
-```
+Source reviewed: organizer-provided `2026 FD Alumni By-Laws_Basketball.pdf`.
 
 Useful public-facing highlights:
 

--- a/docs/projects/fd-2026-launch-polish-notes.md
+++ b/docs/projects/fd-2026-launch-polish-notes.md
@@ -1,0 +1,63 @@
+# FD Alumni Hub 2026 Launch Polish Notes
+
+_Last updated: 2026-06-27_
+
+## Admin workflow polish
+
+The Rails/Vite admin should bias toward day-to-day tournament operations instead of one-time setup work.
+
+Implemented direction:
+
+- Keep Add Team and Add Game available, but collapsed by default once records exist.
+- Use the schedule importer as the primary way to populate a season schedule.
+- Keep manual game/team creation for late organizer changes, playoff placeholders, make-up games, or emergency corrections.
+- Support bulk roster entry from pasted team lists so organizers are not forced to open the single-player modal repeatedly.
+- Support applying one common GuamTime ticket link across the schedule, then manually overriding championship or special-session games later.
+
+## Ticket link guidance
+
+Organizer guidance indicates most games can share one GuamTime ticket link, while championship sessions may need separate handling. The admin Links page should support:
+
+1. Fill missing ticket links with a common GuamTime URL.
+2. Replace all ticket links with a common GuamTime URL.
+3. Manual row-by-row overrides after bulk fill.
+
+Public copy should avoid hard-coding prices unless organizers provide final public pricing. GuamTime remains the source of truth for current price and checkout details.
+
+## By-laws review summary
+
+Source reviewed locally:
+
+```text
+/Users/leonshimizu/Desktop/2026 FD Alumni By-Laws_Basketball.pdf
+```
+
+Useful public-facing highlights:
+
+- Waivers are required before players can play.
+- Player eligibility is verified through FD administration / FDMSAA criteria.
+- Teams need at least five eligible players to start.
+- Complete uniforms are mandatory.
+- No jewelry during games.
+- Games use two 20-minute halves with a five-minute halftime.
+- First 37 minutes run continuously; final three minutes of the second half use stop-clock rules.
+- Pool-play ties use a three-point shootout; playoff ties use overtime.
+- All teams make playoffs; tiebreakers start with head-to-head and points for/against.
+- Forfeits and incomplete uniforms can trigger team fees.
+- Sportsmanship and campus conduct rules apply.
+
+Do **not** publish the raw PDF contents without organizer approval because the source includes personal contact details and internal language that should be summarized for a public hub.
+
+## Future OCR schedule import
+
+The 2026 schedule is now imported from a structured JSON file and idempotent Rails task. For future years, build on that foundation with an operator-reviewed OCR workflow:
+
+1. Admin uploads schedule PDF/image.
+2. Backend extracts tables using PDF text extraction first, OCR fallback second.
+3. System presents a preview table with date, time, game number, away team, home team, phase, and warnings.
+4. Admin fixes ambiguous rows in-browser.
+5. System writes a structured schedule JSON snapshot with source metadata.
+6. Admin imports the reviewed snapshot through the existing schedule importer pattern.
+7. Import report shows created/updated/skipped rows.
+
+Important: OCR should never silently write games directly to production. Keep a human review step because schedule PDFs can include blank cells, merged rows, bracket placeholders, and special rows like father-son games.

--- a/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
+++ b/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
@@ -204,6 +204,8 @@ Build this only if roster delegation becomes necessary for launch. It should be 
 
 ## 6. Recommended next steps
 
+Future schedule automation note: OCR/upload should build on the structured importer by producing a human-reviewed schedule preview and JSON snapshot before writing games. Do not let OCR silently mutate production schedules.
+
 1. Merge the 2026 schedule import PR.
 2. Create Rails staging Neon DB.
 3. Deploy Rails API staging to Render.

--- a/web/README.md
+++ b/web/README.md
@@ -33,6 +33,7 @@ Public parity:
 - `/schedule`
 - `/standings`
 - `/watch`
+- `/info`
 - `/news`
 - `/gallery`
 - `/history`
@@ -52,3 +53,5 @@ Admin parity:
 - `/admin/ingest`
 
 Deployment planning for the Rails/Vite cutover lives in `docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md`.
+
+2026 launch polish, by-laws review notes, and future OCR schedule import planning live in `docs/projects/fd-2026-launch-polish-notes.md`.

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -31,6 +31,12 @@
     <priority>0.9</priority>
   </url>
   <url>
+    <loc>https://fd-alumni-hub.netlify.app/info</loc>
+    <lastmod>2026-06-27</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.85</priority>
+  </url>
+  <url>
     <loc>https://fd-alumni-hub.netlify.app/news</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import { GalleryPage } from './pages/public/GalleryPage'
 import { HistoryPage } from './pages/public/HistoryPage'
 import { HistoryDetailPage } from './pages/public/HistoryDetailPage'
 import { SponsorsPage } from './pages/public/SponsorsPage'
+import { InfoPage } from './pages/public/InfoPage'
 import { AdminOverviewPage } from './pages/admin/AdminOverviewPage'
 import { AdminTournamentsPage } from './pages/admin/AdminTournamentsPage'
 import { AdminGamesPage } from './pages/admin/AdminGamesPage'
@@ -44,6 +45,7 @@ export function App() {
           <Route path="history" element={<HistoryPage />} />
           <Route path="history/:year" element={<HistoryDetailPage />} />
           <Route path="sponsors" element={<SponsorsPage />} />
+          <Route path="info" element={<InfoPage />} />
         </Route>
         <Route path="admin" element={<AdminLayout />}>
           <Route index element={<AdminOverviewPage />} />

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -9,6 +9,7 @@ const navItems = [
   { to: '/schedule', label: 'Schedule' },
   { to: '/standings', label: 'Standings' },
   { to: '/watch', label: 'Watch' },
+  { to: '/info', label: 'Info' },
   { to: '/news', label: 'News' },
   { to: '/gallery', label: 'Gallery' },
   { to: '/history', label: 'History' },
@@ -54,7 +55,7 @@ export function PublicLayout() {
       <footer className="site-footer">
         <div>
           <strong>FD Alumni Basketball Hub</strong>
-          <p>A central guide to schedule, standings, tickets, streams, coverage, sponsors, and tournament history.</p>
+          <p>A central guide to schedule, standings, tickets, streams, tournament info, coverage, sponsors, and tournament history.</p>
         </div>
         <div className="footer-links">
           <a href={externalHref(import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net') || undefined} target="_blank" rel="noreferrer">GuamTime</a>

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -56,6 +56,7 @@ export function PublicLayout() {
         <div>
           <strong>FD Alumni Basketball Hub</strong>
           <p>A central guide to schedule, standings, tickets, streams, tournament info, coverage, sponsors, and tournament history.</p>
+          <p className="site-credit">Built by <a href={externalHref('https://shimizu-technology.com') || undefined} target="_blank" rel="noreferrer">Shimizu Technology</a>.</p>
         </div>
         <div className="footer-links">
           <a href={externalHref(import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net') || undefined} target="_blank" rel="noreferrer">GuamTime</a>

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -58,9 +58,11 @@ export function PublicLayout() {
           <p>A central guide to schedule, standings, tickets, streams, tournament info, coverage, sponsors, and tournament history.</p>
           <p className="site-credit">Built by <a href={externalHref('https://shimizu-technology.com') || undefined} target="_blank" rel="noreferrer">Shimizu Technology</a>.</p>
         </div>
-        <div className="footer-links">
+        <div className="footer-links" aria-label="Tournament and partner links">
+          <a href={externalHref('https://fatherduenas.com/') || undefined} target="_blank" rel="noreferrer">Father Duenas</a>
           <a href={externalHref(import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net') || undefined} target="_blank" rel="noreferrer">GuamTime</a>
           <a href={externalHref(import.meta.env.VITE_CLUTCH_URL || 'https://www.clutchguam.com') || undefined} target="_blank" rel="noreferrer">Clutch</a>
+          <a href={externalHref('https://guamsportsnetwork.com/') || undefined} target="_blank" rel="noreferrer">GSPN</a>
         </div>
       </footer>
     </div>

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -63,3 +63,21 @@ export function Field({ label, children }: { label: string; children: ReactNode 
 export function FormGrid({ children }: { children: ReactNode }) {
   return <div className="form-grid">{children}</div>
 }
+
+export function PaginationControls({ page, pageSize, total, onPageChange }: { page: number; pageSize: number; total: number; onPageChange: (page: number) => void }) {
+  if (total <= pageSize) return null
+
+  const pageCount = Math.ceil(total / pageSize)
+  const start = (page - 1) * pageSize + 1
+  const end = Math.min(page * pageSize, total)
+
+  return (
+    <div className="pagination-controls" role="navigation" aria-label="Pagination">
+      <span>{start}–{end} of {total}</span>
+      <div className="row-actions">
+        <button className="btn secondary small" type="button" onClick={() => onPageChange(Math.max(1, page - 1))} disabled={page <= 1}>Previous</button>
+        <button className="btn secondary small" type="button" onClick={() => onPageChange(Math.min(pageCount, page + 1))} disabled={page >= pageCount}>Next</button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -177,6 +177,7 @@ export const api = {
   adminUpdateTeam: (id: string, payload: Partial<Team>, tournamentId?: string | null) => request<{ team: Team }>(`/admin/teams/${id}${query({ tournamentId })}`, json('PATCH', { team: payload })),
   adminDeleteTeam: (id: string, tournamentId?: string | null) => request<void>(`/admin/teams/${id}${query({ tournamentId })}`, { method: 'DELETE' }),
   adminCreateRosterEntry: (payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries${query({ tournamentId })}`, json('POST', { rosterEntry: payload })),
+  adminBulkRosterEntries: (payload: Array<Partial<RosterEntry>>, tournamentId?: string | null) => request<{ created: number; rosterEntries: RosterEntry[] }>(`/admin/roster-entries/bulk${query({ tournamentId })}`, json('POST', { rosterEntries: payload })),
   adminUpdateRosterEntry: (id: string, payload: Partial<RosterEntry>, tournamentId?: string | null) => request<{ rosterEntry: RosterEntry }>(`/admin/roster-entries/${id}${query({ tournamentId })}`, json('PATCH', { rosterEntry: payload })),
   adminDeleteRosterEntry: (id: string, tournamentId?: string | null) => request<void>(`/admin/roster-entries/${id}${query({ tournamentId })}`, { method: 'DELETE' }),
 

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -468,10 +468,8 @@ function BulkRosterModal({ team, existingCount, onClose, onSaved }: { team: Team
 
     setSaving(true)
     try {
-      for (const draft of drafts) {
-        await api.adminCreateRosterEntry({ teamId: team.id, ...draft, active: true }, team.tournamentId)
-      }
-      await onSaved(`Added ${drafts.length} roster ${drafts.length === 1 ? 'player' : 'players'}`)
+      const response = await api.adminBulkRosterEntries(drafts.map((draft) => ({ teamId: team.id, ...draft, active: true })), team.tournamentId)
+      await onSaved(`Added ${response.created} roster ${response.created === 1 ? 'player' : 'players'}`)
     } catch (err) {
       setError(mutationErrorMessage(err, 'Unable to bulk add roster players'))
     } finally {
@@ -603,7 +601,12 @@ function parseRosterLine(line: string, sortOrder: number): BulkRosterDraft | nul
       return { jerseyNumber: first, name: commaParts[1] || '', position: commaParts[2] || '', nickname: commaParts.slice(3).join(', '), sortOrder }
     }
 
-    return { name: commaParts[0] || '', jerseyNumber: normalizeJerseyNumber(commaParts[1]) || commaParts[1] || '', position: commaParts[2] || '', nickname: commaParts.slice(3).join(', '), sortOrder }
+    const jerseyNumber = normalizeJerseyNumber(commaParts[1])
+    if (jerseyNumber) {
+      return { name: commaParts[0] || '', jerseyNumber, position: commaParts[2] || '', nickname: commaParts.slice(3).join(', '), sortOrder }
+    }
+
+    return { name: commaParts[0] || '', jerseyNumber: '', position: commaParts[1] || '', nickname: commaParts.slice(2).join(', '), sortOrder }
   }
 
   const jerseyMatch = line.match(/^#?(\d{1,3})\s+(.+)$/)

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -50,7 +50,7 @@ export function AdminDivisionsPage() {
       />
       <TournamentFilter tournaments={tournaments} value={tournament?.id || ''} onChange={setTournamentId} />
       <DivisionSettingsPanel tournament={tournament} divisions={divisions} allDivisions={allDivisions} onSaved={reload} />
-      <CreateTeamPanel tournament={tournament} divisions={divisions} onSaved={reload} />
+      <CreateTeamPanel tournament={tournament} teamsCount={teams.length} divisions={divisions} onSaved={reload} />
       <Panel>
         <div className="section-heading">
           <div>
@@ -187,10 +187,15 @@ function EditableDivision({ division, onSaved }: { division: Division; onSaved: 
   )
 }
 
-function CreateTeamPanel({ tournament, divisions, onSaved }: { tournament: Tournament | null; divisions: Division[]; onSaved: () => Promise<void> }) {
+function CreateTeamPanel({ tournament, teamsCount, divisions, onSaved }: { tournament: Tournament | null; teamsCount: number; divisions: Division[]; onSaved: () => Promise<void> }) {
   const [form, setForm] = useState({ classYearLabel: '', displayName: '', divisionId: '' })
   const [message, setMessage] = useState('')
   const [saving, setSaving] = useState(false)
+  const [open, setOpen] = useState(teamsCount === 0)
+
+  useEffect(() => {
+    if (teamsCount === 0) setOpen(true)
+  }, [teamsCount])
 
   useEffect(() => {
     setForm((current) => ({ ...current, divisionId: divisions[0]?.id || '' }))
@@ -222,7 +227,35 @@ function CreateTeamPanel({ tournament, divisions, onSaved }: { tournament: Tourn
     }
   }
 
-  return <Panel><div className="section-heading"><h2>Add team</h2>{message && <span>{message}</span>}</div>{!tournament ? <EmptyState title="Choose a tournament first" /> : <form onSubmit={submit}><p className="form-note">Tournament: {tournament.year}</p><FormGrid><Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} placeholder="Class of 2016/17" required /></Field><Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} placeholder="2016/17" required /></Field><Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} required /></Field></FormGrid><button className="btn primary" type="submit" disabled={!divisions.length || saving}>{saving ? 'Creating' : 'Create team'}</button></form>}</Panel>
+  return (
+    <Panel className="collapsible-panel admin-create-panel">
+      <div className="section-heading collapsible-heading">
+        <div>
+          <h2>Add team</h2>
+          <p>Usually only needed before schedule import or when organizers approve a late team.</p>
+        </div>
+        <div className="section-actions">
+          {message && <span>{message}</span>}
+          <button className="btn secondary small" type="button" aria-expanded={open} onClick={() => setOpen((value) => !value)}>
+            {open ? 'Hide add team' : 'Add team'}
+          </button>
+        </div>
+      </div>
+      {open && (!tournament ? <EmptyState title="Choose a tournament first" /> : (
+        <div className="collapsible-body">
+          <form onSubmit={submit}>
+            <p className="form-note">Tournament: {tournament.year}</p>
+            <FormGrid>
+              <Field label="Class label"><input value={form.classYearLabel} onChange={(event) => setForm({ ...form, classYearLabel: event.target.value })} placeholder="Class of 2016/17" required /></Field>
+              <Field label="Display name"><input value={form.displayName} onChange={(event) => setForm({ ...form, displayName: event.target.value })} placeholder="2016/17" required /></Field>
+              <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} required /></Field>
+            </FormGrid>
+            <button className="btn primary" type="submit" disabled={!divisions.length || saving}>{saving ? 'Creating' : 'Create team'}</button>
+          </form>
+        </div>
+      ))}
+    </Panel>
+  )
 }
 
 function TeamToolbar({ query, division, sort, divisions, onQueryChange, onDivisionChange, onSortChange }: { query: string; division: string; sort: TeamSortOption; divisions: string[]; onQueryChange: (value: string) => void; onDivisionChange: (value: string) => void; onSortChange: (value: TeamSortOption) => void }) {
@@ -327,10 +360,12 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
   const [message, setMessage] = useState('')
   const [editingEntry, setEditingEntry] = useState<RosterEntry | null>(null)
   const [adding, setAdding] = useState(false)
+  const [bulkAdding, setBulkAdding] = useState(false)
 
   const closeModal = () => {
     setEditingEntry(null)
     setAdding(false)
+    setBulkAdding(false)
   }
 
   return (
@@ -342,9 +377,24 @@ function RosterEditor({ team, entries, onSaved }: { team: Team; entries: RosterE
       {message && <p className="form-note">{message}</p>}
       {open && (
         <div className="collapsible-body roster-manager-body">
-          <div className="row-actions"><button className="btn secondary small" type="button" onClick={() => setAdding(true)}>Add player</button></div>
+          <div className="row-actions">
+            <button className="btn secondary small" type="button" onClick={() => setAdding(true)}>Add player</button>
+            <button className="btn secondary small" type="button" onClick={() => setBulkAdding(true)}>Bulk add roster</button>
+          </div>
           {entries.length ? <RosterTable entries={entries} onEdit={setEditingEntry} /> : <EmptyState title="Roster empty" description="Add players if organizers provide roster details." />}
         </div>
+      )}
+      {bulkAdding && (
+        <BulkRosterModal
+          team={team}
+          existingCount={entries.length}
+          onClose={closeModal}
+          onSaved={async (action) => {
+            setMessage(action)
+            closeModal()
+            await onSaved()
+          }}
+        />
       )}
       {(adding || editingEntry) && (
         <RosterEntryModal
@@ -390,6 +440,77 @@ function RosterTable({ entries, onEdit }: { entries: RosterEntry[]; onEdit: (ent
           ))}
         </tbody>
       </table>
+    </div>
+  )
+}
+
+type BulkRosterDraft = {
+  name: string
+  jerseyNumber: string
+  position: string
+  nickname: string
+  sortOrder: number
+}
+
+function BulkRosterModal({ team, existingCount, onClose, onSaved }: { team: Team; existingCount: number; onClose: () => void; onSaved: (message: string) => Promise<void> }) {
+  const [rawText, setRawText] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const drafts = useMemo(() => parseBulkRoster(rawText, existingCount), [rawText, existingCount])
+
+  const save = async (event: FormEvent) => {
+    event.preventDefault()
+    setError('')
+    if (!drafts.length) {
+      setError('Paste at least one player name before saving.')
+      return
+    }
+
+    setSaving(true)
+    try {
+      for (const draft of drafts) {
+        await api.adminCreateRosterEntry({ teamId: team.id, ...draft, active: true }, team.tournamentId)
+      }
+      await onSaved(`Added ${drafts.length} roster ${drafts.length === 1 ? 'player' : 'players'}`)
+    } catch (err) {
+      setError(mutationErrorMessage(err, 'Unable to bulk add roster players'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation">
+      <div className="modal-card roster-modal bulk-roster-modal" role="dialog" aria-modal="true" aria-label={`Bulk add roster players to ${team.displayName}`}>
+        <div className="section-heading compact-heading">
+          <div>
+            <h2>Bulk add roster</h2>
+            <p className="muted">{team.displayName}</p>
+          </div>
+          <button className="btn secondary small" type="button" onClick={onClose} disabled={saving}>Close</button>
+        </div>
+        <form onSubmit={save}>
+          <Field label="Paste roster lines">
+            <textarea
+              value={rawText}
+              onChange={(event) => setRawText(event.target.value)}
+              placeholder={'23, John Cruz, G, JC\n12, Mike Santos, F\nDavid Perez'}
+              rows={8}
+            />
+          </Field>
+          <p className="field-help">One player per line. Commas are recommended: jersey number, full name, position, nickname. Name-only lines also work.</p>
+          {drafts.length > 0 && (
+            <div className="roster-table-wrap bulk-roster-preview" role="region" aria-label="Bulk roster preview" tabIndex={0}>
+              <table className="data-table roster-admin-table">
+                <thead><tr><th>Sort</th><th>Name</th><th>Jersey #</th><th>Position</th><th>Nickname</th></tr></thead>
+                <tbody>{drafts.map((draft) => <tr key={`${draft.sortOrder}-${draft.name}`}><td>{draft.sortOrder}</td><td><strong>{draft.name}</strong></td><td>{draft.jerseyNumber || '—'}</td><td>{draft.position || '—'}</td><td>{draft.nickname || '—'}</td></tr>)}</tbody>
+              </table>
+            </div>
+          )}
+          {error && <p className="form-error" role="alert">{error}</p>}
+          <button className="btn primary" type="submit" disabled={saving || !drafts.length}>{saving ? 'Adding roster' : drafts.length ? `Add ${drafts.length} ${drafts.length === 1 ? 'player' : 'players'}` : 'Add roster players'}</button>
+        </form>
+      </div>
     </div>
   )
 }
@@ -462,6 +583,38 @@ function RosterEntryModal({ team, entry, nextSortOrder, onClose, onSaved }: { te
       </div>
     </div>
   )
+}
+
+function parseBulkRoster(value: string, existingCount: number): BulkRosterDraft[] {
+  return value
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line, index) => parseRosterLine(line, existingCount + index + 1))
+    .filter((entry): entry is BulkRosterDraft => Boolean(entry?.name))
+}
+
+function parseRosterLine(line: string, sortOrder: number): BulkRosterDraft | null {
+  const commaParts = line.split(',').map((part) => part.trim()).filter(Boolean)
+
+  if (commaParts.length > 1) {
+    const first = normalizeJerseyNumber(commaParts[0])
+    if (first) {
+      return { jerseyNumber: first, name: commaParts[1] || '', position: commaParts[2] || '', nickname: commaParts.slice(3).join(', '), sortOrder }
+    }
+
+    return { name: commaParts[0] || '', jerseyNumber: normalizeJerseyNumber(commaParts[1]) || commaParts[1] || '', position: commaParts[2] || '', nickname: commaParts.slice(3).join(', '), sortOrder }
+  }
+
+  const jerseyMatch = line.match(/^#?(\d{1,3})\s+(.+)$/)
+  if (jerseyMatch) return { jerseyNumber: jerseyMatch[1], name: jerseyMatch[2].trim(), position: '', nickname: '', sortOrder }
+
+  return { name: line, jerseyNumber: '', position: '', nickname: '', sortOrder }
+}
+
+function normalizeJerseyNumber(value: string) {
+  const match = value.trim().match(/^#?(\d{1,3})$/)
+  return match?.[1] || ''
 }
 
 function DivisionSelect({ value, divisions, currentName, onChange, required }: { value: string; divisions: Division[]; currentName?: string | null; onChange: (value: string) => void; required?: boolean }) {

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -14,41 +14,42 @@ const gameDayRefreshIntervalMs = 10_000
 export function AdminGameDayPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
   const [date, setDate] = useState('')
-  const { data, loading, error, reload } = useAsync(async () => {
-    const [tournaments, gameDay, games] = await Promise.all([
+  const setup = useAsync(async () => {
+    const [tournaments, games] = await Promise.all([
       api.adminTournaments(),
-      api.adminGameDay({ tournamentId: tournamentId || null, date: date || null }),
       api.adminGames(tournamentId || null),
     ])
-    return { tournaments: tournaments.tournaments, gameDay, allGames: games.games }
-  }, [tournamentId, date])
+    return { tournaments: tournaments.tournaments, allGames: games.games }
+  }, [tournamentId])
+  const gameDayState = useAsync(() => api.adminGameDay({ tournamentId: tournamentId || null, date: date || null }), [tournamentId, date])
 
   useEffect(() => {
-    if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
-  }, [data?.tournaments, tournamentId, setTournamentId])
+    if (!tournamentId && setup.data?.tournaments[0]?.id) setTournamentId(setup.data.tournaments[0].id)
+  }, [setup.data?.tournaments, tournamentId, setTournamentId])
 
-  const gameDayOptions = useMemo(() => scheduledGameDayOptions(data?.allGames || []), [data?.allGames])
-
-  useEffect(() => {
-    if (!date) setDate(gameDayOptions[0] || data?.gameDay.date || '')
-  }, [data?.gameDay.date, date, gameDayOptions])
+  const gameDayOptions = useMemo(() => scheduledGameDayOptions(setup.data?.allGames || []), [setup.data?.allGames])
 
   useEffect(() => {
-    if (!data) return undefined
+    if (!date) setDate(gameDayOptions[0] || gameDayState.data?.date || '')
+  }, [gameDayState.data?.date, date, gameDayOptions])
+
+  useEffect(() => {
+    if (!gameDayState.data) return undefined
 
     const intervalId = window.setInterval(() => {
-      void reload()
+      void gameDayState.reload()
     }, gameDayRefreshIntervalMs)
 
     return () => window.clearInterval(intervalId)
-  }, [data, reload])
+  }, [gameDayState.data, gameDayState.reload])
 
-  if (loading && !data) return <LoadingState label="Loading game-day controls" />
-  if (error && !data) return <ErrorState message={error} onRetry={reload} />
+  if ((setup.loading && !setup.data) || (gameDayState.loading && !gameDayState.data)) return <LoadingState label="Loading game-day controls" />
+  if (setup.error && !setup.data) return <ErrorState message={setup.error} onRetry={setup.reload} />
+  if (gameDayState.error && !gameDayState.data) return <ErrorState message={gameDayState.error} onRetry={gameDayState.reload} />
 
-  const tournaments = data?.tournaments || []
-  const tournament = selectedTournament(tournaments, tournamentId) || data?.gameDay.tournament || null
-  const gameDay = data?.gameDay
+  const tournaments = setup.data?.tournaments || []
+  const tournament = selectedTournament(tournaments, tournamentId) || gameDayState.data?.tournament || null
+  const gameDay = gameDayState.data
   const selectedDate = date || gameDay?.date || ''
   const gameDayNote = gameDay?.date === selectedDate ? gameDay?.gameDayNote || null : null
 
@@ -71,8 +72,8 @@ export function AdminGameDayPage() {
         )}
       </Panel>
 
-      <GameDayNoteForm tournament={tournament} date={selectedDate} note={gameDayNote} onSaved={reload} />
-      <PredictionAdminPanel tournament={tournament} games={gameDay?.games || []} polls={gameDay?.predictionPolls || []} onSaved={reload} />
+      <GameDayNoteForm tournament={tournament} date={selectedDate} note={gameDayNote} onSaved={gameDayState.reload} />
+      <PredictionAdminPanel tournament={tournament} games={gameDay?.games || []} polls={gameDay?.predictionPolls || []} onSaved={gameDayState.reload} />
     </div>
   )
 }

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -21,27 +21,31 @@ export function AdminGameDayPage() {
     ])
     return { tournaments: tournaments.tournaments, allGames: games.games }
   }, [tournamentId])
-  const gameDayState = useAsync(() => api.adminGameDay({ tournamentId: tournamentId || null, date: date || null }), [tournamentId, date])
+  const gameDayOptions = useMemo(() => scheduledGameDayOptions(setup.data?.allGames || []), [setup.data?.allGames])
+  const gameDayQueryDate = date || gameDayOptions[0] || ''
+  const gameDayState = useAsync(async () => {
+    if (!tournamentId || !gameDayQueryDate) return emptyGameDayPayload(gameDayQueryDate)
+
+    return api.adminGameDay({ tournamentId, date: gameDayQueryDate })
+  }, [tournamentId, gameDayQueryDate])
 
   useEffect(() => {
     if (!tournamentId && setup.data?.tournaments[0]?.id) setTournamentId(setup.data.tournaments[0].id)
   }, [setup.data?.tournaments, tournamentId, setTournamentId])
 
-  const gameDayOptions = useMemo(() => scheduledGameDayOptions(setup.data?.allGames || []), [setup.data?.allGames])
+  useEffect(() => {
+    if (!date && gameDayOptions[0]) setDate(gameDayOptions[0])
+  }, [date, gameDayOptions])
 
   useEffect(() => {
-    if (!date) setDate(gameDayOptions[0] || gameDayState.data?.date || '')
-  }, [gameDayState.data?.date, date, gameDayOptions])
-
-  useEffect(() => {
-    if (!gameDayState.data) return undefined
+    if (!gameDayState.data || !gameDayQueryDate) return undefined
 
     const intervalId = window.setInterval(() => {
       void gameDayState.reload()
     }, gameDayRefreshIntervalMs)
 
     return () => window.clearInterval(intervalId)
-  }, [gameDayState.data, gameDayState.reload])
+  }, [gameDayQueryDate, gameDayState.data, gameDayState.reload])
 
   if ((setup.loading && !setup.data) || (gameDayState.loading && !gameDayState.data)) return <LoadingState label="Loading game-day controls" />
   if (setup.error && !setup.data) return <ErrorState message={setup.error} onRetry={setup.reload} />
@@ -50,7 +54,7 @@ export function AdminGameDayPage() {
   const tournaments = setup.data?.tournaments || []
   const tournament = selectedTournament(tournaments, tournamentId) || gameDayState.data?.tournament || null
   const gameDay = gameDayState.data
-  const selectedDate = date || gameDay?.date || ''
+  const selectedDate = date || gameDay?.date || gameDayQueryDate || ''
   const gameDayNote = gameDay?.date === selectedDate ? gameDay?.gameDayNote || null : null
 
   return (
@@ -76,6 +80,10 @@ export function AdminGameDayPage() {
       <PredictionAdminPanel tournament={tournament} games={gameDay?.games || []} polls={gameDay?.predictionPolls || []} onSaved={gameDayState.reload} />
     </div>
   )
+}
+
+function emptyGameDayPayload(date: string) {
+  return { tournament: null as Tournament | null, date, gameDayNote: null as GameDayNote | null, games: [] as Game[], predictionPolls: [] as PredictionPoll[] }
 }
 
 function scheduledGameDayOptions(games: Game[]) {

--- a/web/src/pages/admin/AdminGameDayPage.tsx
+++ b/web/src/pages/admin/AdminGameDayPage.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom'
 import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import { api } from '../../lib/api'
 import { selectedTournament, tournamentScopedPath, useTournamentSelection } from '../../lib/admin'
-import { formatGuamDateTime, toDateInputValue } from '../../lib/datetime'
+import { formatGuamDate, formatGuamDateTime, toDateInputValue, toLocalDateTimeInputValue } from '../../lib/datetime'
 import { DEFAULT_GAME_VENUE } from '../../lib/games'
 import { mutationErrorMessage } from '../../lib/errors'
 import { useAsync } from '../../lib/hooks'
@@ -15,20 +15,23 @@ export function AdminGameDayPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
   const [date, setDate] = useState('')
   const { data, loading, error, reload } = useAsync(async () => {
-    const [tournaments, gameDay] = await Promise.all([
+    const [tournaments, gameDay, games] = await Promise.all([
       api.adminTournaments(),
       api.adminGameDay({ tournamentId: tournamentId || null, date: date || null }),
+      api.adminGames(tournamentId || null),
     ])
-    return { tournaments: tournaments.tournaments, gameDay }
+    return { tournaments: tournaments.tournaments, gameDay, allGames: games.games }
   }, [tournamentId, date])
 
   useEffect(() => {
     if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
   }, [data?.tournaments, tournamentId, setTournamentId])
 
+  const gameDayOptions = useMemo(() => scheduledGameDayOptions(data?.allGames || []), [data?.allGames])
+
   useEffect(() => {
-    if (!date && data?.gameDay.date) setDate(data.gameDay.date)
-  }, [data?.gameDay.date, date])
+    if (!date) setDate(gameDayOptions[0] || data?.gameDay.date || '')
+  }, [data?.gameDay.date, date, gameDayOptions])
 
   useEffect(() => {
     if (!data) return undefined
@@ -58,15 +61,24 @@ export function AdminGameDayPage() {
         actions={<Link className="btn secondary" to="/today">View Today page</Link>}
       />
 
-      <Panel className="toolbar-panel">
+      <Panel className="toolbar-panel game-day-toolbar-panel">
         <label><span>Tournament</span><select value={tournament?.id || ''} onChange={(event) => setTournamentId(event.target.value)}>{tournaments.map((item) => <option key={item.id} value={item.id}>{item.year} · {item.name}</option>)}</select></label>
         <label><span>Game day</span><input type="date" value={date} onChange={(event) => setDate(event.target.value)} /></label>
+        {gameDayOptions.length > 0 && (
+          <div className="game-day-date-jump" aria-label="Scheduled game-day shortcuts">
+            {gameDayOptions.map((option) => <button key={option} type="button" className={option === selectedDate ? 'selected' : ''} onClick={() => setDate(option)}>{formatGuamDate(option, { weekday: 'short', year: undefined })}</button>)}
+          </div>
+        )}
       </Panel>
 
       <GameDayNoteForm tournament={tournament} date={selectedDate} note={gameDayNote} onSaved={reload} />
       <PredictionAdminPanel tournament={tournament} games={gameDay?.games || []} polls={gameDay?.predictionPolls || []} onSaved={reload} />
     </div>
   )
+}
+
+function scheduledGameDayOptions(games: Game[]) {
+  return Array.from(new Set(games.map((game) => toLocalDateTimeInputValue(game.startTime).slice(0, 10)).filter(Boolean))).sort()
 }
 
 function GameDayNoteForm({ tournament, date, note, onSaved }: { tournament: Tournament | null; date: string; note: GameDayNote | null; onSaved: () => Promise<void> }) {
@@ -157,7 +169,7 @@ function PredictionAdminPanel({ tournament, games, polls, onSaved }: { tournamen
             {tournamentPoll ? <PredictionPollControls poll={tournamentPoll} onUpdate={updatePoll} /> : <button className="btn secondary" onClick={() => createPoll({ tournamentId: tournament.id, pollType: 'tournament', question: 'Who wins the tournament?' })}>Open tournament poll</button>}
           </article>
 
-          {!games.length ? <EmptyState title="No games on selected date" description="Game prediction controls appear once games exist for this date." /> : games.map((game) => {
+          {!games.length ? <EmptyState title="No games on selected date" description="Use a game-day shortcut above or choose a date with scheduled games." /> : games.map((game) => {
             const poll = gamePolls.get(game.id)
             return (
               <article className="admin-row-card prediction-admin-row" key={game.id}>

--- a/web/src/pages/admin/AdminGamesPage.tsx
+++ b/web/src/pages/admin/AdminGamesPage.tsx
@@ -46,7 +46,7 @@ export function AdminGamesPage() {
     <div className="page-stack admin-page">
       <PageHeader eyebrow="Admin" title="Games and scores" description="Build the schedule, enter final scores, and attach GuamTime ticket links or Clutch stream links for each game. Final scores automatically refresh standings." />
       <TournamentFilter tournaments={tournaments} value={currentTournament?.id || ''} onChange={setTournamentId} />
-      <CreateGamePanel tournament={currentTournament} teams={data?.teams || []} divisions={divisions} onSaved={reload} />
+      <CreateGamePanel tournament={currentTournament} teams={data?.teams || []} gamesCount={games.length} divisions={divisions} onSaved={reload} />
       <Panel>
         <div className="section-heading"><h2>Game list</h2><span>{visibleGames.length} of {games.length} games</span></div>
         <GameToolbar query={gameQuery} status={statusFilter} division={divisionFilter} sort={gameSort} divisions={divisionOptions} onQueryChange={setGameQuery} onStatusChange={setStatusFilter} onDivisionChange={setDivisionFilter} onSortChange={setGameSort} />
@@ -81,11 +81,16 @@ function GameToolbar({ query, status, division, sort, divisions, onQueryChange, 
   )
 }
 
-function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament: Tournament | null; teams: Team[]; divisions: Division[]; onSaved: () => Promise<void> }) {
+function CreateGamePanel({ tournament, teams, gamesCount, divisions, onSaved }: { tournament: Tournament | null; teams: Team[]; gamesCount: number; divisions: Division[]; onSaved: () => Promise<void> }) {
   const [form, setForm] = useState({ homeTeamId: '', awayTeamId: '', startDate: guamTodayInputValue(), startTime: '18:30', divisionId: '', bracketCode: '', ticketUrl: '', streamUrl: '', status: 'scheduled' as Game['status'] })
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState('')
+  const [open, setOpen] = useState(gamesCount === 0)
   const availableTeams = useMemo(() => teams.filter((team) => !tournament || team.tournamentId === tournament.id), [teams, tournament])
+
+  useEffect(() => {
+    if (gamesCount === 0) setOpen(true)
+  }, [gamesCount])
 
   useEffect(() => {
     setForm((current) => ({ ...current, homeTeamId: '', awayTeamId: '', divisionId: '' }))
@@ -126,24 +131,37 @@ function CreateGamePanel({ tournament, teams, divisions, onSaved }: { tournament
   }
 
   return (
-    <Panel>
-      <div className="section-heading"><h2>Add game</h2>{message && <span>{message}</span>}</div>
-      {!tournament ? <EmptyState title="Choose a tournament first" /> : (
-        <form onSubmit={submit}>
-          <p className="form-note">Tournament: {tournament.year}. Venue defaults to {DEFAULT_GAME_VENUE}.</p>
-          <FormGrid>
-            <Field label="Away team"><select value={form.awayTeamId} onChange={(event) => setForm({ ...form, awayTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
-            <Field label="Home team"><select value={form.homeTeamId} onChange={(event) => setForm({ ...form, homeTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
-            <Field label="Game date (Guam)"><input type="date" value={form.startDate} onChange={(event) => setForm({ ...form, startDate: event.target.value })} required /></Field>
-            <TipoffTimeField value={form.startTime} onChange={(startTime) => setForm({ ...form, startTime })} />
-            <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
-            <Field label="Bracket / round"><input value={form.bracketCode} onChange={(event) => setForm({ ...form, bracketCode: event.target.value })} placeholder="Pool A, Semifinal, Final" /></Field>
-            <Field label="Ticket URL"><input value={form.ticketUrl} onChange={(event) => setForm({ ...form, ticketUrl: event.target.value })} placeholder="GuamTime link" /></Field>
-            <Field label="Stream URL"><input value={form.streamUrl} onChange={(event) => setForm({ ...form, streamUrl: event.target.value })} placeholder="Clutch or partner stream" /></Field>
-          </FormGrid>
-          <button className="btn primary" type="submit" disabled={saving || availableTeams.length < 2}>{saving ? 'Saving' : 'Create game'}</button>
-        </form>
-      )}
+    <Panel className="collapsible-panel admin-create-panel">
+      <div className="section-heading collapsible-heading">
+        <div>
+          <h2>Add game</h2>
+          <p>Rarely needed after the schedule import. Open this only for make-up games, playoff placeholders, or organizer revisions.</p>
+        </div>
+        <div className="section-actions">
+          {message && <span>{message}</span>}
+          <button className="btn secondary small" type="button" aria-expanded={open} onClick={() => setOpen((value) => !value)}>
+            {open ? 'Hide add game' : 'Add game'}
+          </button>
+        </div>
+      </div>
+      {open && (!tournament ? <EmptyState title="Choose a tournament first" /> : (
+        <div className="collapsible-body">
+          <form onSubmit={submit}>
+            <p className="form-note">Tournament: {tournament.year}. Venue defaults to {DEFAULT_GAME_VENUE}.</p>
+            <FormGrid>
+              <Field label="Away team"><select value={form.awayTeamId} onChange={(event) => setForm({ ...form, awayTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
+              <Field label="Home team"><select value={form.homeTeamId} onChange={(event) => setForm({ ...form, homeTeamId: event.target.value })} required><option value="">Select team</option>{availableTeams.map((team) => <option key={team.id} value={team.id}>{team.displayName}</option>)}</select></Field>
+              <Field label="Game date (Guam)"><input type="date" value={form.startDate} onChange={(event) => setForm({ ...form, startDate: event.target.value })} required /></Field>
+              <TipoffTimeField value={form.startTime} onChange={(startTime) => setForm({ ...form, startTime })} />
+              <Field label="Division"><DivisionSelect value={form.divisionId} divisions={divisions} onChange={(divisionId) => setForm({ ...form, divisionId })} /></Field>
+              <Field label="Bracket / round"><input value={form.bracketCode} onChange={(event) => setForm({ ...form, bracketCode: event.target.value })} placeholder="Pool A, Semifinal, Final" /></Field>
+              <Field label="Ticket URL"><input value={form.ticketUrl} onChange={(event) => setForm({ ...form, ticketUrl: event.target.value })} placeholder="GuamTime link" /></Field>
+              <Field label="Stream URL"><input value={form.streamUrl} onChange={(event) => setForm({ ...form, streamUrl: event.target.value })} placeholder="Clutch or partner stream" /></Field>
+            </FormGrid>
+            <button className="btn primary" type="submit" disabled={saving || availableTeams.length < 2}>{saving ? 'Saving' : 'Create game'}</button>
+          </form>
+        </div>
+      ))}
     </Panel>
   )
 }

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -115,7 +115,7 @@ export function AdminLinksPage() {
           <span>{visibleGames.length} of {data?.games.length || 0}</span>
         </div>
         {focusedGame && <div className="focused-filter-note"><span>Focused from Missing Links: {gameMatchupLabel(focusedGame)}</span><button className="btn secondary small" type="button" onClick={clearFocus}>Show all games</button></div>}
-        {unsavedCount > 0 && <div className="focused-filter-note draft-filter-note"><span>{unsavedCount} {unsavedCount === 1 ? 'game has' : 'games have'} unsaved link changes. Edited rows stay visible while filters are active until you save.</span><button className="btn primary small" type="button" onClick={save}>Save changes</button></div>}
+        {unsavedCount > 0 && <div className="focused-filter-note draft-filter-note"><span>{unsavedCount} {unsavedCount === 1 ? 'game has' : 'games have'} unsaved link changes. Drafts are preserved until you save; clear search or filters to review every pending row.</span><button className="btn primary small" type="button" onClick={save}>Save changes</button></div>}
         <LinkToolbar query={query} filter={filter} sort={sort} onQueryChange={setQuery} onFilterChange={setFilter} onSortChange={setSort} />
         {!data?.games.length ? <EmptyState title="No games found" description="Create games before attaching ticket and stream links." /> : null}
         {data?.games.length && !visibleGames.length ? <EmptyState title="No games match those filters" description="Clear search, focus, or link filters to see more games." /> : null}

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -177,9 +177,9 @@ function filterAndSortLinkGames(games: Game[], drafts: Record<string, LinkDraft>
     .filter((game) => {
       if (focusGameId && game.id !== focusGameId) return false
 
-      const draft = drafts[game.id] || { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' }
-      const hasTicket = Boolean(draft.ticketUrl || game.ticketUrl)
-      const hasStream = Boolean(draft.streamUrl || game.streamUrl)
+      const draft = linkDraftForGame(game, drafts)
+      const hasTicket = Boolean(draft.ticketUrl)
+      const hasStream = Boolean(draft.streamUrl)
       const matchesFilter = filter === 'all' ||
         (filter === 'missingTickets' && !hasTicket) ||
         (filter === 'missingStreams' && !hasStream) ||
@@ -203,7 +203,11 @@ function compareLinkGames(a: Game, b: Game, sort: LinkSort, drafts: Record<strin
 }
 
 function linkStatusValue(game: Game, drafts: Record<string, LinkDraft>, key: keyof LinkDraft) {
-  const draftValue = drafts[game.id]?.[key]
-  const persistedValue = key === 'ticketUrl' ? game.ticketUrl : game.streamUrl
-  return draftValue || persistedValue ? 1 : 0
+  return linkDraftForGame(game, drafts)[key] ? 1 : 0
+}
+
+function linkDraftForGame(game: Game, drafts: Record<string, LinkDraft>) {
+  return Object.prototype.hasOwnProperty.call(drafts, game.id)
+    ? drafts[game.id]
+    : { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' }
 }

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -48,6 +48,11 @@ export function AdminLinksPage() {
   const pagedGames = useMemo(() => visibleGames.slice((page - 1) * linksPageSize, page * linksPageSize), [visibleGames, page])
   const focusedGame = focusGameId ? (data?.games || []).find((game) => game.id === focusGameId) : null
 
+  useEffect(() => {
+    const pageCount = Math.max(1, Math.ceil(visibleGames.length / linksPageSize))
+    if (page > pageCount) setPage(pageCount)
+  }, [page, visibleGames.length])
+
   const clearFocus = () => {
     const next = new URLSearchParams(searchParams)
     next.delete('gameId')

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -48,6 +48,7 @@ export function AdminLinksPage() {
   const currentPage = Math.min(page, Math.max(1, Math.ceil(visibleGames.length / linksPageSize)))
   const pagedGames = useMemo(() => visibleGames.slice((currentPage - 1) * linksPageSize, currentPage * linksPageSize), [visibleGames, currentPage])
   const focusedGame = focusGameId ? (data?.games || []).find((game) => game.id === focusGameId) : null
+  const unsavedCount = useMemo(() => (data?.games || []).filter((game) => hasLinkDraftChanges(game, linkDraftForGame(game, drafts))).length, [data?.games, drafts])
 
   const clearFocus = () => {
     const next = new URLSearchParams(searchParams)
@@ -114,10 +115,14 @@ export function AdminLinksPage() {
           <span>{visibleGames.length} of {data?.games.length || 0}</span>
         </div>
         {focusedGame && <div className="focused-filter-note"><span>Focused from Missing Links: {gameMatchupLabel(focusedGame)}</span><button className="btn secondary small" type="button" onClick={clearFocus}>Show all games</button></div>}
+        {unsavedCount > 0 && <div className="focused-filter-note draft-filter-note"><span>{unsavedCount} {unsavedCount === 1 ? 'game has' : 'games have'} unsaved link changes. Edited rows stay visible while filters are active until you save.</span><button className="btn primary small" type="button" onClick={save}>Save changes</button></div>}
         <LinkToolbar query={query} filter={filter} sort={sort} onQueryChange={setQuery} onFilterChange={setFilter} onSortChange={setSort} />
         {!data?.games.length ? <EmptyState title="No games found" description="Create games before attaching ticket and stream links." /> : null}
         {data?.games.length && !visibleGames.length ? <EmptyState title="No games match those filters" description="Clear search, focus, or link filters to see more games." /> : null}
-        {pagedGames.length > 0 && <div className="admin-list link-admin-list">{pagedGames.map((game) => <LinkRow key={game.id} game={game} value={drafts[game.id] || { ticketUrl: '', streamUrl: '' }} onChange={(value) => setDrafts((prev) => ({ ...prev, [game.id]: value }))} />)}</div>}
+        {pagedGames.length > 0 && <div className="admin-list link-admin-list">{pagedGames.map((game) => {
+          const value = linkDraftForGame(game, drafts)
+          return <LinkRow key={game.id} game={game} value={value} dirty={hasLinkDraftChanges(game, value)} onChange={(nextValue) => setDrafts((prev) => ({ ...prev, [game.id]: nextValue }))} />
+        })}</div>}
         <PaginationControls page={currentPage} pageSize={linksPageSize} total={visibleGames.length} onPageChange={setPage} />
       </Panel>
     </div>
@@ -160,10 +165,10 @@ function LinkToolbar({ query, filter, sort, onQueryChange, onFilterChange, onSor
   )
 }
 
-function LinkRow({ game, value, onChange }: { game: Game; value: LinkDraft; onChange: (value: LinkDraft) => void }) {
+function LinkRow({ game, value, dirty, onChange }: { game: Game; value: LinkDraft; dirty: boolean; onChange: (value: LinkDraft) => void }) {
   return (
     <article className="admin-row-card link-admin-row">
-      <div className="admin-row-head"><div><strong>{gameMatchupLabel(game)}</strong><span>{formatGuamDateTime(game.startTime)}</span></div></div>
+      <div className="admin-row-head"><div><strong>{gameMatchupLabel(game)}</strong><span>{formatGuamDateTime(game.startTime)}</span></div>{dirty && <span className="draft-badge">Unsaved changes</span>}</div>
       <FormGrid>
         <Field label="GuamTime ticket URL"><input value={value.ticketUrl} onChange={(event) => onChange({ ...value, ticketUrl: event.target.value })} /></Field>
         <Field label="Clutch / stream URL"><input value={value.streamUrl} onChange={(event) => onChange({ ...value, streamUrl: event.target.value })} /></Field>
@@ -186,10 +191,9 @@ function filterAndSortLinkGames(games: Game[], drafts: Record<string, LinkDraft>
         (filter === 'missingStreams' && !hasStream) ||
         (filter === 'missingEither' && (!hasTicket || !hasStream)) ||
         (filter === 'complete' && hasTicket && hasStream)
-      if (!matchesFilter) return false
-
       const searchable = [ gameMatchupLabel(game), formatGuamDateTime(game.startTime), game.bracketCode || '', draft.ticketUrl, draft.streamUrl ].join(' ').toLowerCase()
-      return !normalizedQuery || searchable.includes(normalizedQuery)
+      const matchesQuery = !normalizedQuery || searchable.includes(normalizedQuery)
+      return matchesQuery && (matchesFilter || hasLinkDraftChanges(game, draft))
     })
     .slice()
     .sort((a, b) => compareLinkGames(a, b, sort, drafts))
@@ -210,5 +214,14 @@ function linkStatusValue(game: Game, drafts: Record<string, LinkDraft>, key: key
 function linkDraftForGame(game: Game, drafts: Record<string, LinkDraft>) {
   return Object.prototype.hasOwnProperty.call(drafts, game.id)
     ? drafts[game.id]
-    : { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' }
+    : persistedLinkDraft(game)
+}
+
+function hasLinkDraftChanges(game: Game, draft: LinkDraft) {
+  const persisted = persistedLinkDraft(game)
+  return draft.ticketUrl !== persisted.ticketUrl || draft.streamUrl !== persisted.streamUrl
+}
+
+function persistedLinkDraft(game: Game) {
+  return { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' }
 }

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -45,13 +45,9 @@ export function AdminLinksPage() {
   }, [query, filter, sort, focusGameId, tournamentId])
 
   const visibleGames = useMemo(() => filterAndSortLinkGames(data?.games || [], drafts, query, filter, sort, focusGameId), [data?.games, drafts, query, filter, sort, focusGameId])
-  const pagedGames = useMemo(() => visibleGames.slice((page - 1) * linksPageSize, page * linksPageSize), [visibleGames, page])
+  const currentPage = Math.min(page, Math.max(1, Math.ceil(visibleGames.length / linksPageSize)))
+  const pagedGames = useMemo(() => visibleGames.slice((currentPage - 1) * linksPageSize, currentPage * linksPageSize), [visibleGames, currentPage])
   const focusedGame = focusGameId ? (data?.games || []).find((game) => game.id === focusGameId) : null
-
-  useEffect(() => {
-    const pageCount = Math.max(1, Math.ceil(visibleGames.length / linksPageSize))
-    if (page > pageCount) setPage(pageCount)
-  }, [page, visibleGames.length])
 
   const clearFocus = () => {
     const next = new URLSearchParams(searchParams)
@@ -122,7 +118,7 @@ export function AdminLinksPage() {
         {!data?.games.length ? <EmptyState title="No games found" description="Create games before attaching ticket and stream links." /> : null}
         {data?.games.length && !visibleGames.length ? <EmptyState title="No games match those filters" description="Clear search, focus, or link filters to see more games." /> : null}
         {pagedGames.length > 0 && <div className="admin-list link-admin-list">{pagedGames.map((game) => <LinkRow key={game.id} game={game} value={drafts[game.id] || { ticketUrl: '', streamUrl: '' }} onChange={(value) => setDrafts((prev) => ({ ...prev, [game.id]: value }))} />)}</div>}
-        <PaginationControls page={page} pageSize={linksPageSize} total={visibleGames.length} onPageChange={setPage} />
+        <PaginationControls page={currentPage} pageSize={linksPageSize} total={visibleGames.length} onPageChange={setPage} />
       </Panel>
     </div>
   )

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -176,7 +176,7 @@ function filterAndSortLinkGames(games: Game[], drafts: Record<string, LinkDraft>
   const normalizedQuery = query.trim().toLowerCase()
   return games
     .filter((game) => {
-      if (focusGameId && game.id !== focusGameId) return false
+      if (focusGameId) return game.id === focusGameId
 
       const draft = linkDraftForGame(game, drafts)
       const hasTicket = Boolean(draft.ticketUrl)

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -1,17 +1,30 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { api } from '../../lib/api'
 import { selectedTournament, useTournamentSelection } from '../../lib/admin'
 import { useAsync } from '../../lib/hooks'
 import { formatGuamDateTime } from '../../lib/datetime'
+import { gameMatchupLabel } from '../../lib/games'
 import { externalHref } from '../../lib/urls'
 import type { Game, Tournament } from '../../lib/types'
-import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel } from '../../components/ui'
+import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, PaginationControls, Panel } from '../../components/ui'
+
+const linksPageSize = 12
+type LinkFilter = 'all' | 'missingTickets' | 'missingStreams' | 'missingEither' | 'complete'
+type LinkSort = 'startAsc' | 'startDesc' | 'matchup' | 'tickets' | 'streams'
+type LinkDraft = { ticketUrl: string; streamUrl: string }
 
 export function AdminLinksPage() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [tournamentId, setTournamentId] = useTournamentSelection()
-  const [drafts, setDrafts] = useState<Record<string, { ticketUrl: string; streamUrl: string }>>({})
+  const [drafts, setDrafts] = useState<Record<string, LinkDraft>>({})
   const [commonTicketUrl, setCommonTicketUrl] = useState('')
   const [message, setMessage] = useState('')
+  const [query, setQuery] = useState('')
+  const [filter, setFilter] = useState<LinkFilter>('all')
+  const [sort, setSort] = useState<LinkSort>('startAsc')
+  const [page, setPage] = useState(1)
+  const focusGameId = searchParams.get('gameId') || ''
   const { data, loading, error, reload } = useAsync(async () => {
     const [tournaments, links] = await Promise.all([api.adminTournaments(), api.adminLinks(tournamentId || null)])
     return { tournaments: tournaments.tournaments, games: links.games, tournament: links.tournament }
@@ -22,10 +35,24 @@ export function AdminLinksPage() {
   }, [data?.tournaments, tournamentId, setTournamentId])
 
   useEffect(() => {
-    const next: Record<string, { ticketUrl: string; streamUrl: string }> = {}
+    const next: Record<string, LinkDraft> = {}
     data?.games.forEach((game) => { next[game.id] = { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' } })
     setDrafts(next)
   }, [data?.games])
+
+  useEffect(() => {
+    setPage(1)
+  }, [query, filter, sort, focusGameId, tournamentId])
+
+  const visibleGames = useMemo(() => filterAndSortLinkGames(data?.games || [], drafts, query, filter, sort, focusGameId), [data?.games, drafts, query, filter, sort, focusGameId])
+  const pagedGames = useMemo(() => visibleGames.slice((page - 1) * linksPageSize, page * linksPageSize), [visibleGames, page])
+  const focusedGame = focusGameId ? (data?.games || []).find((game) => game.id === focusGameId) : null
+
+  const clearFocus = () => {
+    const next = new URLSearchParams(searchParams)
+    next.delete('gameId')
+    setSearchParams(next, { replace: true })
+  }
 
   const applyCommonTicketUrl = (mode: 'missing' | 'all') => {
     const normalizedUrl = externalHref(commonTicketUrl)
@@ -78,7 +105,19 @@ export function AdminLinksPage() {
       <TicketBulkPanel value={commonTicketUrl} gamesCount={data?.games.length || 0} onChange={setCommonTicketUrl} onApply={applyCommonTicketUrl} />
       {message && <Panel className="notice-panel">{message}</Panel>}
       <Panel>
-        {!data?.games.length ? <EmptyState title="No games found" description="Create games before attaching ticket and stream links." /> : <div className="admin-list">{data.games.map((game) => <LinkRow key={game.id} game={game} value={drafts[game.id] || { ticketUrl: '', streamUrl: '' }} onChange={(value) => setDrafts((prev) => ({ ...prev, [game.id]: value }))} />)}</div>}
+        <div className="section-heading">
+          <div>
+            <h2>Game links</h2>
+            <p className="muted">Search, filter, and page through the schedule without losing unsaved link edits.</p>
+          </div>
+          <span>{visibleGames.length} of {data?.games.length || 0}</span>
+        </div>
+        {focusedGame && <div className="focused-filter-note"><span>Focused from Missing Links: {gameMatchupLabel(focusedGame)}</span><button className="btn secondary small" type="button" onClick={clearFocus}>Show all games</button></div>}
+        <LinkToolbar query={query} filter={filter} sort={sort} onQueryChange={setQuery} onFilterChange={setFilter} onSortChange={setSort} />
+        {!data?.games.length ? <EmptyState title="No games found" description="Create games before attaching ticket and stream links." /> : null}
+        {data?.games.length && !visibleGames.length ? <EmptyState title="No games match those filters" description="Clear search, focus, or link filters to see more games." /> : null}
+        {pagedGames.length > 0 && <div className="admin-list link-admin-list">{pagedGames.map((game) => <LinkRow key={game.id} game={game} value={drafts[game.id] || { ticketUrl: '', streamUrl: '' }} onChange={(value) => setDrafts((prev) => ({ ...prev, [game.id]: value }))} />)}</div>}
+        <PaginationControls page={page} pageSize={linksPageSize} total={visibleGames.length} onPageChange={setPage} />
       </Panel>
     </div>
   )
@@ -110,6 +149,61 @@ function TicketBulkPanel({ value, gamesCount, onChange, onApply }: { value: stri
   )
 }
 
-function LinkRow({ game, value, onChange }: { game: Game; value: { ticketUrl: string; streamUrl: string }; onChange: (value: { ticketUrl: string; streamUrl: string }) => void }) {
-  return <article className="admin-row-card"><div className="admin-row-head"><div><strong>{game.awayTeam?.displayName} at {game.homeTeam?.displayName}</strong><span>{formatGuamDateTime(game.startTime)}</span></div></div><FormGrid><Field label="GuamTime ticket URL"><input value={value.ticketUrl} onChange={(event) => onChange({ ...value, ticketUrl: event.target.value })} /></Field><Field label="Clutch / stream URL"><input value={value.streamUrl} onChange={(event) => onChange({ ...value, streamUrl: event.target.value })} /></Field></FormGrid></article>
+function LinkToolbar({ query, filter, sort, onQueryChange, onFilterChange, onSortChange }: { query: string; filter: LinkFilter; sort: LinkSort; onQueryChange: (value: string) => void; onFilterChange: (value: LinkFilter) => void; onSortChange: (value: LinkSort) => void }) {
+  return (
+    <div className="link-toolbar toolbar-panel">
+      <label><span>Search games</span><input value={query} onChange={(event) => onQueryChange(event.target.value)} placeholder="Team, date, bracket, link" /></label>
+      <label><span>Link status</span><select value={filter} onChange={(event) => onFilterChange(event.target.value as LinkFilter)}><option value="all">All games</option><option value="missingTickets">Missing tickets</option><option value="missingStreams">Missing streams</option><option value="missingEither">Missing either link</option><option value="complete">Ticket and stream posted</option></select></label>
+      <label><span>Sort</span><select value={sort} onChange={(event) => onSortChange(event.target.value as LinkSort)}><option value="startAsc">Start time · earliest</option><option value="startDesc">Start time · latest</option><option value="matchup">Matchup</option><option value="tickets">Ticket status</option><option value="streams">Stream status</option></select></label>
+    </div>
+  )
+}
+
+function LinkRow({ game, value, onChange }: { game: Game; value: LinkDraft; onChange: (value: LinkDraft) => void }) {
+  return (
+    <article className="admin-row-card link-admin-row">
+      <div className="admin-row-head"><div><strong>{gameMatchupLabel(game)}</strong><span>{formatGuamDateTime(game.startTime)}</span></div></div>
+      <FormGrid>
+        <Field label="GuamTime ticket URL"><input value={value.ticketUrl} onChange={(event) => onChange({ ...value, ticketUrl: event.target.value })} /></Field>
+        <Field label="Clutch / stream URL"><input value={value.streamUrl} onChange={(event) => onChange({ ...value, streamUrl: event.target.value })} /></Field>
+      </FormGrid>
+    </article>
+  )
+}
+
+function filterAndSortLinkGames(games: Game[], drafts: Record<string, LinkDraft>, query: string, filter: LinkFilter, sort: LinkSort, focusGameId: string) {
+  const normalizedQuery = query.trim().toLowerCase()
+  return games
+    .filter((game) => {
+      if (focusGameId && game.id !== focusGameId) return false
+
+      const draft = drafts[game.id] || { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' }
+      const hasTicket = Boolean(draft.ticketUrl || game.ticketUrl)
+      const hasStream = Boolean(draft.streamUrl || game.streamUrl)
+      const matchesFilter = filter === 'all' ||
+        (filter === 'missingTickets' && !hasTicket) ||
+        (filter === 'missingStreams' && !hasStream) ||
+        (filter === 'missingEither' && (!hasTicket || !hasStream)) ||
+        (filter === 'complete' && hasTicket && hasStream)
+      if (!matchesFilter) return false
+
+      const searchable = [ gameMatchupLabel(game), formatGuamDateTime(game.startTime), game.bracketCode || '', draft.ticketUrl, draft.streamUrl ].join(' ').toLowerCase()
+      return !normalizedQuery || searchable.includes(normalizedQuery)
+    })
+    .slice()
+    .sort((a, b) => compareLinkGames(a, b, sort, drafts))
+}
+
+function compareLinkGames(a: Game, b: Game, sort: LinkSort, drafts: Record<string, LinkDraft>) {
+  if (sort === 'startDesc') return new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
+  if (sort === 'matchup') return gameMatchupLabel(a).localeCompare(gameMatchupLabel(b), undefined, { numeric: true })
+  if (sort === 'tickets') return linkStatusValue(a, drafts, 'ticketUrl') - linkStatusValue(b, drafts, 'ticketUrl') || new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+  if (sort === 'streams') return linkStatusValue(a, drafts, 'streamUrl') - linkStatusValue(b, drafts, 'streamUrl') || new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+  return new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+}
+
+function linkStatusValue(game: Game, drafts: Record<string, LinkDraft>, key: keyof LinkDraft) {
+  const draftValue = drafts[game.id]?.[key]
+  const persistedValue = key === 'ticketUrl' ? game.ticketUrl : game.streamUrl
+  return draftValue || persistedValue ? 1 : 0
 }

--- a/web/src/pages/admin/AdminLinksPage.tsx
+++ b/web/src/pages/admin/AdminLinksPage.tsx
@@ -10,6 +10,7 @@ import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Pane
 export function AdminLinksPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
   const [drafts, setDrafts] = useState<Record<string, { ticketUrl: string; streamUrl: string }>>({})
+  const [commonTicketUrl, setCommonTicketUrl] = useState('')
   const [message, setMessage] = useState('')
   const { data, loading, error, reload } = useAsync(async () => {
     const [tournaments, links] = await Promise.all([api.adminTournaments(), api.adminLinks(tournamentId || null)])
@@ -25,6 +26,26 @@ export function AdminLinksPage() {
     data?.games.forEach((game) => { next[game.id] = { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' } })
     setDrafts(next)
   }, [data?.games])
+
+  const applyCommonTicketUrl = (mode: 'missing' | 'all') => {
+    const normalizedUrl = externalHref(commonTicketUrl)
+    if (!normalizedUrl) {
+      setMessage('Paste a GuamTime ticket link first')
+      return
+    }
+
+    let changed = 0
+    const next = { ...drafts }
+    for (const game of data?.games || []) {
+      const existing = next[game.id] || { ticketUrl: game.ticketUrl || '', streamUrl: game.streamUrl || '' }
+      if (mode === 'all' || !existing.ticketUrl) {
+        if (existing.ticketUrl !== normalizedUrl) changed += 1
+        next[game.id] = { ...existing, ticketUrl: normalizedUrl }
+      }
+    }
+    setDrafts(next)
+    setMessage(`${mode === 'all' ? 'Replaced' : 'Filled'} ticket links for ${changed} ${changed === 1 ? 'game' : 'games'}. Save changes to publish.`)
+  }
 
   const save = async () => {
     const updates = (data?.games || [])
@@ -54,6 +75,7 @@ export function AdminLinksPage() {
     <div className="page-stack admin-page">
       <PageHeader eyebrow="Admin" title="Ticket and stream links" description="Paste GuamTime ticket links and Clutch or partner stream links for each scheduled game." actions={<button className="btn primary" onClick={save}>Save changes</button>} />
       <TournamentFilter tournaments={data?.tournaments || []} value={tournament?.id || ''} onChange={setTournamentId} />
+      <TicketBulkPanel value={commonTicketUrl} gamesCount={data?.games.length || 0} onChange={setCommonTicketUrl} onApply={applyCommonTicketUrl} />
       {message && <Panel className="notice-panel">{message}</Panel>}
       <Panel>
         {!data?.games.length ? <EmptyState title="No games found" description="Create games before attaching ticket and stream links." /> : <div className="admin-list">{data.games.map((game) => <LinkRow key={game.id} game={game} value={drafts[game.id] || { ticketUrl: '', streamUrl: '' }} onChange={(value) => setDrafts((prev) => ({ ...prev, [game.id]: value }))} />)}</div>}
@@ -64,6 +86,28 @@ export function AdminLinksPage() {
 
 function TournamentFilter({ tournaments, value, onChange }: { tournaments: Tournament[]; value: string; onChange: (value: string) => void }) {
   return <Panel className="toolbar-panel"><label><span>Tournament</span><select value={value} onChange={(event) => onChange(event.target.value)}>{tournaments.map((tournament) => <option key={tournament.id} value={tournament.id}>{tournament.year} · {tournament.name}</option>)}</select></label></Panel>
+}
+
+function TicketBulkPanel({ value, gamesCount, onChange, onApply }: { value: string; gamesCount: number; onChange: (value: string) => void; onApply: (mode: 'missing' | 'all') => void }) {
+  return (
+    <Panel className="bulk-link-panel">
+      <div className="section-heading compact-heading">
+        <div>
+          <h2>Common ticket link</h2>
+          <p className="muted">Most games can share the same GuamTime link. Championship sessions or special events can be overridden row-by-row after applying.</p>
+        </div>
+        <span>{gamesCount} games</span>
+      </div>
+      <div className="bulk-ticket-actions">
+        <Field label="GuamTime ticket URL"><input value={value} onChange={(event) => onChange(event.target.value)} placeholder="https://guamtime.net/..." /></Field>
+        <div className="row-actions">
+          <button className="btn secondary" type="button" onClick={() => onApply('missing')}>Fill missing only</button>
+          <button className="btn primary" type="button" onClick={() => onApply('all')}>Apply to all games</button>
+        </div>
+      </div>
+      <p className="field-help">Ticket prices can vary by listing or session, so GuamTime remains the source of truth for current pricing before purchase.</p>
+    </Panel>
+  )
 }
 
 function LinkRow({ game, value, onChange }: { game: Game; value: { ticketUrl: string; streamUrl: string }; onChange: (value: { ticketUrl: string; streamUrl: string }) => void }) {

--- a/web/src/pages/admin/AdminMissingLinksPage.tsx
+++ b/web/src/pages/admin/AdminMissingLinksPage.tsx
@@ -1,14 +1,24 @@
-import { useEffect } from 'react'
+import { Link } from 'react-router-dom'
+import { useEffect, useMemo, useState } from 'react'
 import { api } from '../../lib/api'
-import { selectedTournament, useTournamentSelection } from '../../lib/admin'
+import { selectedTournament, tournamentScopedPath, useTournamentSelection } from '../../lib/admin'
 import { useAsync } from '../../lib/hooks'
 import { formatGuamDateTime } from '../../lib/datetime'
-import { DEFAULT_GAME_VENUE } from '../../lib/games'
+import { DEFAULT_GAME_VENUE, gameMatchupLabel } from '../../lib/games'
+import { externalHref } from '../../lib/urls'
 import type { Game, Tournament } from '../../lib/types'
-import { EmptyState, ErrorState, LoadingState, PageHeader, Panel, StatCard } from '../../components/ui'
+import { EmptyState, ErrorState, Field, LoadingState, PageHeader, PaginationControls, Panel, StatCard } from '../../components/ui'
+
+const missingPageSize = 8
+type MissingCategory = 'all' | 'tickets' | 'streams' | 'scores'
+type MissingSort = 'startAsc' | 'startDesc' | 'matchup'
+type LinkKind = 'ticket' | 'stream'
 
 export function AdminMissingLinksPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
+  const [query, setQuery] = useState('')
+  const [category, setCategory] = useState<MissingCategory>('all')
+  const [sort, setSort] = useState<MissingSort>('startAsc')
   const { data, loading, error, reload } = useAsync(async () => {
     const [tournaments, missing] = await Promise.all([api.adminTournaments(), api.adminMissingLinks(tournamentId || null)])
     return { tournaments: tournaments.tournaments, ...missing }
@@ -25,12 +35,18 @@ export function AdminMissingLinksPage() {
 
   return (
     <div className="page-stack admin-page">
-      <PageHeader eyebrow="Admin" title="Missing links and scores" description="Find games still missing GuamTime tickets, Clutch streams, or final scores." />
+      <PageHeader
+        eyebrow="Admin"
+        title="Missing links and scores"
+        description="Find games still missing GuamTime tickets, Clutch streams, or final scores. Add links here or jump to the full Links workspace."
+        actions={<Link className="btn secondary" to={tournamentScopedPath('/admin/links', tournament?.id)}>Open Links page</Link>}
+      />
       <TournamentFilter tournaments={data?.tournaments || []} value={tournament?.id || ''} onChange={setTournamentId} />
       <div className="stats-grid three"><StatCard label="Missing tickets" value={data?.summary.missingTickets || 0} /><StatCard label="Missing streams" value={data?.summary.missingStreams || 0} /><StatCard label="Missing scores" value={data?.summary.missingScores || 0} tone="gold" /></div>
-      <MissingPanel title="Tickets missing" games={data?.missingTickets || []} />
-      <MissingPanel title="Streams missing" games={data?.missingStreams || []} />
-      <MissingPanel title="Final scores missing" games={data?.missingScores || []} />
+      <MissingToolbar query={query} category={category} sort={sort} onQueryChange={setQuery} onCategoryChange={setCategory} onSortChange={setSort} />
+      {(category === 'all' || category === 'tickets') && <MissingPanel title="Tickets missing" games={data?.missingTickets || []} query={query} sort={sort} linkKind="ticket" tournamentId={tournament?.id || ''} onSaved={reload} />}
+      {(category === 'all' || category === 'streams') && <MissingPanel title="Streams missing" games={data?.missingStreams || []} query={query} sort={sort} linkKind="stream" tournamentId={tournament?.id || ''} onSaved={reload} />}
+      {(category === 'all' || category === 'scores') && <MissingPanel title="Final scores missing" games={data?.missingScores || []} query={query} sort={sort} tournamentId={tournament?.id || ''} onSaved={reload} />}
     </div>
   )
 }
@@ -39,6 +55,104 @@ function TournamentFilter({ tournaments, value, onChange }: { tournaments: Tourn
   return <Panel className="toolbar-panel"><label><span>Tournament</span><select value={value} onChange={(event) => onChange(event.target.value)}>{tournaments.map((tournament) => <option key={tournament.id} value={tournament.id}>{tournament.year} · {tournament.name}</option>)}</select></label></Panel>
 }
 
-function MissingPanel({ title, games }: { title: string; games: Game[] }) {
-  return <Panel><div className="section-heading"><h2>{title}</h2><span>{games.length}</span></div>{games.length === 0 ? <EmptyState title="Nothing missing in this category" /> : <div className="compact-list">{games.slice(0, 50).map((game) => <div key={game.id} className="compact-row"><span>{formatGuamDateTime(game.startTime)}</span><strong>{game.awayTeam?.displayName} at {game.homeTeam?.displayName}</strong><small>{game.venue || DEFAULT_GAME_VENUE}</small></div>)}</div>}</Panel>
+function MissingToolbar({ query, category, sort, onQueryChange, onCategoryChange, onSortChange }: { query: string; category: MissingCategory; sort: MissingSort; onQueryChange: (value: string) => void; onCategoryChange: (value: MissingCategory) => void; onSortChange: (value: MissingSort) => void }) {
+  return (
+    <Panel className="missing-toolbar toolbar-panel">
+      <label><span>Search games</span><input value={query} onChange={(event) => onQueryChange(event.target.value)} placeholder="Team, date, bracket, venue" /></label>
+      <label><span>Category</span><select value={category} onChange={(event) => onCategoryChange(event.target.value as MissingCategory)}><option value="all">All gaps</option><option value="tickets">Tickets only</option><option value="streams">Streams only</option><option value="scores">Scores only</option></select></label>
+      <label><span>Sort</span><select value={sort} onChange={(event) => onSortChange(event.target.value as MissingSort)}><option value="startAsc">Start time · earliest</option><option value="startDesc">Start time · latest</option><option value="matchup">Matchup</option></select></label>
+    </Panel>
+  )
+}
+
+function MissingPanel({ title, games, query, sort, linkKind, tournamentId, onSaved }: { title: string; games: Game[]; query: string; sort: MissingSort; linkKind?: LinkKind; tournamentId: string; onSaved: () => Promise<void> }) {
+  const [page, setPage] = useState(1)
+  const visibleGames = useMemo(() => filterAndSortMissingGames(games, query, sort), [games, query, sort])
+  const pagedGames = useMemo(() => visibleGames.slice((page - 1) * missingPageSize, page * missingPageSize), [visibleGames, page])
+
+  useEffect(() => {
+    setPage(1)
+  }, [query, sort, games])
+
+  return (
+    <Panel>
+      <div className="section-heading"><h2>{title}</h2><span>{visibleGames.length} of {games.length}</span></div>
+      {games.length === 0 ? <EmptyState title="Nothing missing in this category" /> : null}
+      {games.length > 0 && !visibleGames.length ? <EmptyState title="No gaps match those filters" description="Clear search or change sorting to see more games." /> : null}
+      {pagedGames.length > 0 && (
+        <div className="compact-list missing-gap-list">
+          {pagedGames.map((game) => <MissingGameRow key={game.id} game={game} linkKind={linkKind} tournamentId={tournamentId} onSaved={onSaved} />)}
+        </div>
+      )}
+      <PaginationControls page={page} pageSize={missingPageSize} total={visibleGames.length} onPageChange={setPage} />
+    </Panel>
+  )
+}
+
+function MissingGameRow({ game, linkKind, tournamentId, onSaved }: { game: Game; linkKind?: LinkKind; tournamentId: string; onSaved: () => Promise<void> }) {
+  const [value, setValue] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [message, setMessage] = useState('')
+  const linkLabel = linkKind === 'ticket' ? 'GuamTime ticket URL' : 'Clutch / stream URL'
+  const linksPath = tournamentScopedPath('/admin/links', tournamentId, { gameId: game.id })
+  const gamesPath = tournamentScopedPath('/admin/games', tournamentId)
+
+  const saveLink = async () => {
+    const normalized = externalHref(value)
+    if (!normalized || !linkKind) {
+      setMessage('Paste a valid link first')
+      return
+    }
+
+    setSaving(true)
+    setMessage('')
+    try {
+      await api.adminBulkLinks([linkKind === 'ticket' ? { id: game.id, ticketUrl: normalized } : { id: game.id, streamUrl: normalized }])
+      setValue('')
+      await onSaved()
+    } catch (err) {
+      setMessage(err instanceof Error ? err.message : 'Unable to save link')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <article className="compact-row missing-gap-row">
+      <div className="missing-gap-main">
+        <span>{formatGuamDateTime(game.startTime)}</span>
+        <strong>{gameMatchupLabel(game)}</strong>
+        <small>{game.venue || DEFAULT_GAME_VENUE}{game.bracketCode ? ` · ${game.bracketCode}` : ''}</small>
+      </div>
+      {linkKind ? (
+        <div className="missing-gap-actions">
+          <Field label={linkLabel}><input value={value} onChange={(event) => setValue(event.target.value)} placeholder="https://..." /></Field>
+          <div className="row-actions">
+            <button className="btn primary small" type="button" onClick={saveLink} disabled={saving}>{saving ? 'Saving' : 'Save link'}</button>
+            <Link className="btn secondary small" to={linksPath}>Open in Links</Link>
+          </div>
+          {message && <p className="form-error" role="alert">{message}</p>}
+        </div>
+      ) : (
+        <div className="row-actions"><Link className="btn secondary small" to={gamesPath}>Open Games page</Link></div>
+      )}
+    </article>
+  )
+}
+
+function filterAndSortMissingGames(games: Game[], query: string, sort: MissingSort) {
+  const normalizedQuery = query.trim().toLowerCase()
+  return games
+    .filter((game) => {
+      const searchable = [ gameMatchupLabel(game), formatGuamDateTime(game.startTime), game.venue || '', game.bracketCode || '' ].join(' ').toLowerCase()
+      return !normalizedQuery || searchable.includes(normalizedQuery)
+    })
+    .slice()
+    .sort((a, b) => compareMissingGames(a, b, sort))
+}
+
+function compareMissingGames(a: Game, b: Game, sort: MissingSort) {
+  if (sort === 'startDesc') return new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
+  if (sort === 'matchup') return gameMatchupLabel(a).localeCompare(gameMatchupLabel(b), undefined, { numeric: true })
+  return new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
 }

--- a/web/src/pages/admin/AdminMissingLinksPage.tsx
+++ b/web/src/pages/admin/AdminMissingLinksPage.tsx
@@ -10,9 +10,9 @@ import type { Game, Tournament } from '../../lib/types'
 import { EmptyState, ErrorState, Field, LoadingState, PageHeader, PaginationControls, Panel, StatCard } from '../../components/ui'
 
 const missingPageSize = 8
-type MissingCategory = 'all' | 'tickets' | 'streams' | 'scores'
+type MissingCategory = 'all' | 'links' | 'tickets' | 'streams' | 'scores'
 type MissingSort = 'startAsc' | 'startDesc' | 'matchup'
-type LinkKind = 'ticket' | 'stream'
+type MissingGap = { game: Game; missingTicket: boolean; missingStream: boolean; missingScore: boolean }
 
 export function AdminMissingLinksPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
@@ -28,6 +28,8 @@ export function AdminMissingLinksPage() {
     if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
   }, [data?.tournaments, tournamentId, setTournamentId])
 
+  const gaps = useMemo(() => buildMissingGaps(data?.missingTickets || [], data?.missingStreams || [], data?.missingScores || [], category), [data?.missingTickets, data?.missingStreams, data?.missingScores, category])
+
   if (loading && !data) return <LoadingState label="Checking data health" />
   if (error) return <ErrorState message={error} onRetry={reload} />
 
@@ -38,15 +40,13 @@ export function AdminMissingLinksPage() {
       <PageHeader
         eyebrow="Admin"
         title="Missing links and scores"
-        description="Find games still missing GuamTime tickets, Clutch streams, or final scores. Add links here or jump to the full Links workspace."
+        description="Find games still missing GuamTime tickets, Clutch streams, or final scores. One game row now shows every missing field for that game."
         actions={<Link className="btn secondary" to={tournamentScopedPath('/admin/links', tournament?.id)}>Open Links page</Link>}
       />
       <TournamentFilter tournaments={data?.tournaments || []} value={tournament?.id || ''} onChange={setTournamentId} />
       <div className="stats-grid three"><StatCard label="Missing tickets" value={data?.summary.missingTickets || 0} /><StatCard label="Missing streams" value={data?.summary.missingStreams || 0} /><StatCard label="Missing scores" value={data?.summary.missingScores || 0} tone="gold" /></div>
       <MissingToolbar query={query} category={category} sort={sort} onQueryChange={setQuery} onCategoryChange={setCategory} onSortChange={setSort} />
-      {(category === 'all' || category === 'tickets') && <MissingPanel title="Tickets missing" games={data?.missingTickets || []} query={query} sort={sort} linkKind="ticket" tournamentId={tournament?.id || ''} onSaved={reload} />}
-      {(category === 'all' || category === 'streams') && <MissingPanel title="Streams missing" games={data?.missingStreams || []} query={query} sort={sort} linkKind="stream" tournamentId={tournament?.id || ''} onSaved={reload} />}
-      {(category === 'all' || category === 'scores') && <MissingPanel title="Final scores missing" games={data?.missingScores || []} query={query} sort={sort} tournamentId={tournament?.id || ''} onSaved={reload} />}
+      <MissingPanel gaps={gaps} query={query} sort={sort} tournamentId={tournament?.id || ''} onSaved={reload} />
     </div>
   )
 }
@@ -59,100 +59,184 @@ function MissingToolbar({ query, category, sort, onQueryChange, onCategoryChange
   return (
     <Panel className="missing-toolbar toolbar-panel">
       <label><span>Search games</span><input value={query} onChange={(event) => onQueryChange(event.target.value)} placeholder="Team, date, bracket, venue" /></label>
-      <label><span>Category</span><select value={category} onChange={(event) => onCategoryChange(event.target.value as MissingCategory)}><option value="all">All gaps</option><option value="tickets">Tickets only</option><option value="streams">Streams only</option><option value="scores">Scores only</option></select></label>
+      <label><span>Category</span><select value={category} onChange={(event) => onCategoryChange(event.target.value as MissingCategory)}><option value="all">All gaps</option><option value="links">Links only</option><option value="tickets">Tickets only</option><option value="streams">Streams only</option><option value="scores">Scores only</option></select></label>
       <label><span>Sort</span><select value={sort} onChange={(event) => onSortChange(event.target.value as MissingSort)}><option value="startAsc">Start time · earliest</option><option value="startDesc">Start time · latest</option><option value="matchup">Matchup</option></select></label>
     </Panel>
   )
 }
 
-function MissingPanel({ title, games, query, sort, linkKind, tournamentId, onSaved }: { title: string; games: Game[]; query: string; sort: MissingSort; linkKind?: LinkKind; tournamentId: string; onSaved: () => Promise<void> }) {
+function MissingPanel({ gaps, query, sort, tournamentId, onSaved }: { gaps: MissingGap[]; query: string; sort: MissingSort; tournamentId: string; onSaved: () => Promise<void> }) {
   const [page, setPage] = useState(1)
-  const visibleGames = useMemo(() => filterAndSortMissingGames(games, query, sort), [games, query, sort])
-  const pagedGames = useMemo(() => visibleGames.slice((page - 1) * missingPageSize, page * missingPageSize), [visibleGames, page])
+  const visibleGaps = useMemo(() => filterAndSortMissingGaps(gaps, query, sort), [gaps, query, sort])
+  const pagedGaps = useMemo(() => visibleGaps.slice((page - 1) * missingPageSize, page * missingPageSize), [visibleGaps, page])
 
   useEffect(() => {
     setPage(1)
-  }, [query, sort, games])
+  }, [query, sort, gaps])
 
   return (
     <Panel>
-      <div className="section-heading"><h2>{title}</h2><span>{visibleGames.length} of {games.length}</span></div>
-      {games.length === 0 ? <EmptyState title="Nothing missing in this category" /> : null}
-      {games.length > 0 && !visibleGames.length ? <EmptyState title="No gaps match those filters" description="Clear search or change sorting to see more games." /> : null}
-      {pagedGames.length > 0 && (
+      <div className="section-heading"><div><h2>Games needing updates</h2><p className="muted">Ticket, stream, and score gaps are grouped by game to keep game-day cleanup compact.</p></div><span>{visibleGaps.length} of {gaps.length}</span></div>
+      {gaps.length === 0 ? <EmptyState title="No gaps found" description="Ticket links, stream links, and final scores are complete for this filter." /> : null}
+      {gaps.length > 0 && !visibleGaps.length ? <EmptyState title="No gaps match those filters" description="Clear search or change sorting to see more games." /> : null}
+      {pagedGaps.length > 0 && (
         <div className="compact-list missing-gap-list">
-          {pagedGames.map((game) => <MissingGameRow key={game.id} game={game} linkKind={linkKind} tournamentId={tournamentId} onSaved={onSaved} />)}
+          {pagedGaps.map((gap) => <MissingGameRow key={gap.game.id} gap={gap} tournamentId={tournamentId} onSaved={onSaved} />)}
         </div>
       )}
-      <PaginationControls page={page} pageSize={missingPageSize} total={visibleGames.length} onPageChange={setPage} />
+      <PaginationControls page={page} pageSize={missingPageSize} total={visibleGaps.length} onPageChange={setPage} />
     </Panel>
   )
 }
 
-function MissingGameRow({ game, linkKind, tournamentId, onSaved }: { game: Game; linkKind?: LinkKind; tournamentId: string; onSaved: () => Promise<void> }) {
-  const [value, setValue] = useState('')
+function MissingGameRow({ gap, tournamentId, onSaved }: { gap: MissingGap; tournamentId: string; onSaved: () => Promise<void> }) {
+  const { game } = gap
+  const [ticketUrl, setTicketUrl] = useState('')
+  const [streamUrl, setStreamUrl] = useState('')
+  const [homeScore, setHomeScore] = useState(scoreDraft(game.homeScore))
+  const [awayScore, setAwayScore] = useState(scoreDraft(game.awayScore))
   const [saving, setSaving] = useState(false)
   const [message, setMessage] = useState('')
-  const linkLabel = linkKind === 'ticket' ? 'GuamTime ticket URL' : 'Clutch / stream URL'
   const linksPath = tournamentScopedPath('/admin/links', tournamentId, { gameId: game.id })
   const gamesPath = tournamentScopedPath('/admin/games', tournamentId)
 
-  const saveLink = async () => {
-    const normalized = externalHref(value)
-    if (!normalized || !linkKind) {
-      setMessage('Paste a valid link first')
+  useEffect(() => {
+    setTicketUrl('')
+    setStreamUrl('')
+    setHomeScore(scoreDraft(game.homeScore))
+    setAwayScore(scoreDraft(game.awayScore))
+    setMessage('')
+  }, [game.id, game.homeScore, game.awayScore, gap.missingTicket, gap.missingStream, gap.missingScore])
+
+  const saveUpdates = async () => {
+    const linkUpdate: { id: string; ticketUrl?: string | null; streamUrl?: string | null } = { id: game.id }
+    let hasLinkUpdate = false
+
+    if (gap.missingTicket && ticketUrl.trim()) {
+      linkUpdate.ticketUrl = externalHref(ticketUrl)
+      hasLinkUpdate = true
+    }
+
+    if (gap.missingStream && streamUrl.trim()) {
+      linkUpdate.streamUrl = externalHref(streamUrl)
+      hasLinkUpdate = true
+    }
+
+    const scoreChanged = gap.missingScore && (homeScore.trim() !== scoreDraft(game.homeScore) || awayScore.trim() !== scoreDraft(game.awayScore))
+    const parsedHomeScore = parseScore(homeScore)
+    const parsedAwayScore = parseScore(awayScore)
+
+    if (scoreChanged && (parsedHomeScore === null || parsedAwayScore === null)) {
+      setMessage('Enter both final scores as whole numbers before saving scores.')
+      return
+    }
+
+    if (!hasLinkUpdate && !scoreChanged) {
+      setMessage('Add at least one missing link or score before saving.')
       return
     }
 
     setSaving(true)
     setMessage('')
     try {
-      await api.adminBulkLinks([linkKind === 'ticket' ? { id: game.id, ticketUrl: normalized } : { id: game.id, streamUrl: normalized }])
-      setValue('')
+      const requests: Array<Promise<unknown>> = []
+      if (hasLinkUpdate) requests.push(api.adminBulkLinks([linkUpdate]))
+      if (scoreChanged) requests.push(api.adminUpdateGame(game.id, { homeScore: parsedHomeScore, awayScore: parsedAwayScore, status: 'final' }))
+      await Promise.all(requests)
       await onSaved()
     } catch (err) {
-      setMessage(err instanceof Error ? err.message : 'Unable to save link')
+      setMessage(err instanceof Error ? err.message : 'Unable to save updates')
     } finally {
       setSaving(false)
     }
   }
 
   return (
-    <article className="compact-row missing-gap-row">
+    <article className="compact-row missing-gap-row consolidated-gap-row">
       <div className="missing-gap-main">
         <span>{formatGuamDateTime(game.startTime)}</span>
         <strong>{gameMatchupLabel(game)}</strong>
         <small>{game.venue || DEFAULT_GAME_VENUE}{game.bracketCode ? ` · ${game.bracketCode}` : ''}</small>
-      </div>
-      {linkKind ? (
-        <div className="missing-gap-actions">
-          <Field label={linkLabel}><input value={value} onChange={(event) => setValue(event.target.value)} placeholder="https://..." /></Field>
-          <div className="row-actions">
-            <button className="btn primary small" type="button" onClick={saveLink} disabled={saving}>{saving ? 'Saving' : 'Save link'}</button>
-            <Link className="btn secondary small" to={linksPath}>Open in Links</Link>
-          </div>
-          {message && <p className="form-error" role="alert">{message}</p>}
+        <div className="gap-chip-row">
+          {gap.missingTicket && <span>Ticket link</span>}
+          {gap.missingStream && <span>Stream link</span>}
+          {gap.missingScore && <span>Final score</span>}
         </div>
-      ) : (
-        <div className="row-actions"><Link className="btn secondary small" to={gamesPath}>Open Games page</Link></div>
-      )}
+      </div>
+      <div className="missing-gap-actions consolidated-gap-actions">
+        <div className="gap-field-grid">
+          {gap.missingTicket && <Field label="GuamTime ticket URL"><input value={ticketUrl} onChange={(event) => setTicketUrl(event.target.value)} placeholder="https://..." /></Field>}
+          {gap.missingStream && <Field label="Clutch / stream URL"><input value={streamUrl} onChange={(event) => setStreamUrl(event.target.value)} placeholder="https://..." /></Field>}
+          {gap.missingScore && (
+            <div className="score-gap-fields">
+              <Field label={`Home score · ${game.homeTeam?.displayName || 'Home'}`}><input inputMode="numeric" pattern="[0-9]*" value={homeScore} onChange={(event) => setHomeScore(event.target.value)} placeholder="0" /></Field>
+              <Field label={`Away score · ${game.awayTeam?.displayName || 'Away'}`}><input inputMode="numeric" pattern="[0-9]*" value={awayScore} onChange={(event) => setAwayScore(event.target.value)} placeholder="0" /></Field>
+            </div>
+          )}
+        </div>
+        <div className="row-actions">
+          <button className="btn primary small" type="button" onClick={saveUpdates} disabled={saving}>{saving ? 'Saving' : 'Save updates'}</button>
+          {(gap.missingTicket || gap.missingStream) && <Link className="btn secondary small" to={linksPath}>Open in Links</Link>}
+          {gap.missingScore && <Link className="btn secondary small" to={gamesPath}>Open Games</Link>}
+        </div>
+        {message && <p className="form-error" role="alert">{message}</p>}
+      </div>
     </article>
   )
 }
 
-function filterAndSortMissingGames(games: Game[], query: string, sort: MissingSort) {
+function buildMissingGaps(missingTickets: Game[], missingStreams: Game[], missingScores: Game[], category: MissingCategory) {
+  const gaps = new Map<string, MissingGap>()
+  const ensureGap = (game: Game) => {
+    const existing = gaps.get(game.id)
+    if (existing) return existing
+
+    const next = { game, missingTicket: false, missingStream: false, missingScore: false }
+    gaps.set(game.id, next)
+    return next
+  }
+
+  missingTickets.forEach((game) => { ensureGap(game).missingTicket = true })
+  missingStreams.forEach((game) => { ensureGap(game).missingStream = true })
+  missingScores.forEach((game) => { ensureGap(game).missingScore = true })
+
+  return Array.from(gaps.values()).filter((gap) => {
+    if (category === 'all') return true
+    if (category === 'links') return gap.missingTicket || gap.missingStream
+    if (category === 'tickets') return gap.missingTicket
+    if (category === 'streams') return gap.missingStream
+    return gap.missingScore
+  })
+}
+
+function filterAndSortMissingGaps(gaps: MissingGap[], query: string, sort: MissingSort) {
   const normalizedQuery = query.trim().toLowerCase()
-  return games
-    .filter((game) => {
-      const searchable = [ gameMatchupLabel(game), formatGuamDateTime(game.startTime), game.venue || '', game.bracketCode || '' ].join(' ').toLowerCase()
+  return gaps
+    .filter((gap) => {
+      const { game } = gap
+      const searchable = [ gameMatchupLabel(game), formatGuamDateTime(game.startTime), game.venue || '', game.bracketCode || '', gapLabel(gap) ].join(' ').toLowerCase()
       return !normalizedQuery || searchable.includes(normalizedQuery)
     })
     .slice()
-    .sort((a, b) => compareMissingGames(a, b, sort))
+    .sort((a, b) => compareMissingGames(a.game, b.game, sort))
+}
+
+function gapLabel(gap: MissingGap) {
+  return [gap.missingTicket ? 'ticket GuamTime' : '', gap.missingStream ? 'stream Clutch' : '', gap.missingScore ? 'score final' : ''].filter(Boolean).join(' ')
 }
 
 function compareMissingGames(a: Game, b: Game, sort: MissingSort) {
   if (sort === 'startDesc') return new Date(b.startTime).getTime() - new Date(a.startTime).getTime()
   if (sort === 'matchup') return gameMatchupLabel(a).localeCompare(gameMatchupLabel(b), undefined, { numeric: true })
   return new Date(a.startTime).getTime() - new Date(b.startTime).getTime()
+}
+
+function scoreDraft(score: number | null) {
+  return score === null ? '' : String(score)
+}
+
+function parseScore(value: string) {
+  const trimmed = value.trim()
+  if (!/^\d+$/.test(trimmed)) return null
+  return Number.parseInt(trimmed, 10)
 }

--- a/web/src/pages/admin/AdminNewsPage.tsx
+++ b/web/src/pages/admin/AdminNewsPage.tsx
@@ -1,18 +1,25 @@
-import { useEffect, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
+import { useEffect, useMemo, useState, type Dispatch, type FormEvent, type SetStateAction } from 'react'
 import { api } from '../../lib/api'
 import { selectedTournament, useTournamentSelection } from '../../lib/admin'
 import { mutationErrorMessage } from '../../lib/errors'
 import { useAsync } from '../../lib/hooks'
-import { toDateInputValue } from '../../lib/datetime'
+import { formatGuamDate, toDateInputValue } from '../../lib/datetime'
 import { gameOptionLabel } from '../../lib/games'
+import { externalHref } from '../../lib/urls'
 import type { Article, Game, Tournament } from '../../lib/types'
-import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Panel } from '../../components/ui'
+import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, PaginationControls, Panel } from '../../components/ui'
 import { ImageUrlUploadField } from '../../components/admin/ImageUrlUploadField'
+import { IconExternal } from '../../components/Icons'
 
+const articlesPageSize = 8
+type ArticleSort = 'publishedDesc' | 'publishedAsc' | 'title' | 'source'
 type ArticleForm = { tournamentId: string; gameId: string; title: string; source: string; url: string; publishedAt: string; imageUrl: string; excerpt: string }
 
 export function AdminNewsPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
+  const [articleQuery, setArticleQuery] = useState('')
+  const [articleSort, setArticleSort] = useState<ArticleSort>('publishedDesc')
+  const [page, setPage] = useState(1)
   const { data, loading, error, reload } = useAsync(async () => {
     const [tournaments, articles, games] = await Promise.all([api.adminTournaments(), api.adminArticles(tournamentId || null), api.adminGames(tournamentId || null)])
     return { tournaments: tournaments.tournaments, articles: articles.articles, games: games.games }
@@ -21,6 +28,13 @@ export function AdminNewsPage() {
   useEffect(() => {
     if (!tournamentId && data?.tournaments[0]?.id) setTournamentId(data.tournaments[0].id)
   }, [data?.tournaments, tournamentId, setTournamentId])
+
+  useEffect(() => {
+    setPage(1)
+  }, [articleQuery, articleSort, tournamentId])
+
+  const visibleArticles = useMemo(() => filterAndSortArticles(data?.articles || [], data?.games || [], articleQuery, articleSort), [data?.articles, data?.games, articleQuery, articleSort])
+  const pagedArticles = useMemo(() => visibleArticles.slice((page - 1) * articlesPageSize, page * articlesPageSize), [visibleArticles, page])
 
   if (loading && !data) return <LoadingState label="Loading articles" />
   if (error) return <ErrorState message={error} onRetry={reload} />
@@ -33,7 +47,18 @@ export function AdminNewsPage() {
       <TournamentFilter tournaments={data?.tournaments || []} value={tournament?.id || ''} onChange={setTournamentId} />
       <CreateArticlePanel tournaments={data?.tournaments || []} games={data?.games || []} selectedTournamentId={tournamentId} onSaved={reload} />
       <Panel>
-        {!data?.articles.length ? <EmptyState title="No articles found" /> : <div className="admin-list">{data.articles.map((article) => <ArticleRow key={article.id} article={article} games={data.games} onSaved={reload} />)}</div>}
+        <div className="section-heading">
+          <div>
+            <h2>Articles</h2>
+            <p className="muted">Preview images, search links, and expand only the article you need to edit.</p>
+          </div>
+          <span>{visibleArticles.length} of {data?.articles.length || 0}</span>
+        </div>
+        <ArticleToolbar query={articleQuery} sort={articleSort} onQueryChange={setArticleQuery} onSortChange={setArticleSort} />
+        {!data?.articles.length ? <EmptyState title="No articles found" /> : null}
+        {data?.articles.length && !visibleArticles.length ? <EmptyState title="No articles match those filters" description="Clear the search to see more coverage links." /> : null}
+        {pagedArticles.length > 0 && <div className="admin-list article-admin-list">{pagedArticles.map((article) => <ArticleRow key={article.id} article={article} games={data?.games || []} onSaved={reload} />)}</div>}
+        <PaginationControls page={page} pageSize={articlesPageSize} total={visibleArticles.length} onPageChange={setPage} />
       </Panel>
     </div>
   )
@@ -80,16 +105,32 @@ function CreateArticlePanel({ tournaments, games, selectedTournamentId, onSaved 
   return <Panel><div className="section-heading"><h2>Add article</h2>{message && <span>{message}</span>}</div><form onSubmit={submit}><ArticleFields form={form} setForm={setForm} tournaments={tournaments} games={games} includeTournament /><button className="btn primary" type="submit" disabled={!form.tournamentId}>Create article</button></form></Panel>
 }
 
+function ArticleToolbar({ query, sort, onQueryChange, onSortChange }: { query: string; sort: ArticleSort; onQueryChange: (value: string) => void; onSortChange: (value: ArticleSort) => void }) {
+  return (
+    <div className="article-toolbar toolbar-panel">
+      <label><span>Search articles</span><input value={query} onChange={(event) => onQueryChange(event.target.value)} placeholder="Title, source, URL, excerpt" /></label>
+      <label><span>Sort</span><select value={sort} onChange={(event) => onSortChange(event.target.value as ArticleSort)}><option value="publishedDesc">Published · newest</option><option value="publishedAsc">Published · oldest</option><option value="title">Title</option><option value="source">Source</option></select></label>
+    </div>
+  )
+}
+
 function ArticleRow({ article, games, onSaved }: { article: Article; games: Game[]; onSaved: () => Promise<void> }) {
-  const [form, setForm] = useState<ArticleForm>({ tournamentId: article.tournamentId, gameId: article.gameId || '', title: article.title, source: article.source, url: article.url, publishedAt: toDateInputValue(article.publishedAt), imageUrl: article.imageUrl || '', excerpt: article.excerpt || '' })
+  const [form, setForm] = useState<ArticleForm>(articleFormState(article))
+  const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
   const [mutationError, setMutationError] = useState('')
+
+  useEffect(() => {
+    if (!editing) setForm(articleFormState(article))
+  }, [article, editing])
+
   const save = async () => {
     setSaving(true)
     setMutationError('')
     try {
       await api.adminUpdateArticle(article.id, { ...form, gameId: form.gameId || null, publishedAt: form.publishedAt || null, imageUrl: form.imageUrl || null, excerpt: form.excerpt || null })
+      setEditing(false)
       await onSaved()
     } catch (err) {
       setMutationError(mutationErrorMessage(err, 'Unable to save article'))
@@ -97,6 +138,7 @@ function ArticleRow({ article, games, onSaved }: { article: Article; games: Game
       setSaving(false)
     }
   }
+
   const remove = async () => {
     if (!confirm('Delete this article link?')) return
     setDeleting(true)
@@ -111,22 +153,103 @@ function ArticleRow({ article, games, onSaved }: { article: Article; games: Game
     }
   }
 
-  return <article className="admin-row-card"><ArticleFields form={form} setForm={setForm} games={games} />{mutationError && <p className="form-error" role="alert">{mutationError}</p>}<div className="row-actions"><button className="btn secondary" onClick={save} disabled={saving || deleting}>{saving ? 'Saving' : 'Save'}</button><button className="btn danger" onClick={remove} disabled={saving || deleting}>{deleting ? 'Deleting' : 'Delete'}</button></div></article>
+  const cancel = () => {
+    setForm(articleFormState(article))
+    setEditing(false)
+    setMutationError('')
+  }
+
+  return (
+    <article className="admin-row-card article-admin-card">
+      {!editing ? (
+        <ArticleSummary article={article} onEdit={() => setEditing(true)} onDelete={remove} deleting={deleting} />
+      ) : (
+        <>
+          <ArticleFields form={form} setForm={setForm} games={games} />
+          <div className="row-actions"><button className="btn secondary" type="button" onClick={cancel} disabled={saving || deleting}>Cancel</button><button className="btn primary" type="button" onClick={save} disabled={saving || deleting}>{saving ? 'Saving' : 'Save article'}</button><button className="btn danger" type="button" onClick={remove} disabled={saving || deleting}>{deleting ? 'Deleting' : 'Delete'}</button></div>
+        </>
+      )}
+      {mutationError && <p className="form-error" role="alert">{mutationError}</p>}
+    </article>
+  )
+}
+
+function ArticleSummary({ article, onEdit, onDelete, deleting }: { article: Article; onEdit: () => void; onDelete: () => void; deleting: boolean }) {
+  return (
+    <div className="article-summary-card">
+      <ArticleImagePreview src={article.imageUrl} title={article.title} compact />
+      <div className="article-summary-main">
+        <span>{article.source}{article.publishedAt ? ` · ${formatGuamDate(article.publishedAt)}` : ' · Date pending'}</span>
+        <h3>{article.title}</h3>
+        <a href={externalHref(article.url) || undefined} target="_blank" rel="noreferrer">Open source <IconExternal size={14} /></a>
+        {article.excerpt && <p>{article.excerpt}</p>}
+        {article.game && <small>{gameOptionLabel(article.game)}</small>}
+      </div>
+      <div className="row-actions article-summary-actions"><button className="btn secondary small" type="button" onClick={onEdit}>Edit</button><button className="btn danger small" type="button" onClick={onDelete} disabled={deleting}>{deleting ? 'Deleting' : 'Delete'}</button></div>
+    </div>
+  )
 }
 
 function ArticleFields({ form, setForm, tournaments, games = [], includeTournament = false }: { form: ArticleForm; setForm: Dispatch<SetStateAction<ArticleForm>>; tournaments?: Tournament[]; games?: Game[]; includeTournament?: boolean }) {
   const availableGames = games.filter((game) => !form.tournamentId || game.tournamentId === form.tournamentId)
 
   return (
-    <FormGrid>
-      {includeTournament && tournaments && <Field label="Tournament"><select value={form.tournamentId} onChange={(event) => setForm({ ...form, tournamentId: event.target.value, gameId: '' })}>{tournaments.map((tournament) => <option key={tournament.id} value={tournament.id}>{tournament.year}</option>)}</select></Field>}
-      <Field label="Related game"><select value={form.gameId} onChange={(event) => setForm({ ...form, gameId: event.target.value })}><option value="">Tournament-level article</option>{availableGames.map((game) => <option key={game.id} value={game.id}>{gameOptionLabel(game)}</option>)}</select></Field>
-      <Field label="Title"><input value={form.title} onChange={(event) => setForm({ ...form, title: event.target.value })} required /></Field>
-      <Field label="Source"><input value={form.source} onChange={(event) => setForm({ ...form, source: event.target.value })} required /></Field>
-      <Field label="URL"><input value={form.url} onChange={(event) => setForm({ ...form, url: event.target.value })} required /></Field>
-      <Field label="Published"><input type="date" value={form.publishedAt} onChange={(event) => setForm({ ...form, publishedAt: event.target.value })} /></Field>
-      <ImageUrlUploadField label="Image URL" value={form.imageUrl} tournamentId={form.tournamentId} purpose="article-image" onChange={(imageUrl) => setForm({ ...form, imageUrl })} help="Upload an article image to S3 or paste a publisher image URL." />
-      <Field label="Excerpt"><input value={form.excerpt} onChange={(event) => setForm({ ...form, excerpt: event.target.value })} /></Field>
-    </FormGrid>
+    <div className="article-fields-layout">
+      <ArticleImagePreview src={form.imageUrl} title={form.title || 'Article image preview'} />
+      <FormGrid>
+        {includeTournament && tournaments && <Field label="Tournament"><select value={form.tournamentId} onChange={(event) => setForm({ ...form, tournamentId: event.target.value, gameId: '' })}>{tournaments.map((tournament) => <option key={tournament.id} value={tournament.id}>{tournament.year}</option>)}</select></Field>}
+        <Field label="Related game"><select value={form.gameId} onChange={(event) => setForm({ ...form, gameId: event.target.value })}><option value="">Tournament-level article</option>{availableGames.map((game) => <option key={game.id} value={game.id}>{gameOptionLabel(game)}</option>)}</select></Field>
+        <Field label="Title"><input value={form.title} onChange={(event) => setForm({ ...form, title: event.target.value })} required /></Field>
+        <Field label="Source"><input value={form.source} onChange={(event) => setForm({ ...form, source: event.target.value })} required /></Field>
+        <Field label="URL"><input value={form.url} onChange={(event) => setForm({ ...form, url: event.target.value })} required /></Field>
+        <Field label="Published"><input type="date" value={form.publishedAt} onChange={(event) => setForm({ ...form, publishedAt: event.target.value })} /></Field>
+        <ImageUrlUploadField label="Image URL" value={form.imageUrl} tournamentId={form.tournamentId} purpose="article-image" onChange={(imageUrl) => setForm({ ...form, imageUrl })} help="Upload an article image to S3 or paste a publisher image URL." />
+        <Field label="Excerpt"><input value={form.excerpt} onChange={(event) => setForm({ ...form, excerpt: event.target.value })} /></Field>
+      </FormGrid>
+    </div>
   )
+}
+
+function ArticleImagePreview({ src, title, compact = false }: { src?: string | null; title: string; compact?: boolean }) {
+  const [failed, setFailed] = useState(false)
+
+  useEffect(() => {
+    setFailed(false)
+  }, [src])
+
+  const href = externalHref(src || '')
+  if (!href || failed) return <div className={compact ? 'article-image-preview compact empty' : 'article-image-preview empty'}><span>{failed ? 'Image unavailable' : 'No image'}</span></div>
+
+  return (
+    <a className={compact ? 'article-image-preview compact' : 'article-image-preview'} href={href} target="_blank" rel="noreferrer" aria-label="Open article image">
+      <img src={href} alt={title ? `${title} preview` : 'Article image preview'} loading="lazy" onError={() => setFailed(true)} />
+    </a>
+  )
+}
+
+function articleFormState(article: Article): ArticleForm {
+  return { tournamentId: article.tournamentId, gameId: article.gameId || '', title: article.title, source: article.source, url: article.url, publishedAt: toDateInputValue(article.publishedAt), imageUrl: article.imageUrl || '', excerpt: article.excerpt || '' }
+}
+
+function filterAndSortArticles(articles: Article[], games: Game[], query: string, sort: ArticleSort) {
+  const normalizedQuery = query.trim().toLowerCase()
+  return articles
+    .filter((article) => {
+      const game = article.game || games.find((item) => item.id === article.gameId)
+      const searchable = [ article.title, article.source, article.url, article.imageUrl || '', article.excerpt || '', game ? gameOptionLabel(game) : '' ].join(' ').toLowerCase()
+      return !normalizedQuery || searchable.includes(normalizedQuery)
+    })
+    .slice()
+    .sort((a, b) => compareArticles(a, b, sort))
+}
+
+function compareArticles(a: Article, b: Article, sort: ArticleSort) {
+  if (sort === 'publishedAsc') return articleDateValue(a) - articleDateValue(b)
+  if (sort === 'title') return a.title.localeCompare(b.title, undefined, { numeric: true })
+  if (sort === 'source') return `${a.source} ${a.title}`.localeCompare(`${b.source} ${b.title}`, undefined, { numeric: true })
+  return articleDateValue(b) - articleDateValue(a)
+}
+
+function articleDateValue(article: Article) {
+  return article.publishedAt ? new Date(article.publishedAt).getTime() : 0
 }

--- a/web/src/pages/public/InfoPage.tsx
+++ b/web/src/pages/public/InfoPage.tsx
@@ -1,0 +1,79 @@
+import type { ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { externalHref } from '../../lib/urls'
+import { PageHeader, Panel } from '../../components/ui'
+import { IconArrowRight, IconCalendar, IconExternal, IconShield, IconTrophy } from '../../components/Icons'
+
+const eligibilityHighlights = [
+  'Players must meet FD alumni or honorary alumni eligibility requirements verified by FD administration.',
+  'Players must be 18 or have a parental release on file.',
+  'Liability and waiver forms are required before a player can play.',
+  'Use full names in the scorebook so local coverage can identify players accurately.',
+]
+
+const gameRuleHighlights = [
+  'Games use two 20-minute halves with a five-minute halftime.',
+  'The first 37 minutes run continuously; the final three minutes of the second half use stop clock rules.',
+  'Teams need five eligible players to start. Grace-period and forfeit rules apply.',
+  'Pool-play ties use a three-point shootout. Playoff ties use a three-minute overtime period.',
+  'The white three-point line is used, and the pool-play 4-point area is in effect for 2026.',
+]
+
+const conductHighlights = [
+  'Complete uniforms are required. Incomplete uniforms may result in a team fee.',
+  'No jewelry is allowed during games.',
+  'Teams are responsible for cleaning their bench area and helping keep the court dry and safe.',
+  'Sportsmanship toward officials, staff, alumni, families, and fans is expected throughout the tournament.',
+]
+
+export function InfoPage() {
+  return (
+    <div className="page-stack info-page">
+      <PageHeader
+        eyebrow="Tournament info"
+        title="Tickets, rules, and game-day basics"
+        description="A fan-friendly summary of the 2026 FD Alumni Basketball Tournament information. GuamTime remains the source of truth for ticket purchase details and current pricing."
+        actions={<Link className="btn secondary" to="/schedule">Open schedule <IconArrowRight /></Link>}
+      />
+
+      <section className="info-hero-grid">
+        <Panel className="info-feature-card ticket-info-card">
+          <span className="info-card-icon"><IconExternal /></span>
+          <h2>Tickets</h2>
+          <p>Most games are expected to use the same GuamTime event link, with championship sessions handled separately if organizers post a different listing.</p>
+          <p>Prices may vary by session or event. Always confirm the active price on GuamTime before purchasing.</p>
+          <a className="btn primary" href={externalHref(import.meta.env.VITE_GUAMTIME_URL || 'https://guamtime.net') || undefined} target="_blank" rel="noreferrer">Open GuamTime <IconExternal /></a>
+        </Panel>
+
+        <Panel className="info-feature-card">
+          <span className="info-card-icon"><IconCalendar /></span>
+          <h2>Schedule</h2>
+          <p>Pool play is loaded from the organizer schedule. Playoff and championship details should be added as matchups are confirmed.</p>
+          <Link className="btn secondary" to="/schedule">View schedule <IconArrowRight /></Link>
+        </Panel>
+      </section>
+
+      <section className="info-section-grid">
+        <InfoListCard icon={<IconShield />} title="Roster and eligibility" items={eligibilityHighlights} />
+        <InfoListCard icon={<IconTrophy />} title="Game format" items={gameRuleHighlights} />
+        <InfoListCard icon={<IconShield />} title="Conduct and operations" items={conductHighlights} />
+      </section>
+
+      <Panel className="notice-panel rules-note-panel">
+        This page is a summarized guide, not the full tournament by-laws. If anything differs from organizer instructions, FDMSAA and tournament staff guidance controls.
+      </Panel>
+    </div>
+  )
+}
+
+function InfoListCard({ icon, title, items }: { icon: ReactNode; title: string; items: string[] }) {
+  return (
+    <Panel className="info-list-card">
+      <span className="info-card-icon">{icon}</span>
+      <h2>{title}</h2>
+      <ul>
+        {items.map((item) => <li key={item}>{item}</li>)}
+      </ul>
+    </Panel>
+  )
+}

--- a/web/src/pages/public/InfoPage.tsx
+++ b/web/src/pages/public/InfoPage.tsx
@@ -56,7 +56,7 @@ export function InfoPage() {
       <section className="info-section-grid">
         <InfoListCard icon={<IconShield />} title="Roster and eligibility" items={eligibilityHighlights} />
         <InfoListCard icon={<IconTrophy />} title="Game format" items={gameRuleHighlights} />
-        <InfoListCard icon={<IconShield />} title="Conduct and operations" items={conductHighlights} />
+        <InfoListCard icon={<IconCalendar />} title="Conduct and operations" items={conductHighlights} />
       </section>
 
       <Panel className="notice-panel rules-note-panel">

--- a/web/src/pages/public/SchedulePage.tsx
+++ b/web/src/pages/public/SchedulePage.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { useMemo, useState } from 'react'
 import { api } from '../../lib/api'
-import { formatGuamDateTime, guamDayLabel, isPastGuamGame } from '../../lib/datetime'
+import { formatGuamDateTime, formatGuamTime, guamDayLabel, isPastGuamGame } from '../../lib/datetime'
 import { useAsync } from '../../lib/hooks'
 import { DEFAULT_GAME_VENUE } from '../../lib/games'
 import { externalHref } from '../../lib/urls'
@@ -20,31 +20,38 @@ export function SchedulePage() {
   if (error) return <ErrorState message={error} onRetry={reload} />
 
   return (
-    <div className="page-stack">
+    <div className="page-stack schedule-page">
       <PageHeader
         eyebrow={data?.tournament ? `${data.tournament.year} tournament` : 'Schedule'}
         title="Tournament schedule"
         description="Game times are shown for Guam. Ticket and stream buttons route to partner platforms when links are available."
+        actions={<Link className="btn secondary" to="/info">Rules and ticket info <IconArrowRight /></Link>}
       />
 
-      <Panel className="watch-hero today-schedule-callout">
+      <Panel className="watch-hero today-schedule-callout compact-callout">
         <div>
           <h2>Today at The Jungle</h2>
-          <p>Mobile-first game-day info, roster notes, live links, and fan predictions.</p>
+          <p>Game-day notes, roster details, live links, and fan predictions.</p>
         </div>
         <Link className="btn primary" to="/today">Open Today <IconArrowRight /></Link>
       </Panel>
 
-      <Panel className="toolbar-panel">
+      <Panel className="toolbar-panel schedule-filter-panel">
         <label><span>Division</span><select value={division} onChange={(event) => setDivision(event.target.value)}><option value="">All divisions</option>{data?.divisions.map((item) => <option key={item} value={item}>{item}</option>)}</select></label>
         <label><span>Phase</span><select value={phase} onChange={(event) => setPhase(event.target.value)}><option value="">All phases</option>{data?.phases.map((item) => <option key={item} value={item}>{labelPhase(item)}</option>)}</select></label>
       </Panel>
+
+      {grouped.length > 1 && (
+        <nav className="schedule-day-jump" aria-label="Schedule day shortcuts">
+          {grouped.map(([day, games]) => <a key={day} href={`#${dayAnchorId(day)}`}><strong>{shortDayLabel(day)}</strong><span>{games.length}</span></a>)}
+        </nav>
+      )}
 
       {grouped.length === 0 ? (
         <EmptyState title="No games match this view" description="Clear filters or check back once organizers load the next schedule." />
       ) : (
         grouped.map(([day, games]) => (
-          <section className="day-section" key={day}>
+          <section className="day-section" key={day} id={dayAnchorId(day)}>
             <h2>{day}</h2>
             <div className="game-card-grid">
               {games.map((game) => <GameCard key={game.id} game={game} />)}
@@ -63,7 +70,7 @@ function GameCard({ game }: { game: Game }) {
   return (
     <article className="game-card">
       <div className="game-card-top">
-        <span>{formatGuamDateTime(game.startTime)}</span>
+        <span className="game-time-mobile">{formatGuamTime(game.startTime)}</span><span className="game-time-full">{formatGuamDateTime(game.startTime)}</span>
         <StatusBadge status={resultPending ? 'result-pending' : game.status} />
       </div>
       <div className="matchup">
@@ -94,6 +101,14 @@ function groupGamesByDay(games: Game[]) {
     groups.set(key, [...(groups.get(key) || []), game])
   })
   return Array.from(groups.entries())
+}
+
+function dayAnchorId(day: string) {
+  return `schedule-${day.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`
+}
+
+function shortDayLabel(day: string) {
+  return day.replace(/^[^,]+,\s*/, '')
 }
 
 function labelPhase(phase: string) {

--- a/web/src/pages/public/StandingsPage.tsx
+++ b/web/src/pages/public/StandingsPage.tsx
@@ -31,7 +31,19 @@ export function StandingsPage() {
       {!data?.standings.length ? (
         <EmptyState title="No standings yet" description="Standings appear after games have final scores and the recompute job has run." />
       ) : (
-        <Panel>
+        <Panel className="standings-panel">
+          <div className="standings-mobile-list" aria-label="Mobile standings list">
+            {data.standings.map((standing, index) => (
+              <article className="standing-mobile-card" key={standing.id}>
+                <div><span>#{index + 1}</span><strong>{standing.team.displayName}</strong><small>{standing.team.division || 'Division pending'}</small></div>
+                <dl>
+                  <div><dt>W</dt><dd>{standing.wins}</dd></div>
+                  <div><dt>L</dt><dd>{standing.losses}</dd></div>
+                  <div><dt>Diff</dt><dd>{standing.pointDifferential > 0 ? `+${standing.pointDifferential}` : standing.pointDifferential}</dd></div>
+                </dl>
+              </article>
+            ))}
+          </div>
           <div className="table-wrap">
             <table className="data-table standings-table">
               <thead><tr><th>Rank</th><th>Team</th><th>Division</th><th>W</th><th>L</th><th>PF</th><th>PA</th><th>Diff</th></tr></thead>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -152,6 +152,8 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .form-error { margin: -.25rem 0 .2rem; color: var(--danger); font-weight: 800; }
 .form-note { margin: -.25rem 0 .2rem; color: var(--success); font-weight: 900; }
 .field-help { color: var(--muted); font-size: .76rem; font-weight: 700; line-height: 1.35; }
+.pagination-controls { display: flex; justify-content: space-between; gap: .85rem; align-items: center; margin-top: 1rem; padding-top: 1rem; border-top: 1px solid var(--line); }
+.pagination-controls > span { color: var(--muted); font-weight: 900; }
 .tipoff-field { min-width: min(100%, 16rem); }
 .time-shortcuts { display: flex; flex-wrap: wrap; gap: .4rem; }
 .time-chip { min-height: 2rem; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--fd-maroon); padding: .38rem .58rem; font-size: .78rem; font-weight: 900; cursor: pointer; transition: background .16s ease, border-color .16s ease, transform .16s ease; }
@@ -378,6 +380,28 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .bulk-ticket-actions .row-actions { justify-content: flex-end; }
 .bulk-roster-modal { width: min(54rem, 100%); }
 .bulk-roster-preview { max-height: 18rem; }
+.link-toolbar, .missing-toolbar, .article-toolbar { margin-bottom: 1rem; padding: .8rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface-strong); }
+.link-toolbar label:first-child, .missing-toolbar label:first-child, .article-toolbar label:first-child { flex: 1 1 18rem; }
+.link-admin-list, .article-admin-list { margin-top: 1rem; }
+.focused-filter-note { display: flex; justify-content: space-between; gap: .75rem; align-items: center; margin-bottom: .8rem; padding: .75rem .85rem; border: 1px solid rgba(111,29,53,.18); border-radius: .95rem; background: var(--fd-maroon-50); color: var(--fd-maroon); font-weight: 900; }
+.missing-gap-list { margin-top: .5rem; }
+.missing-gap-row { grid-template-columns: minmax(0, .8fr) minmax(18rem, 1.2fr); align-items: center; }
+.missing-gap-main { display: grid; gap: .2rem; }
+.missing-gap-actions { display: grid; gap: .55rem; }
+.missing-gap-actions .field { min-width: 0; }
+.article-fields-layout { display: grid; grid-template-columns: 11rem minmax(0, 1fr); gap: 1rem; align-items: start; }
+.article-fields-layout .form-grid { margin-bottom: 1rem; }
+.article-image-preview { overflow: hidden; display: grid; place-items: center; width: 100%; aspect-ratio: 4 / 3; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface-strong); color: var(--muted); font-weight: 900; text-align: center; }
+.article-image-preview img { width: 100%; height: 100%; object-fit: cover; }
+.article-image-preview.compact { width: 8.5rem; min-height: 6.25rem; aspect-ratio: 4 / 3; flex: 0 0 auto; }
+.article-summary-card { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: 1rem; align-items: start; }
+.article-summary-main { min-width: 0; display: grid; gap: .35rem; }
+.article-summary-main span { color: var(--fd-maroon); font-size: .75rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.article-summary-main h3 { margin: 0; font-size: 1.15rem; letter-spacing: -.035em; }
+.article-summary-main p { margin: 0; color: var(--muted); line-height: 1.4; }
+.article-summary-main small { color: var(--muted); font-weight: 750; }
+.article-summary-main a { color: var(--fd-maroon); font-weight: 900; display: inline-flex; align-items: center; gap: .35rem; width: fit-content; }
+.article-summary-actions { justify-content: flex-end; }
 .game-day-toolbar-panel { align-items: end; }
 .game-day-date-jump { flex: 1 1 100%; display: flex; gap: .45rem; overflow-x: auto; padding-top: .2rem; }
 .game-day-date-jump button { flex: 0 0 auto; min-height: 2.25rem; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--fd-maroon); padding: .45rem .7rem; font-weight: 900; cursor: pointer; }
@@ -509,6 +533,10 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .schedule-page .link-muted { display: grid; place-items: center; min-height: 2rem; border: 1px dashed var(--line); border-radius: 999px; font-size: .76rem; text-align: center; }
   .standings-panel .table-wrap { display: none; }
   .standings-mobile-list { display: grid; gap: .65rem; }
+  .focused-filter-note, .article-summary-card { grid-template-columns: 1fr; display: grid; }
+  .article-fields-layout, .missing-gap-row { grid-template-columns: 1fr; }
+  .article-image-preview.compact { width: 100%; }
+  .article-summary-actions { justify-content: flex-start; }
   .bulk-ticket-actions .row-actions { justify-content: flex-start; }
   .site-footer { display: grid; }
   .footer-links { flex-wrap: wrap; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -54,7 +54,7 @@ h1, h2, h3, .brand strong, .btn, .stat-card strong { font-family: "Sora", "Sourc
 .site-footer .site-credit { color: rgba(255,255,255,.58); font-size: .9rem; }
 .site-credit a { color: var(--fd-gold-100); font-weight: 900; }
 .site-credit a:hover { color: #fff; }
-.footer-links { display: flex; gap: 1rem; align-items: center; font-weight: 800; color: var(--fd-gold-100); }
+.footer-links { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 1rem; align-items: center; font-weight: 800; color: var(--fd-gold-100); }
 
 .page-stack { display: grid; gap: 1.1rem; }
 .page-header { display: flex; gap: 1rem; justify-content: space-between; align-items: end; margin-bottom: .25rem; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -184,6 +184,16 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .data-table th { text-align: left; color: var(--muted); font-size: .76rem; text-transform: uppercase; letter-spacing: .09em; }
 .data-table th, .data-table td { padding: .85rem; border-bottom: 1px solid var(--line); }
 .data-table td small { display: block; color: var(--muted); margin-top: .15rem; }
+.standings-mobile-list { display: none; }
+.standing-mobile-card { display: grid; gap: .75rem; padding: .85rem; border: 1px solid var(--line); border-radius: 1rem; background: #fff; }
+.standing-mobile-card > div { display: grid; gap: .1rem; }
+.standing-mobile-card span { color: var(--fd-maroon); font-size: .78rem; font-weight: 950; letter-spacing: .1em; text-transform: uppercase; }
+.standing-mobile-card strong { font-size: 1.15rem; letter-spacing: -.035em; }
+.standing-mobile-card small { color: var(--muted); font-weight: 750; }
+.standing-mobile-card dl { display: grid; grid-template-columns: repeat(3, 1fr); gap: .5rem; margin: 0; }
+.standing-mobile-card dl div { padding: .6rem; border-radius: .8rem; background: var(--surface-strong); }
+.standing-mobile-card dt { color: var(--muted); font-size: .7rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
+.standing-mobile-card dd { margin: .15rem 0 0; color: var(--ink); font-weight: 950; }
 
 .article-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; }
 .article-card { overflow: hidden; background: #fff; border: 1px solid var(--line); border-radius: 1.35rem; box-shadow: 0 14px 36px rgba(66,16,31,.07); }
@@ -245,6 +255,22 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .watch-hero h2 { margin: 0; }
 .watch-hero p { margin: .25rem 0 0; color: var(--muted); }
 .today-schedule-callout { grid-template-columns: minmax(0, 1fr) auto; }
+.compact-callout { padding-block: .95rem; }
+.schedule-filter-panel { align-items: end; }
+.schedule-day-jump { display: flex; gap: .5rem; overflow-x: auto; padding: .15rem .05rem .45rem; scroll-padding-inline: .5rem; }
+.schedule-day-jump a { flex: 0 0 auto; display: inline-flex; align-items: center; gap: .45rem; min-height: 2.45rem; padding: .55rem .75rem; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--fd-maroon); font-weight: 900; box-shadow: 0 10px 24px rgba(66,16,31,.05); }
+.schedule-day-jump span { display: grid; place-items: center; min-width: 1.45rem; height: 1.45rem; border-radius: 999px; background: var(--fd-maroon-50); font-size: .74rem; }
+.game-time-mobile { display: none; }
+.info-hero-grid { display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(18rem, .85fr); gap: .9rem; }
+.info-section-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .9rem; }
+.info-feature-card, .info-list-card { display: grid; align-content: start; gap: .75rem; }
+.info-feature-card h2, .info-list-card h2 { margin: 0; letter-spacing: -.045em; }
+.info-feature-card p { margin: 0; color: var(--muted); line-height: 1.55; }
+.ticket-info-card { background: linear-gradient(135deg, #fff, var(--fd-gold-100)); }
+.info-card-icon { display: grid; place-items: center; width: 2.6rem; height: 2.6rem; border-radius: .9rem; background: var(--fd-maroon-50); color: var(--fd-maroon); }
+.info-list-card ul { display: grid; gap: .55rem; margin: 0; padding-left: 1.1rem; color: var(--muted); line-height: 1.45; }
+.info-list-card li::marker { color: var(--fd-maroon); }
+.rules-note-panel { line-height: 1.45; }
 .today-brief-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: .8rem; }
 .today-brief-card { display: grid; gap: .35rem; }
 .today-brief-card--wide { grid-column: 1 / -1; }
@@ -343,6 +369,16 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .team-card-list, .game-admin-list { margin-top: 1rem; }
 .team-toolbar, .game-toolbar { margin-bottom: 1rem; padding: .8rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface-strong); }
 .team-toolbar label:first-child, .game-toolbar label:first-child { flex: 1 1 18rem; }
+.admin-create-panel .collapsible-heading { margin-bottom: 0; }
+.bulk-link-panel { background: linear-gradient(135deg, #fff, #fff8ea); }
+.bulk-ticket-actions { display: grid; grid-template-columns: minmax(16rem, 1fr) auto; gap: .8rem; align-items: end; }
+.bulk-ticket-actions .row-actions { justify-content: flex-end; }
+.bulk-roster-modal { width: min(54rem, 100%); }
+.bulk-roster-preview { max-height: 18rem; }
+.game-day-toolbar-panel { align-items: end; }
+.game-day-date-jump { flex: 1 1 100%; display: flex; gap: .45rem; overflow-x: auto; padding-top: .2rem; }
+.game-day-date-jump button { flex: 0 0 auto; min-height: 2.25rem; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--fd-maroon); padding: .45rem .7rem; font-weight: 900; cursor: pointer; }
+.game-day-date-jump button.selected { background: var(--fd-maroon); color: #fff; border-color: var(--fd-maroon); }
 .compact-admin-list { margin-top: 1rem; }
 .admin-row-card { padding: 1rem; border: 1px solid var(--line); border-radius: 1.15rem; background: #fff; display: grid; gap: .85rem; }
 .team-summary-card { position: relative; overflow: hidden; border-color: rgba(111,29,53,.16); box-shadow: 0 16px 38px rgba(66,16,31,.07); }
@@ -412,7 +448,8 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-mobile-close { position: absolute; top: .9rem; right: .85rem; z-index: 2; display: grid; place-items: center; width: 2.35rem; height: 2.35rem; border: 1px solid rgba(255,255,255,.14); border-radius: .85rem; color: rgba(255,255,255,.8); background: rgba(255,255,255,.08); }
   .admin-content, .admin-content.sidebar-collapsed { margin-left: 0; padding: 1rem clamp(.85rem, 3vw, 1.25rem) 2.5rem; }
   .admin-topbar { display: none; }
-  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .archive-card-grid, .archive-media-strip, .today-brief-grid, .prediction-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .archive-card-grid, .archive-media-strip, .today-brief-grid, .prediction-grid, .info-section-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .info-hero-grid { grid-template-columns: 1fr; }
   .form-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .game-detail-summary, .team-facts-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   .compact-admin-row { grid-template-columns: 1fr; }
@@ -440,11 +477,36 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .section-heading { align-items: flex-start; flex-wrap: wrap; }
   .section-actions { width: 100%; justify-content: flex-start; }
   .panel, .state-card, .stat-card { border-radius: 1.1rem; }
-  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .form-grid, .health-grid, .archive-card-grid, .archive-media-strip, .archive-hero, .home-today-note-grid, .today-brief-grid, .today-game-card, .prediction-grid, .roster-columns, .prediction-admin-row { grid-template-columns: 1fr; }
+  .stats-grid, .stats-grid.three, .stats-grid.four, .game-card-grid, .article-grid, .sponsor-grid, .partner-strip, .workflow-steps, .form-grid, .health-grid, .archive-card-grid, .archive-media-strip, .archive-hero, .home-today-note-grid, .today-brief-grid, .today-game-card, .prediction-grid, .roster-columns, .prediction-admin-row, .info-section-grid, .bulk-ticket-actions { grid-template-columns: 1fr; }
   .archive-hero img { justify-self: start; }
   .timeline-link-row { grid-template-columns: 1fr auto; }
   .timeline-link-row .timeline-year { grid-column: 1 / -1; }
   .archive-game-row { align-items: flex-start; flex-direction: column; }
+  .schedule-page .page-header { gap: .65rem; padding: .95rem; }
+  .schedule-page .page-header h1 { font-size: clamp(2rem, 9vw, 2.45rem); line-height: 1; }
+  .schedule-page .page-header p { margin: .45rem 0 0; font-size: .95rem; line-height: 1.42; }
+  .schedule-page .page-actions .btn { width: 100%; }
+  .schedule-page .compact-callout { grid-template-columns: 1fr; padding: .85rem; gap: .75rem; }
+  .schedule-page .compact-callout h2 { font-size: 1.2rem; }
+  .schedule-page .compact-callout p { font-size: .94rem; line-height: 1.4; }
+  .schedule-filter-panel { display: grid; grid-template-columns: 1fr 1fr; gap: .65rem; padding: .85rem; }
+  .schedule-filter-panel label { min-width: 0; }
+  .schedule-day-jump { position: sticky; top: 4.1rem; z-index: 12; margin-inline: -.75rem; padding: .45rem .75rem; background: rgba(246,239,232,.94); backdrop-filter: blur(12px); border-block: 1px solid rgba(232,220,213,.72); }
+  .schedule-day-jump a { min-height: 2.25rem; padding: .45rem .65rem; font-size: .9rem; }
+  .day-section { scroll-margin-top: 7.5rem; }
+  .day-section h2 { margin: .65rem 0 .6rem; font-size: 1.55rem; }
+  .schedule-page .game-card { gap: .65rem; padding: .82rem; border-radius: 1rem; }
+  .schedule-page .game-card-top { align-items: center; }
+  .game-time-mobile { display: inline; }
+  .game-time-full { display: none; }
+  .schedule-page .team-line { padding: .55rem .6rem; }
+  .schedule-page .game-meta { gap: .35rem; font-size: .78rem; }
+  .schedule-page .game-actions { display: grid; grid-template-columns: 1fr 1fr; align-items: stretch; }
+  .schedule-page .game-actions .btn { width: 100%; }
+  .schedule-page .link-muted { display: grid; place-items: center; min-height: 2rem; border: 1px dashed var(--line); border-radius: 999px; font-size: .76rem; text-align: center; }
+  .standings-panel .table-wrap { display: none; }
+  .standings-mobile-list { display: grid; gap: .65rem; }
+  .bulk-ticket-actions .row-actions { justify-content: flex-start; }
   .site-footer { display: grid; }
   .footer-links { flex-wrap: wrap; }
   .timeline-row { grid-template-columns: 1fr; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -51,6 +51,9 @@ h1, h2, h3, .brand strong, .btn, .stat-card strong { font-family: "Sora", "Sourc
 .site-main { position: relative; z-index: 1; flex: 1; width: min(1160px, calc(100% - 2.5rem)); margin: 0 auto; padding: clamp(1.3rem, 3.4vw, 2.75rem) 0 clamp(2rem, 5vw, 4rem); color: var(--ink); }
 .site-footer { position: relative; z-index: 1; display: flex; justify-content: space-between; gap: 1rem; padding: 2rem clamp(1rem, 4vw, 3rem); background: var(--fd-maroon-900); border-top: 1px solid rgba(255,255,255,.12); color: #fff; }
 .site-footer p { color: rgba(255,255,255,.72); margin: .35rem 0 0; max-width: 46rem; }
+.site-footer .site-credit { color: rgba(255,255,255,.58); font-size: .9rem; }
+.site-credit a { color: var(--fd-gold-100); font-weight: 900; }
+.site-credit a:hover { color: #fff; }
 .footer-links { display: flex; gap: 1rem; align-items: center; font-weight: 800; color: var(--fd-gold-100); }
 
 .page-stack { display: grid; gap: 1.1rem; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -384,6 +384,8 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .link-toolbar label:first-child, .missing-toolbar label:first-child, .article-toolbar label:first-child { flex: 1 1 18rem; }
 .link-admin-list, .article-admin-list { margin-top: 1rem; }
 .focused-filter-note { display: flex; justify-content: space-between; gap: .75rem; align-items: center; margin-bottom: .8rem; padding: .75rem .85rem; border: 1px solid rgba(111,29,53,.18); border-radius: .95rem; background: var(--fd-maroon-50); color: var(--fd-maroon); font-weight: 900; }
+.draft-filter-note { background: #fff8ea; border-color: rgba(210,163,57,.42); color: #5d4210; }
+.draft-badge { width: fit-content; padding: .3rem .55rem; border-radius: 999px; background: #fff8ea; color: #5d4210; font-size: .7rem; font-weight: 950; letter-spacing: .07em; text-transform: uppercase; }
 .missing-gap-list { margin-top: .5rem; }
 .missing-gap-row { grid-template-columns: minmax(0, .7fr) minmax(20rem, 1.3fr); align-items: start; }
 .missing-gap-main { display: grid; gap: .2rem; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -385,10 +385,15 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .link-admin-list, .article-admin-list { margin-top: 1rem; }
 .focused-filter-note { display: flex; justify-content: space-between; gap: .75rem; align-items: center; margin-bottom: .8rem; padding: .75rem .85rem; border: 1px solid rgba(111,29,53,.18); border-radius: .95rem; background: var(--fd-maroon-50); color: var(--fd-maroon); font-weight: 900; }
 .missing-gap-list { margin-top: .5rem; }
-.missing-gap-row { grid-template-columns: minmax(0, .8fr) minmax(18rem, 1.2fr); align-items: center; }
+.missing-gap-row { grid-template-columns: minmax(0, .7fr) minmax(20rem, 1.3fr); align-items: start; }
 .missing-gap-main { display: grid; gap: .2rem; }
 .missing-gap-actions { display: grid; gap: .55rem; }
 .missing-gap-actions .field { min-width: 0; }
+.gap-chip-row { display: flex; flex-wrap: wrap; gap: .35rem; margin-top: .35rem; }
+.gap-chip-row span { padding: .28rem .5rem; border-radius: 999px; background: var(--fd-maroon-50); color: var(--fd-maroon); font-size: .68rem; font-weight: 950; letter-spacing: .07em; text-transform: uppercase; }
+.gap-field-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr)); gap: .65rem; }
+.score-gap-fields { display: grid; grid-template-columns: repeat(2, minmax(7rem, 1fr)); gap: .65rem; }
+.consolidated-gap-row { background: linear-gradient(135deg, #fff, #fffdf8); }
 .article-fields-layout { display: grid; grid-template-columns: 11rem minmax(0, 1fr); gap: 1rem; align-items: start; }
 .article-fields-layout .form-grid { margin-bottom: 1rem; }
 .article-image-preview { overflow: hidden; display: grid; place-items: center; width: 100%; aspect-ratio: 4 / 3; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface-strong); color: var(--muted); font-weight: 900; text-align: center; }
@@ -534,7 +539,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .standings-panel .table-wrap { display: none; }
   .standings-mobile-list { display: grid; gap: .65rem; }
   .focused-filter-note, .article-summary-card { grid-template-columns: 1fr; display: grid; }
-  .article-fields-layout, .missing-gap-row { grid-template-columns: 1fr; }
+  .article-fields-layout, .missing-gap-row, .score-gap-fields { grid-template-columns: 1fr; }
   .article-image-preview.compact { width: 100%; }
   .article-summary-actions { justify-content: flex-start; }
   .bulk-ticket-actions .row-actions { justify-content: flex-start; }


### PR DESCRIPTION
## Summary
- collapse low-frequency Add Team/Add Game admin forms by default while keeping them available for late changes
- add bulk roster paste/preview/save workflow so admins can add whole team rosters without repeated modal cycles
- add common GuamTime ticket-link fill on the Links page, with missing-only and replace-all modes for championship/session overrides later
- add a public Tournament Info page with curated by-laws/rules highlights and ticket guidance without publishing raw by-laws/contact details
- tighten mobile schedule UX with compact callout, day-jump chips, mobile time display, and compact pending-link buttons
- add mobile standings cards while keeping the desktop table
- improve Game Day admin by defaulting toward scheduled game days and adding game-day shortcut chips
- document launch-polish decisions, by-laws review, and future operator-reviewed OCR schedule import direction

## Notes
- The by-laws PDF did not include public spectator ticket prices. Public copy intentionally points users to GuamTime as the source of truth for current pricing.
- Raw by-laws contents are not published because the source includes personal contact info and internal language; the new `/info` page uses cleaned-up public highlights.
- OCR is documented as a future workflow only. This PR does not implement OCR.

## Verification
- [x] `npm run web:build`
- [x] `./scripts/gate.sh`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers a broad UX and admin-experience polish pass ahead of the 2026 launch, covering seven distinct improvement areas across the admin panel and public-facing pages.

- **Bulk roster workflow** adds a new `POST /admin/roster-entries/bulk` endpoint (with a full server-side transaction) and a frontend paste-preview-save modal, replacing per-player modal cycles with a single atomic import.
- **Admin form collapse** makes Add Team and Add Game panels collapse by default (opening automatically when the list is empty), reducing visual noise for admins who already have data loaded.
- **Links page** gains a common-ticket-URL bulk fill panel, inline filter/sort/pagination, and a consolidated "Missing links and scores" view that groups all gaps per game with inline save fields.
- **Public pages** get a new `/info` Tournament Info page with curated rules highlights, mobile standings cards alongside the existing desktop table, compact mobile schedule UX with sticky day-jump chips, and responsive game-card improvements.

<h3>Confidence Score: 5/5</h3>

Safe to merge. All new backend endpoints are transactional and well-tested; frontend changes are UI-only with no data integrity risk.

The bulk roster API uses a proper server-side transaction — validate-all-then-save-all — with a companion integration test that confirms atomicity on mixed valid/invalid input. The frontend bulk modal calls a single API endpoint rather than a sequential loop, so partial-commit risk is eliminated. The Links, Missing Links, and News admin pages add purely presentational filter/sort/pagination layers with no persistent state outside of what is explicitly saved. The two observations flagged are edge-case UX quirks that do not affect data correctness and are unlikely to surface in normal Guam-admin use.

No files require special attention before merging.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/app/controllers/api/v1/admin/roster_entries_controller.rb | Adds a well-structured `bulk` action with a server-side transaction: validates all entries before saving any, rolls back on any failure, and returns structured per-index errors. Strong test coverage added in the companion test file. |
| web/src/pages/admin/AdminDivisionsPage.tsx | Adds BulkRosterModal (paste → preview → single atomic API call) and makes CreateTeamPanel collapsible. parseRosterLine correctly falls back to empty jerseyNumber for non-numeric fields rather than assigning them as jersey numbers. |
| web/src/pages/admin/AdminLinksPage.tsx | Significantly expanded with common-ticket bulk fill, filter/sort/pagination, and draft-change tracking. The draft-bypass filter logic keeps games with unsaved edits visible regardless of active filter, which is intentional but can cause the "Missing tickets" filter to appear non-empty after a bulk fill. |
| web/src/pages/admin/AdminMissingLinksPage.tsx | Replaces three separate missing-category panels with a unified per-game gap row showing all missing fields with inline save inputs. Score and link saves use Promise.all for concurrent requests with proper error reporting. |
| web/src/pages/admin/AdminGameDayPage.tsx | Splits the single useAsync into a setup call (tournaments + all games) and a separate gameDayState call, then derives game-day shortcut chips from unique dates in the schedule. The interval refresh is correctly scoped to gameDayState only. |
| web/src/pages/admin/AdminNewsPage.tsx | Adds article list pagination, filter/sort, collapsible article rows with a summary card view, and an image preview component. Form state is properly reset on cancel and after save. |
| web/src/pages/public/InfoPage.tsx | New public page with curated tournament rules highlights and a GuamTime ticket CTA. Static content only; no API calls. Correctly omits raw by-laws and personal contact details. |
| web/src/pages/public/SchedulePage.tsx | Adds sticky day-jump chips (anchor-link based), mobile-only time display, and compact callout styling. dayAnchorId correctly sanitizes day labels into safe HTML IDs. |
| web/src/components/ui.tsx | Adds PaginationControls with proper page clamping, disabled states, and navigation ARIA label. Returns null when all items fit on one page. |
| api/test/controllers/admin_game_day_controller_test.rb | New test verifies bulk roster creation succeeds atomically for valid entries and rolls back completely when any entry is invalid, covering the key correctness guarantee of the transaction. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Admin as Admin Browser
    participant FE as Frontend
    participant API as Rails API

    Note over Admin,API: Bulk Roster Flow
    Admin->>FE: Paste roster text
    FE->>FE: parseBulkRoster() preview
    Admin->>FE: Click "Add N players"
    FE->>API: POST /roster-entries/bulk
    API->>API: RosterEntry.transaction validate all
    alt Any validation error
        API-->>FE: 422 errors per index
        FE->>Admin: Show error, no entries saved
    else All valid
        API->>API: Save all entries
        API-->>FE: 201 created N
        FE->>Admin: Added N players message
    end

    Note over Admin,API: Common Ticket Link Flow
    Admin->>FE: Paste GuamTime URL
    Admin->>FE: Fill missing only / Apply to all
    FE->>FE: applyCommonTicketUrl() update drafts
    Admin->>FE: Click Save changes
    FE->>API: PATCH /links bulk
    API-->>FE: Updated game links
    FE->>Admin: Refresh game list
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Admin as Admin Browser
    participant FE as Frontend
    participant API as Rails API

    Note over Admin,API: Bulk Roster Flow
    Admin->>FE: Paste roster text
    FE->>FE: parseBulkRoster() preview
    Admin->>FE: Click "Add N players"
    FE->>API: POST /roster-entries/bulk
    API->>API: RosterEntry.transaction validate all
    alt Any validation error
        API-->>FE: 422 errors per index
        FE->>Admin: Show error, no entries saved
    else All valid
        API->>API: Save all entries
        API-->>FE: 201 created N
        FE->>Admin: Added N players message
    end

    Note over Admin,API: Common Ticket Link Flow
    Admin->>FE: Paste GuamTime URL
    Admin->>FE: Fill missing only / Apply to all
    FE->>FE: applyCommonTicketUrl() update drafts
    Admin->>FE: Click Save changes
    FE->>API: PATCH /links bulk
    API-->>FE: Updated game links
    FE->>Admin: Refresh game list
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `web/src/pages/admin/AdminDivisionsPage.tsx`, line 298-316 ([link](https://github.com/shimizu-technology/fd-alumni-hub/blob/273c5f173bbc3364fc3d1db2ebed6e3a7f0b7783/web/src/pages/admin/AdminDivisionsPage.tsx#L298-L316)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Bulk save partial failure leaves orphaned players and no recovery path**

   The loop calls `adminCreateRosterEntry` sequentially with no tracking of which requests succeeded. If the API returns an error on, say, the 5th of 12 players, 4 entries are already committed to the database but `setSaving(false)` runs and the modal stays open showing the full 12-player preview. A retry attempt submits all 12 players again, creating duplicates for the first 4 with no warning to the admin.

   At minimum, track the index of the first failure and report "Added N of M players" in the error message, or clear the drafts that were already successfully sent so a retry is safe.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: web/src/pages/admin/AdminDivisionsPage.tsx
   Line: 298-316

   Comment:
   **Bulk save partial failure leaves orphaned players and no recovery path**

   The loop calls `adminCreateRosterEntry` sequentially with no tracking of which requests succeeded. If the API returns an error on, say, the 5th of 12 players, 4 entries are already committed to the database but `setSaving(false)` runs and the modal stays open showing the full 12-player preview. A retry attempt submits all 12 players again, creating duplicates for the first 4 with no warning to the admin.

   At minimum, track the index of the first failure and report "Added N of M players" in the error message, or clear the drafts that were already successfully sent so a retry is safe.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (11): Last reviewed commit: ["Clarify unsaved link draft copy"](https://github.com/shimizu-technology/fd-alumni-hub/commit/1265d9b6f1b8f8f695031a4ba628daf76b4e60a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40263801)</sub>

<!-- /greptile_comment -->