### PR TITLE
Fix Render production boot database connections

### DIFF
--- a/api/config/database.yml
+++ b/api/config/database.yml
@@ -14,5 +14,19 @@ test:
   url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
-  <<: *default
-  url: <%= ENV["DATABASE_URL"] %>
+  primary: &primary_production
+    <<: *default
+    url: <%= ENV["DATABASE_URL"] %>
+  # Rails 8 loads the Solid Cache/Queue/Cable models in production when these
+  # gems are bundled, even though this API currently uses memory cache, async
+  # jobs, and async cable. Point those named connections at the primary DB so
+  # boot can resolve them, but keep database tasks on the primary config only.
+  cache:
+    <<: *primary_production
+    database_tasks: false
+  queue:
+    <<: *primary_production
+    database_tasks: false
+  cable:
+    <<: *primary_production
+    database_tasks: false


### PR DESCRIPTION
## Summary\n- configure Rails production named database connections for Solid Cache/Queue/Cable models\n- keep database tasks on the primary Rails database only\n\n## Validation\n- production boot smoke: RAILS_ENV=production rails server starts locally with DATABASE_URL/SECRET_KEY_BASE\n- cd api && bin/rubocop --no-color\n- cd api && bin/rails test\n\n## Deploy note\nThis fixes Render boot failure: `The cache database is not configured for the production environment`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Render production boot failure caused by Rails 8 registering `SolidCache`, `SolidQueue`, and `SolidCable` models that require named database connections (`cache`, `queue`, `cable`) in `database.yml` even when those adapters are not actively used. The production config is restructured from a flat single-database entry to a multi-database block where all three Solid connection names alias back to the primary PostgreSQL database via a YAML anchor.

- **Named connections added**: `cache`, `queue`, and `cable` all inherit from the `&primary_production` anchor (which itself inherits from `&default`), so they point at the same PostgreSQL instance as `primary`.
- **`database_tasks: false`** is correctly set on every alias connection, preventing Rails from treating them as separate databases during `db:migrate` / `db:schema:load` operations.
- The `development` and `test` flat-config entries are unchanged, which is appropriate because `eager_load` is off in development and the Solid adapters are not configured as active backends in either environment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a targeted, well-understood Rails 8 multi-database stub that resolves the production boot failure without altering any active data path.

The YAML anchor chain is correct: &default → &primary_production → each alias. database_tasks: false is set only on the alias connections, so migrations continue to run normally against the primary. Since memory_store, async queue, and async cable are still the active adapters, the three stub connections are never actually opened at runtime, carrying no connection-pool cost. The development and test configs are deliberately left as flat single-database entries because eager loading is off in those environments and the Solid adapters are unused there too.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| api/config/database.yml | Production section restructured to multi-database named connections; all Solid gem aliases correctly point to the primary DB with database_tasks: false. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Rails 8 boot (production)"] --> B["Eager-loads Solid models\nSolidCache::Record\nSolidQueue::Job\nSolidCable::Message"]
    B --> C{"Named DB connection\nin database.yml?"}
    C -- "Before PR: missing" --> D["💥 Boot failure\n'cache DB not configured'"]
    C -- "After PR: present" --> E["Resolve cache / queue / cable\n→ &primary_production anchor\n(same DATABASE_URL)"]
    E --> F["database_tasks: false\nSkips migrations/schema\non alias connections"]
    E --> G["primary connection\ndatabase_tasks: true\nRuns db:migrate normally"]
    F --> H["✅ Server boots\nSolid adapters NOT used\n(memory_store / async)"]
    G --> H
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Rails 8 boot (production)"] --> B["Eager-loads Solid models\nSolidCache::Record\nSolidQueue::Job\nSolidCable::Message"]
    B --> C{"Named DB connection\nin database.yml?"}
    C -- "Before PR: missing" --> D["💥 Boot failure\n'cache DB not configured'"]
    C -- "After PR: present" --> E["Resolve cache / queue / cable\n→ &primary_production anchor\n(same DATABASE_URL)"]
    E --> F["database_tasks: false\nSkips migrations/schema\non alias connections"]
    E --> G["primary connection\ndatabase_tasks: true\nRuns db:migrate normally"]
    F --> H["✅ Server boots\nSolid adapters NOT used\n(memory_store / async)"]
    G --> H
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Configure production named database conn..."](https://github.com/shimizu-technology/fd-alumni-hub/commit/10896fc09b8c9a04a988348e79bcd3d9dee5770b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40281906)</sub>

<!-- /greptile_comment -->