### PR TITLE
Set Netlify API base URL for Vite

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,8 @@
   publish = "web/dist"
 
 [build.environment]
+  # Public API URL baked into the Vite bundle during Netlify builds.
+  VITE_API_BASE_URL = "https://fd-alumni-hub.onrender.com/api/v1"
   # The old Netlify project still has @netlify/plugin-nextjs installed from the UI.
   # Skip that runtime explicitly now that this repo deploys the Vite build.
   NETLIFY_NEXT_PLUGIN_SKIP = "true"


### PR DESCRIPTION
## Summary
- Bake the public Render Rails API URL into Netlify Vite builds via netlify.toml
- Prevent production from falling back to the local development API URL when Netlify UI env is missing

## Validation
- VITE_API_BASE_URL=https://fd-alumni-hub.onrender.com/api/v1 npm run build
- Verified built JS contains https://fd-alumni-hub.onrender.com/api/v1
- Verified Render API /api/v1/public/home responds 200
- Verified CORS preflight from https://fd-alumni-tourney.netlify.app succeeds

## Deploy note
After merge, trigger a Netlify production deploy/clear cache deploy. If Netlify UI has a VITE_API_BASE_URL value, it must also be https://fd-alumni-hub.onrender.com/api/v1 because UI env can override config values.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bakes the production Render API base URL into the Netlify build via `netlify.toml`'s `[build.environment]` section, preventing the app from falling back to a localhost API URL when the environment variable is absent from the Netlify UI.

- Adds `VITE_API_BASE_URL = \"https://fd-alumni-hub.onrender.com/api/v1\"` to `[build.environment]` in `netlify.toml` so every Netlify build gets the correct API origin baked into the Vite bundle.
- Because `VITE_*` variables are always public (embedded in the client bundle), committing this URL to the repository carries no secrets risk.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the change is minimal and correct, but confirm no conflicting VITE_API_BASE_URL exists in the Netlify UI before or right after deploying.

The one-line addition correctly bakes the production API URL into every Netlify build. The only risk is operational: if a stale or different VITE_API_BASE_URL is set in the Netlify dashboard, it will silently override this file and point the bundle at the wrong API. The PR description already notes this, so the awareness is there — it just needs to be actioned at deploy time.

netlify.toml — verify the Netlify UI has no conflicting VITE_API_BASE_URL entry before triggering the production deploy.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| netlify.toml | Adds VITE_API_BASE_URL to [build.environment]; correct placement, no secrets risk, but Netlify UI environment variables silently take precedence over netlify.toml values. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Dev as Git Push / Merge
    participant Netlify as Netlify Build
    participant Vite as Vite Bundler
    participant Bundle as Built JS Bundle
    participant Browser as Browser
    participant API as Render API(fd-alumni-hub.onrender.com)

    Dev->>Netlify: Trigger production deploy
    Netlify->>Netlify: Read [build.environment] from netlify.toml
    Note over Netlify: VITE_API_BASE_URL=https://fd-alumni-hub.onrender.com/api/v1 (UI env var overrides if also set)
    Netlify->>Vite: npm run build (with env vars injected)
    Vite->>Bundle: Replace import.meta.env.VITE_API_BASE_URL with hardcoded URL
    Bundle->>Browser: Served from Netlify CDN
    Browser->>API: "XHR/fetch to https://fd-alumni-hub.onrender.com/api/v1/*"
    API-->>Browser: JSON response (CORS allowed from netlify.app)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Dev as Git Push / Merge
    participant Netlify as Netlify Build
    participant Vite as Vite Bundler
    participant Bundle as Built JS Bundle
    participant Browser as Browser
    participant API as Render API(fd-alumni-hub.onrender.com)

    Dev->>Netlify: Trigger production deploy
    Netlify->>Netlify: Read [build.environment] from netlify.toml
    Note over Netlify: VITE_API_BASE_URL=https://fd-alumni-hub.onrender.com/api/v1 (UI env var overrides if also set)
    Netlify->>Vite: npm run build (with env vars injected)
    Vite->>Bundle: Replace import.meta.env.VITE_API_BASE_URL with hardcoded URL
    Bundle->>Browser: Served from Netlify CDN
    Browser->>API: "XHR/fetch to https://fd-alumni-hub.onrender.com/api/v1/*"
    API-->>Browser: JSON response (CORS allowed from netlify.app)
```

</a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
netlify.toml:10
**Netlify UI env vars silently override `netlify.toml`**

Netlify gives UI-set environment variables higher precedence than `[build.environment]` in `netlify.toml`. If a `VITE_API_BASE_URL` entry already exists in the Netlify dashboard (e.g. a leftover value pointing at a different host or `localhost`), it will silently win and this line will have no effect — producing a broken production bundle with no build-time error. The PR description mentions this in the deploy note, but it's worth calling out explicitly: before or right after merging, verify (and remove or align) any `VITE_API_BASE_URL` entry in the Netlify UI so the two sources don't diverge.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Set Netlify API base URL for Vite"](https://github.com/shimizu-technology/fd-alumni-hub/commit/272a3e3f1e0cc548e5f3e7c00b0e9345fde4b6ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40329634)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->