### PR TITLE
Polish public header and production web readiness

### DIFF
--- a/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
+++ b/docs/projects/fd-rails-vite-deployment-and-2026-schedule-plan.md
@@ -88,6 +88,7 @@ Publish directory: web/dist
 Important Netlify env vars:
 
 ```bash
+VITE_SITE_URL=https://fd-alumni-tourney.netlify.app
 VITE_API_BASE_URL=https://<render-api>.onrender.com/api/v1
 VITE_CLERK_PUBLISHABLE_KEY=<production Clerk publishable key>
 VITE_CLERK_JWT_TEMPLATE=

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,8 @@
   publish = "web/dist"
 
 [build.environment]
+  # Public production URL used for canonical/SEO metadata in the Vite bundle.
+  VITE_SITE_URL = "https://fd-alumni-tourney.netlify.app"
   # The old Netlify project still has @netlify/plugin-nextjs installed from the UI.
   # Skip that runtime explicitly now that this repo deploys the Vite build.
   NETLIFY_NEXT_PLUGIN_SKIP = "true"

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,3 +1,6 @@
+# Public site URL used for canonical/SEO metadata.
+VITE_SITE_URL=https://fd-alumni-tourney.netlify.app
+
 # Rails API base. Include /api/v1.
 VITE_API_BASE_URL=http://localhost:3001/api/v1
 

--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,7 @@
     <meta name="keywords" content="FD Alumni Basketball Tournament, Guam basketball, Father Duenas alumni, GuamTime tickets, Clutch Guam streams, tournament standings" />
     <meta name="author" content="Shimizu Technology" />
     <meta name="robots" content="index,follow" />
-    <link rel="canonical" href="https://fd-alumni-hub.netlify.app/" />
+    <link rel="canonical" href="https://fd-alumni-tourney.netlify.app/" />
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
@@ -30,32 +30,32 @@
     <meta name="apple-mobile-web-app-title" content="FD Hub" />
 
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://fd-alumni-hub.netlify.app/" />
+    <meta property="og:url" content="https://fd-alumni-tourney.netlify.app/" />
     <meta property="og:site_name" content="FD Alumni Basketball Tournament Hub" />
     <meta property="og:title" content="FD Alumni Basketball Tournament Hub" />
     <meta
       property="og:description"
       content="Schedules, standings, tickets, streams, local coverage, sponsors, and tournament history in one central hub."
     />
-    <meta property="og:image" content="https://fd-alumni-hub.netlify.app/og-image.png" />
+    <meta property="og:image" content="https://fd-alumni-tourney.netlify.app/og-image.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
 
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:url" content="https://fd-alumni-hub.netlify.app/" />
+    <meta name="twitter:url" content="https://fd-alumni-tourney.netlify.app/" />
     <meta name="twitter:title" content="FD Alumni Basketball Tournament Hub" />
     <meta
       name="twitter:description"
       content="Schedules, standings, tickets, streams, local coverage, sponsors, and tournament history in one central hub."
     />
-    <meta name="twitter:image" content="https://fd-alumni-hub.netlify.app/og-image.png" />
+    <meta name="twitter:image" content="https://fd-alumni-tourney.netlify.app/og-image.png" />
 
     <script type="application/ld+json">
       {
         "@context": "https://schema.org",
         "@type": "WebSite",
         "name": "FD Alumni Basketball Tournament Hub",
-        "url": "https://fd-alumni-hub.netlify.app/",
+        "url": "https://fd-alumni-tourney.netlify.app/",
         "description": "Central hub for FD Alumni Basketball Tournament schedules, standings, tickets, streams, news, media, sponsors, and history.",
         "inLanguage": "en-US",
         "publisher": {

--- a/web/public/manifest.json
+++ b/web/public/manifest.json
@@ -2,8 +2,10 @@
   "name": "FD Alumni Basketball Tournament Hub",
   "short_name": "FD Hub",
   "description": "Central hub for FD Alumni Basketball Tournament schedules, standings, tickets, streams, news, media, sponsors, and history.",
+  "id": "/",
   "start_url": "/",
   "display": "standalone",
+  "display_override": ["standalone", "minimal-ui"],
   "background_color": "#fffaf5",
   "theme_color": "#42101f",
   "orientation": "portrait-primary",
@@ -47,5 +49,29 @@
     }
   ],
   "categories": ["sports", "entertainment", "news"],
-  "lang": "en-US"
+  "lang": "en-US",
+  "dir": "ltr",
+  "shortcuts": [
+    {
+      "name": "Today at The Jungle",
+      "short_name": "Today",
+      "description": "Open game-day notes, roster details, and live links.",
+      "url": "/today",
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Tournament Schedule",
+      "short_name": "Schedule",
+      "description": "Open FD Alumni Basketball Tournament schedule and links.",
+      "url": "/schedule",
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    },
+    {
+      "name": "Standings",
+      "short_name": "Standings",
+      "description": "Open tournament standings and score coverage.",
+      "url": "/standings",
+      "icons": [{ "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" }]
+    }
+  ]
 }

--- a/web/public/robots.txt
+++ b/web/public/robots.txt
@@ -1,5 +1,5 @@
 # FD Alumni Basketball Tournament Hub
-# https://fd-alumni-hub.netlify.app
+# https://fd-alumni-tourney.netlify.app
 
 User-agent: *
 Allow: /
@@ -8,4 +8,4 @@ Disallow: /admin
 Disallow: /admin/*
 Disallow: /api/
 
-Sitemap: https://fd-alumni-hub.netlify.app/sitemap.xml
+Sitemap: https://fd-alumni-tourney.netlify.app/sitemap.xml

--- a/web/public/sitemap.xml
+++ b/web/public/sitemap.xml
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/today</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/today</loc>
     <lastmod>2026-06-15</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.98</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/schedule</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/schedule</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.95</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/standings</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/standings</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/watch</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/watch</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/info</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/info</loc>
     <lastmod>2026-06-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.85</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/news</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/news</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/gallery</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/gallery</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.75</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/history</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/history</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
-    <loc>https://fd-alumni-hub.netlify.app/sponsors</loc>
+    <loc>https://fd-alumni-tourney.netlify.app/sponsors</loc>
     <lastmod>2026-06-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,12 +1,13 @@
-const CACHE_NAME = 'fd-alumni-hub-v1';
+const CACHE_NAME = 'fd-alumni-hub-v2';
 const OFFLINE_URL = '/offline.html';
 const CORE_ASSETS = [OFFLINE_URL, '/manifest.json', '/favicon.svg', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', (event) => {
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll(CORE_ASSETS))
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.addAll(CORE_ASSETS))
+      .then(() => self.skipWaiting())
   );
-  self.skipWaiting();
 });
 
 self.addEventListener('activate', (event) => {
@@ -21,7 +22,9 @@ self.addEventListener('activate', (event) => {
 self.addEventListener('fetch', (event) => {
   if (event.request.mode === 'navigate') {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match(OFFLINE_URL))
+      fetch(event.request).catch(() =>
+        caches.match(OFFLINE_URL).then((response) => response || new Response('Offline', { status: 503 }))
+      )
     );
   }
 });

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -1,7 +1,9 @@
 import { NavLink, Outlet } from 'react-router-dom'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { IconClose, IconMenu, IconShield } from './Icons'
 import { externalHref } from '../lib/urls'
+
+const publicMenuId = 'fd-public-mobile-menu'
 
 const navItems = [
   { to: '/', label: 'Home' },
@@ -19,6 +21,23 @@ const navItems = [
 export function PublicLayout() {
   const [open, setOpen] = useState(false)
 
+  useEffect(() => {
+    if (!open || typeof document === 'undefined') return
+
+    const previousOverflow = document.body.style.overflow
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false)
+    }
+
+    document.body.style.overflow = 'hidden'
+    document.addEventListener('keydown', handleKeyDown)
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
+
   return (
     <div className="site-shell">
       <header className="site-header">
@@ -34,16 +53,23 @@ export function PublicLayout() {
         </nav>
         <div className="header-actions">
           <NavLink className="admin-link" to="/admin"><IconShield size={16} /> Admin</NavLink>
-          <button className="icon-button mobile-only" type="button" aria-label="Open menu" onClick={() => setOpen(true)}><IconMenu /></button>
+          <button className="icon-button menu-button mobile-only" type="button" aria-label="Open menu" aria-expanded={open} aria-controls={publicMenuId} onClick={() => setOpen(true)}><IconMenu /><span>Menu</span></button>
         </div>
       </header>
 
       {open && (
-        <div className="mobile-menu" role="dialog" aria-modal="true" aria-label="Mobile navigation">
-          <div className="mobile-menu-panel">
-            <button className="icon-button" type="button" aria-label="Close menu" onClick={() => setOpen(false)}><IconClose /></button>
-            {navItems.map((item) => <NavLink key={item.to} to={item.to} end={item.to === '/'} onClick={() => setOpen(false)}>{item.label}</NavLink>)}
-            <NavLink to="/admin" onClick={() => setOpen(false)}>Admin</NavLink>
+        <div className="mobile-menu" role="presentation">
+          <button className="mobile-menu-backdrop" type="button" aria-label="Close menu" onClick={() => setOpen(false)} />
+          <div id={publicMenuId} className="mobile-menu-panel" role="dialog" aria-modal="true" aria-label="Main navigation">
+            <div className="mobile-menu-head">
+              <span className="brand-crest" aria-hidden="true"><img src="/brand/fd-crest.png" alt="" /></span>
+              <span><strong>FD Alumni Basketball Hub</strong><small>Central Tournament Hub</small></span>
+              <button className="icon-button" type="button" aria-label="Close menu" onClick={() => setOpen(false)}><IconClose /></button>
+            </div>
+            <nav className="mobile-menu-links" aria-label="Main navigation">
+              {navItems.map((item) => <NavLink key={item.to} to={item.to} end={item.to === '/'} onClick={() => setOpen(false)}>{item.label}</NavLink>)}
+            </nav>
+            <NavLink className="mobile-admin-link" to="/admin" onClick={() => setOpen(false)}><IconShield size={16} /> Admin workspace</NavLink>
           </div>
         </div>
       )}

--- a/web/src/components/PublicLayout.tsx
+++ b/web/src/components/PublicLayout.tsx
@@ -1,9 +1,17 @@
 import { NavLink, Outlet } from 'react-router-dom'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { IconClose, IconMenu, IconShield } from './Icons'
 import { externalHref } from '../lib/urls'
 
 const publicMenuId = 'fd-public-mobile-menu'
+const menuFocusableSelector = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
 
 const navItems = [
   { to: '/', label: 'Home' },
@@ -20,21 +28,53 @@ const navItems = [
 
 export function PublicLayout() {
   const [open, setOpen] = useState(false)
+  const menuButtonRef = useRef<HTMLButtonElement | null>(null)
+  const closeButtonRef = useRef<HTMLButtonElement | null>(null)
+  const menuPanelRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
     if (!open || typeof document === 'undefined') return
 
     const previousOverflow = document.body.style.overflow
+    const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const focusTimer = window.setTimeout(() => closeButtonRef.current?.focus({ preventScroll: true }), 0)
+    const focusableElements = () => Array.from(menuPanelRef.current?.querySelectorAll<HTMLElement>(menuFocusableSelector) || [])
+
     const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false)
+      if (event.key === 'Escape') {
+        setOpen(false)
+        return
+      }
+
+      if (event.key !== 'Tab') return
+
+      const focusable = focusableElements()
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+
+      if (!first || !last) {
+        event.preventDefault()
+        menuPanelRef.current?.focus({ preventScroll: true })
+        return
+      }
+
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault()
+        last.focus({ preventScroll: true })
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault()
+        first.focus({ preventScroll: true })
+      }
     }
 
     document.body.style.overflow = 'hidden'
     document.addEventListener('keydown', handleKeyDown)
 
     return () => {
+      window.clearTimeout(focusTimer)
       document.body.style.overflow = previousOverflow
       document.removeEventListener('keydown', handleKeyDown)
+      if (previouslyFocused && document.contains(previouslyFocused)) previouslyFocused.focus({ preventScroll: true })
     }
   }, [open])
 
@@ -48,25 +88,25 @@ export function PublicLayout() {
             <small>Central Tournament Hub</small>
           </span>
         </NavLink>
-        <nav className="desktop-nav" aria-label="Main navigation">
+        <nav className="desktop-nav" aria-label="Primary navigation">
           {navItems.map((item) => <NavLink key={item.to} to={item.to} end={item.to === '/'}>{item.label}</NavLink>)}
         </nav>
         <div className="header-actions">
           <NavLink className="admin-link" to="/admin"><IconShield size={16} /> Admin</NavLink>
-          <button className="icon-button menu-button mobile-only" type="button" aria-label="Open menu" aria-expanded={open} aria-controls={publicMenuId} onClick={() => setOpen(true)}><IconMenu /><span>Menu</span></button>
+          <button ref={menuButtonRef} className="icon-button menu-button mobile-only" type="button" aria-label="Open menu" aria-expanded={open} aria-controls={publicMenuId} onClick={() => setOpen(true)}><IconMenu /><span>Menu</span></button>
         </div>
       </header>
 
       {open && (
         <div className="mobile-menu" role="presentation">
-          <button className="mobile-menu-backdrop" type="button" aria-label="Close menu" onClick={() => setOpen(false)} />
-          <div id={publicMenuId} className="mobile-menu-panel" role="dialog" aria-modal="true" aria-label="Main navigation">
+          <button className="mobile-menu-backdrop" type="button" aria-label="Close menu" tabIndex={-1} onClick={() => setOpen(false)} />
+          <div ref={menuPanelRef} id={publicMenuId} className="mobile-menu-panel" role="dialog" aria-modal="true" aria-label="Site menu" tabIndex={-1}>
             <div className="mobile-menu-head">
               <span className="brand-crest" aria-hidden="true"><img src="/brand/fd-crest.png" alt="" /></span>
               <span><strong>FD Alumni Basketball Hub</strong><small>Central Tournament Hub</small></span>
-              <button className="icon-button" type="button" aria-label="Close menu" onClick={() => setOpen(false)}><IconClose /></button>
+              <button ref={closeButtonRef} className="icon-button" type="button" aria-label="Close menu" onClick={() => setOpen(false)}><IconClose /></button>
             </div>
-            <nav className="mobile-menu-links" aria-label="Main navigation">
+            <nav className="mobile-menu-links" aria-label="Full menu navigation">
               {navItems.map((item) => <NavLink key={item.to} to={item.to} end={item.to === '/'} onClick={() => setOpen(false)}>{item.label}</NavLink>)}
             </nav>
             <NavLink className="mobile-admin-link" to="/admin" onClick={() => setOpen(false)}><IconShield size={16} /> Admin workspace</NavLink>

--- a/web/src/components/SeoManager.tsx
+++ b/web/src/components/SeoManager.tsx
@@ -12,6 +12,12 @@ type SeoRoute = {
   robots?: string
 }
 
+const unknownRouteSeo: SeoRoute = {
+  title: `Page unavailable | ${SITE_NAME}`,
+  description: DEFAULT_DESCRIPTION,
+  robots: 'noindex,nofollow',
+}
+
 const routeSeo: Record<string, SeoRoute> = {
   '/': {
     title: `${SITE_NAME} | Schedule, Standings, Tickets & Streams`,
@@ -72,7 +78,7 @@ function seoForPath(pathname: string): SeoRoute {
     }
   }
 
-  return routeSeo[pathname] || routeSeo['/']
+  return routeSeo[pathname] || unknownRouteSeo
 }
 
 function upsertMeta(selector: string, attributes: Record<string, string>) {
@@ -83,7 +89,8 @@ function upsertMeta(selector: string, attributes: Record<string, string>) {
     document.head.appendChild(element)
   }
 
-  Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, value))
+  const target = element
+  Object.entries(attributes).forEach(([key, value]) => target.setAttribute(key, value))
 }
 
 function upsertLink(selector: string, attributes: Record<string, string>) {
@@ -94,7 +101,8 @@ function upsertLink(selector: string, attributes: Record<string, string>) {
     document.head.appendChild(element)
   }
 
-  Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, value))
+  const target = element
+  Object.entries(attributes).forEach(([key, value]) => target.setAttribute(key, value))
 }
 
 export function SeoManager() {

--- a/web/src/components/SeoManager.tsx
+++ b/web/src/components/SeoManager.tsx
@@ -1,0 +1,128 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+
+const SITE_NAME = 'FD Alumni Basketball Hub'
+const SITE_URL = ((import.meta.env.VITE_SITE_URL as string | undefined) || 'https://fd-alumni-tourney.netlify.app').replace(/\/$/, '')
+const DEFAULT_IMAGE = `${SITE_URL}/og-image.png`
+const DEFAULT_DESCRIPTION = 'Central hub for FD Alumni Basketball Tournament schedules, standings, GuamTime tickets, Clutch streams, news, media, sponsors, and history.'
+
+type SeoRoute = {
+  title: string
+  description: string
+  robots?: string
+}
+
+const routeSeo: Record<string, SeoRoute> = {
+  '/': {
+    title: `${SITE_NAME} | Schedule, Standings, Tickets & Streams`,
+    description: DEFAULT_DESCRIPTION,
+  },
+  '/today': {
+    title: `Today at The Jungle | ${SITE_NAME}`,
+    description: 'Game-day schedule, roster details, live links, and fan predictions for FD Alumni Basketball Tournament action in Guam.',
+  },
+  '/schedule': {
+    title: `Tournament Schedule | ${SITE_NAME}`,
+    description: 'View FD Alumni Basketball Tournament game times, matchups, divisions, ticket links, and stream links in Guam time.',
+  },
+  '/standings': {
+    title: `Standings | ${SITE_NAME}`,
+    description: 'Follow FD Alumni Basketball Tournament standings, records, point differential, and score coverage by division.',
+  },
+  '/watch': {
+    title: `Watch & Tickets | ${SITE_NAME}`,
+    description: 'Find partner links for GuamTime tickets, Clutch streams, local coverage, and FD Alumni Basketball Tournament game media.',
+  },
+  '/info': {
+    title: `Rules & Tournament Info | ${SITE_NAME}`,
+    description: 'Public tournament information, rules highlights, ticket guidance, and venue notes for the FD Alumni Basketball Tournament.',
+  },
+  '/news': {
+    title: `News & Coverage | ${SITE_NAME}`,
+    description: 'Browse FD Alumni Basketball Tournament coverage, GSPN links, partner articles, and local basketball updates.',
+  },
+  '/gallery': {
+    title: `Gallery | ${SITE_NAME}`,
+    description: 'Browse sourced FD Alumni Basketball Tournament photos, media links, and archived tournament images.',
+  },
+  '/history': {
+    title: `Tournament History | ${SITE_NAME}`,
+    description: 'Explore FD Alumni Basketball Tournament history, archived seasons, past scores, articles, and media links.',
+  },
+  '/sponsors': {
+    title: `Sponsors | ${SITE_NAME}`,
+    description: 'View FD Alumni Basketball Tournament sponsors, partner acknowledgements, and community supporters.',
+  },
+}
+
+function seoForPath(pathname: string): SeoRoute {
+  if (pathname.startsWith('/admin')) {
+    return {
+      title: `Admin | ${SITE_NAME}`,
+      description: 'Secure admin workspace for FD Alumni Basketball Hub staff.',
+      robots: 'noindex,nofollow',
+    }
+  }
+
+  if (pathname.startsWith('/history/')) {
+    const year = pathname.split('/').filter(Boolean)[1]
+    return {
+      title: `${year || 'Archive'} Tournament Archive | ${SITE_NAME}`,
+      description: `Archived FD Alumni Basketball Tournament scores, articles, media, and research notes${year ? ` for ${year}` : ''}.`,
+    }
+  }
+
+  return routeSeo[pathname] || routeSeo['/']
+}
+
+function upsertMeta(selector: string, attributes: Record<string, string>) {
+  let element = document.head.querySelector<HTMLMetaElement>(selector)
+
+  if (!element) {
+    element = document.createElement('meta')
+    document.head.appendChild(element)
+  }
+
+  Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, value))
+}
+
+function upsertLink(selector: string, attributes: Record<string, string>) {
+  let element = document.head.querySelector<HTMLLinkElement>(selector)
+
+  if (!element) {
+    element = document.createElement('link')
+    document.head.appendChild(element)
+  }
+
+  Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, value))
+}
+
+export function SeoManager() {
+  const location = useLocation()
+
+  useEffect(() => {
+    const route = seoForPath(location.pathname)
+    const canonicalUrl = `${SITE_URL}${location.pathname === '/' ? '/' : location.pathname}`
+    const robots = route.robots || 'index,follow'
+
+    document.title = route.title
+
+    upsertMeta('meta[name="title"]', { name: 'title', content: route.title })
+    upsertMeta('meta[name="description"]', { name: 'description', content: route.description })
+    upsertMeta('meta[name="robots"]', { name: 'robots', content: robots })
+
+    upsertMeta('meta[property="og:url"]', { property: 'og:url', content: canonicalUrl })
+    upsertMeta('meta[property="og:title"]', { property: 'og:title', content: route.title })
+    upsertMeta('meta[property="og:description"]', { property: 'og:description', content: route.description })
+    upsertMeta('meta[property="og:image"]', { property: 'og:image', content: DEFAULT_IMAGE })
+
+    upsertMeta('meta[name="twitter:url"]', { name: 'twitter:url', content: canonicalUrl })
+    upsertMeta('meta[name="twitter:title"]', { name: 'twitter:title', content: route.title })
+    upsertMeta('meta[name="twitter:description"]', { name: 'twitter:description', content: route.description })
+    upsertMeta('meta[name="twitter:image"]', { name: 'twitter:image', content: DEFAULT_IMAGE })
+
+    upsertLink('link[rel="canonical"]', { rel: 'canonical', href: canonicalUrl })
+  }, [location.pathname])
+
+  return null
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import { App } from './App'
+import { SeoManager } from './components/SeoManager'
 import { PostHogPageView, PostHogProvider } from './providers/PostHogProvider'
 import './styles.css'
 
@@ -9,6 +10,7 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <PostHogProvider>
       <BrowserRouter>
+        <SeoManager />
         <PostHogPageView />
         <App />
       </BrowserRouter>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -490,8 +490,6 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 }
 
 @media (max-width: 980px) {
-  .desktop-nav, .admin-link { display: none; }
-  .mobile-only { display: grid; }
   .hero-card, .split-grid, .today-game-card, .prediction-admin-row { grid-template-columns: 1fr; }
   .admin-sidebar-desktop { display: none; }
   .admin-mobile-topbar { position: sticky; top: 0; z-index: 35; display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: .75rem 1rem; border-bottom: 1px solid rgba(111,29,53,.12); background: rgba(255,250,245,.94); backdrop-filter: blur(16px); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -30,24 +30,34 @@ h1, h2, h3, .brand strong, .btn, .stat-card strong { font-family: "Sora", "Sourc
 
 .site-shell { position: relative; min-height: 100vh; display: flex; flex-direction: column; background: radial-gradient(circle at 7% 7rem, rgba(200,155,60,.2), transparent 18rem), linear-gradient(180deg, var(--fd-maroon-900) 0, var(--fd-maroon-800) 22rem, var(--paper) 22rem, var(--paper) 100%); }
 .site-shell::before { content: ""; position: fixed; inset: 0; pointer-events: none; background: linear-gradient(180deg, rgba(255,255,255,.05), transparent 16rem); }
-.site-header { position: sticky; top: 0; z-index: 20; display: flex; align-items: center; gap: 1.1rem; justify-content: space-between; padding: .75rem clamp(1rem, 4vw, 3rem); background: rgba(66, 16, 31, .97); backdrop-filter: blur(18px); border-bottom: 1px solid rgba(255, 255, 255, .12); color: #fff; }
+.site-header { position: sticky; top: 0; z-index: 20; display: grid; grid-template-columns: minmax(15rem, auto) minmax(0, 1fr) auto; align-items: center; gap: clamp(.65rem, 1.4vw, 1.1rem); padding: .75rem clamp(1rem, 4vw, 3rem); background: rgba(66, 16, 31, .97); backdrop-filter: blur(18px); border-bottom: 1px solid rgba(255, 255, 255, .12); color: #fff; }
 .brand, .admin-brand { display: inline-flex; align-items: center; gap: .75rem; font-weight: 800; }
+.public-brand { min-width: 0; justify-self: start; }
+.public-brand > span:last-child { min-width: 0; }
 .brand small { display: block; color: rgba(255,255,255,.62); font-weight: 800; font-size: .72rem; letter-spacing: .08em; text-transform: uppercase; }
-.public-brand strong { color: #fff; letter-spacing: -.03em; }
-.brand-crest { display: grid; place-items: center; width: 2.8rem; height: 2.8rem; border-radius: .9rem; background: #fff; box-shadow: 0 10px 24px rgba(0,0,0,.16); overflow: hidden; }
+.public-brand strong { display: block; color: #fff; letter-spacing: -.03em; white-space: nowrap; }
+.brand-crest { display: grid; place-items: center; width: 2.8rem; height: 2.8rem; border-radius: .9rem; background: #fff; box-shadow: 0 10px 24px rgba(0,0,0,.16); overflow: hidden; flex: 0 0 auto; }
 .brand-crest img { width: 2.35rem; height: 2.35rem; object-fit: contain; }
 .brand-mark { display: grid; place-items: center; width: 2.75rem; height: 2.75rem; border-radius: 1rem; color: #fff; background: linear-gradient(135deg, var(--fd-maroon), var(--fd-maroon-900)); box-shadow: 0 12px 30px rgba(111,29,53,.22); font-weight: 900; letter-spacing: -.04em; }
-.desktop-nav { display: flex; gap: .18rem; align-items: center; }
-.desktop-nav a, .admin-link { padding: .58rem .78rem; border-radius: 999px; color: rgba(255,255,255,.76); font-weight: 800; font-size: .94rem; }
+.desktop-nav { min-width: 0; display: flex; justify-content: center; gap: .18rem; align-items: center; }
+.desktop-nav a, .admin-link { flex: 0 0 auto; padding: .58rem .78rem; border-radius: 999px; color: rgba(255,255,255,.76); font-weight: 800; font-size: .94rem; white-space: nowrap; }
 .desktop-nav a.active, .desktop-nav a:hover, .admin-link:hover { color: #fff; background: rgba(255,255,255,.12); }
-.header-actions { display: flex; align-items: center; gap: .5rem; }
+.header-actions { justify-self: end; display: flex; align-items: center; gap: .5rem; }
 .admin-link { display: inline-flex; gap: .35rem; align-items: center; border: 1px solid rgba(255,255,255,.18); background: rgba(255,255,255,.07); }
 .icon-button { border: 0; background: #fff; border-radius: .85rem; width: 2.75rem; height: 2.75rem; display: grid; place-items: center; color: var(--fd-maroon); box-shadow: inset 0 0 0 1px var(--line); cursor: pointer; }
 .mobile-only { display: none; }
-.mobile-menu { position: fixed; inset: 0; z-index: 40; background: rgba(23,20,26,.38); display: flex; justify-content: flex-end; }
-.mobile-menu-panel { width: min(22rem, 90vw); background: #fff; padding: 1rem; display: grid; align-content: start; gap: .5rem; box-shadow: -20px 0 60px rgba(23,20,26,.18); }
-.mobile-menu-panel a { padding: .9rem 1rem; border-radius: .9rem; font-weight: 800; color: var(--fd-maroon); }
+.menu-button { width: auto; min-width: 2.75rem; padding: 0 .82rem; grid-auto-flow: column; gap: .42rem; font-weight: 900; }
+.menu-button span { font-size: .88rem; }
+.mobile-menu { position: fixed; inset: 0; z-index: 40; background: rgba(23,20,26,.46); backdrop-filter: blur(4px); display: flex; justify-content: flex-end; padding: .7rem; }
+.mobile-menu-backdrop { position: absolute; inset: 0; border: 0; background: transparent; cursor: pointer; }
+.mobile-menu-panel { position: relative; width: min(24rem, 92vw); max-height: calc(100dvh - 1.4rem); overflow: auto; background: #fff; border: 1px solid rgba(255,255,255,.78); border-radius: 1.35rem; padding: .8rem; display: grid; align-content: start; gap: .75rem; box-shadow: -20px 0 60px rgba(23,20,26,.22); }
+.mobile-menu-head { display: grid; grid-template-columns: auto minmax(0, 1fr) auto; gap: .7rem; align-items: center; padding: .35rem .35rem .7rem; border-bottom: 1px solid var(--line); }
+.mobile-menu-head strong { display: block; color: var(--ink); font-family: "Sora", "Source Sans 3", ui-sans-serif, system-ui, sans-serif; line-height: 1.1; letter-spacing: -.035em; }
+.mobile-menu-head small { display: block; margin-top: .15rem; color: var(--muted); font-size: .68rem; font-weight: 900; letter-spacing: .09em; text-transform: uppercase; }
+.mobile-menu-links { display: grid; gap: .35rem; }
+.mobile-menu-panel a { min-height: 3rem; display: flex; align-items: center; gap: .45rem; padding: .85rem 1rem; border-radius: .95rem; font-weight: 900; color: var(--fd-maroon); }
 .mobile-menu-panel a.active { background: var(--fd-maroon-50); }
+.mobile-admin-link { margin-top: .15rem; border: 1px solid rgba(111,29,53,.16); background: var(--surface-strong); }
 .site-main { position: relative; z-index: 1; flex: 1; width: min(1160px, calc(100% - 2.5rem)); margin: 0 auto; padding: clamp(1.3rem, 3.4vw, 2.75rem) 0 clamp(2rem, 5vw, 4rem); color: var(--ink); }
 .site-footer { position: relative; z-index: 1; display: flex; justify-content: space-between; gap: 1rem; padding: 2rem clamp(1rem, 4vw, 3rem); background: var(--fd-maroon-900); border-top: 1px solid rgba(255,255,255,.12); color: #fff; }
 .site-footer p { color: rgba(255,255,255,.72); margin: .35rem 0 0; max-width: 46rem; }
@@ -466,6 +476,19 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .media-admin-row img, .sponsor-admin-row img { width: 7rem; aspect-ratio: 1; object-fit: cover; border-radius: .9rem; border: 1px solid var(--line); }
 .sponsor-admin-row img { object-fit: contain; background: var(--surface-strong); padding: .6rem; }
 
+@media (max-width: 1320px) {
+  .site-header { grid-template-columns: minmax(14rem, auto) minmax(0, 1fr) auto; }
+  .desktop-nav { justify-content: flex-end; }
+  .desktop-nav a, .admin-link { padding: .54rem .66rem; font-size: .9rem; }
+  .desktop-nav a:nth-child(n+7) { display: none; }
+  .mobile-only { display: grid; }
+}
+
+@media (max-width: 1120px) {
+  .site-header { grid-template-columns: minmax(0, 1fr) auto; }
+  .desktop-nav, .admin-link { display: none; }
+}
+
 @media (max-width: 980px) {
   .desktop-nav, .admin-link { display: none; }
   .mobile-only { display: grid; }
@@ -491,7 +514,7 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 
 @media (max-width: 680px) {
   .site-shell { background: radial-gradient(circle at 0 5rem, rgba(200,155,60,.16), transparent 14rem), linear-gradient(180deg, var(--fd-maroon-900) 0, var(--fd-maroon-800) 13rem, var(--paper) 13rem, var(--paper) 100%); }
-  .site-header { padding: .75rem .9rem; }
+  .site-header { grid-template-columns: minmax(0, 1fr) auto; padding: .75rem .9rem; }
   .site-main { width: min(100% - 1.5rem, 1180px); padding-top: .85rem; }
   .brand { gap: .55rem; min-width: 0; }
   .brand strong { display: block; max-width: 15rem; overflow: hidden; font-size: .98rem; line-height: 1.1; text-overflow: ellipsis; white-space: nowrap; }
@@ -557,4 +580,10 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .game-detail-summary, .score-entry-panel .form-grid, .team-facts-grid { grid-template-columns: 1fr; }
   .compact-admin-row, .media-admin-row, .sponsor-admin-row { grid-template-columns: 1fr; }
   .compact-admin-row .form-grid, .media-admin-row .form-grid, .sponsor-admin-row .form-grid, .media-admin-row .row-actions, .sponsor-admin-row .row-actions, .media-admin-row .form-error, .sponsor-admin-row .form-error { grid-column: auto; }
+}
+
+@media (max-width: 420px) {
+  .menu-button { width: 2.75rem; padding: 0; }
+  .menu-button span { display: none; }
+  .brand strong { max-width: 11.5rem; }
 }


### PR DESCRIPTION
## Summary
- Prevent the public brand lockup from wrapping and stretching the header on smaller desktop widths
- Add a compact desktop state: keep primary nav visible, move secondary links behind a Menu drawer before the layout gets cramped
- Improve the drawer with brand context, backdrop close, Escape close, scroll lock, focus trap, focus restore, and distinct nav landmark labels
- Tighten production web readiness for the new Netlify URL: canonical/OG/Twitter URLs, robots, sitemap, route-level SPA metadata, PWA manifest shortcuts, and a safer offline fallback

## Validation
- ./scripts/gate.sh

## Notes
No Rails API/data model changes. PostHog was already wired through posthog-js with SPA pageviews, masked session replay inputs, admin identify/reset, and VITE_PUBLIC_POSTHOG_* env vars; this PR documents VITE_SITE_URL and fixes SEO/PWA metadata for the active production URL.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the production Netlify URL across all SEO/PWA metadata, adds a new `SeoManager` component for per-route title/meta management, overhauls the public header to use a CSS grid layout with a compact desktop breakpoint, and polishes the mobile drawer with full accessibility (focus trap, Escape, scroll lock, focus restore, backdrop close).

- **SeoManager**: New component placed inside `BrowserRouter` that imperatively upserts `<title>`, `<meta>`, and `<link rel="canonical">` on every client-side navigation using `useLocation`. Admin routes and unmatched paths get `noindex,nofollow`.
- **PublicLayout drawer**: Replaces the old flat panel with a panel that has a branded header, proper `role="dialog"` / `aria-modal`, keyboard focus trap, Escape close, scroll lock, and `previouslyFocused` restoration on close.
- **Service worker**: Bumped to `v2`; `skipWaiting()` moved inside the `waitUntil` promise chain so it only fires after all core assets are cached; offline fallback now returns a `503` if `offline.html` is not cached.
- **CSS breakpoints**: Three-column grid header at wide viewports; at ≤1320px the last four nav items hide and the menu button appears; at ≤1120px the desktop nav and admin link disappear entirely.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are frontend-only, no API or data model changes, and the accessibility, SEO, and service worker improvements are implemented correctly.

The domain rename is consistent across all affected files. The SeoManager upsert helpers find existing static tags from index.html and update them in place, so no duplicate meta elements are created. The focus trap correctly cycles between close button and admin link, restores focus on close, handles Escape, and uses a cleared setTimeout to avoid races. The service worker change to put skipWaiting inside the waitUntil chain is the correct pattern.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/components/SeoManager.tsx | New component that imperatively upserts all SEO meta tags and canonical link on each client-side route change. Logic is correct; upsert helpers find existing static tags from index.html and update them in place, so no duplicate elements are created. |
| web/src/components/PublicLayout.tsx | Adds full focus-trap, Escape/scroll-lock, backdrop-close, and focus-restore to the mobile drawer. Focus is moved to the close button via a cleared setTimeout. aria-label differentiation between desktop and mobile nav landmarks has been addressed. |
| web/public/sw.js | skipWaiting() correctly moved inside the waitUntil promise chain (only fires after caching succeeds), cache name bumped to v2, and offline fallback now returns a 503 Response if offline.html is not cached. |
| web/src/styles.css | Header converted to CSS grid with three responsive breakpoints (1320px compact, 1120px mobile, 980px layout reflow). Dead display:none rules previously flagged have been removed from the 980px block and moved to the correct 1120px block. |
| web/index.html | Static canonical, og:url, og:image, twitter:url, twitter:image, and schema.org URL all updated from the old fd-alumni-hub domain to fd-alumni-tourney.netlify.app. SeoManager will take over per-route updates at runtime. |
| web/public/manifest.json | Adds PWA id, display_override, dir, and three shortcuts (Today, Schedule, Standings) with correct icon references. |
| web/src/main.tsx | SeoManager placed inside BrowserRouter before PostHogPageView so it has router context; renders null and has no visible side effects on the React tree. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant BrowserRouter
    participant SeoManager
    participant document.head
    participant PublicLayout

    User->>BrowserRouter: Navigate to /schedule
    BrowserRouter->>SeoManager: "location.pathname = "/schedule""
    SeoManager->>SeoManager: seoForPath("/schedule")
    SeoManager->>document.head: upsertMeta title, description, robots
    SeoManager->>document.head: upsertMeta og:url, og:title, og:description, og:image
    SeoManager->>document.head: upsertLink canonical href

    User->>PublicLayout: Click Menu button
    PublicLayout->>PublicLayout: setOpen(true)
    PublicLayout->>PublicLayout: useEffect captures previouslyFocused, locks scroll
    PublicLayout->>PublicLayout: setTimeout fires closeButtonRef.focus()
    PublicLayout->>PublicLayout: addEventListener keydown (Escape + Tab trap)

    User->>PublicLayout: Press Escape or click backdrop
    PublicLayout->>PublicLayout: setOpen(false)
    PublicLayout->>PublicLayout: cleanup restores overflow, removes listener
    PublicLayout->>PublicLayout: previouslyFocused.focus() restores menu button
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant BrowserRouter
    participant SeoManager
    participant document.head
    participant PublicLayout

    User->>BrowserRouter: Navigate to /schedule
    BrowserRouter->>SeoManager: "location.pathname = "/schedule""
    SeoManager->>SeoManager: seoForPath("/schedule")
    SeoManager->>document.head: upsertMeta title, description, robots
    SeoManager->>document.head: upsertMeta og:url, og:title, og:description, og:image
    SeoManager->>document.head: upsertLink canonical href

    User->>PublicLayout: Click Menu button
    PublicLayout->>PublicLayout: setOpen(true)
    PublicLayout->>PublicLayout: useEffect captures previouslyFocused, locks scroll
    PublicLayout->>PublicLayout: setTimeout fires closeButtonRef.focus()
    PublicLayout->>PublicLayout: addEventListener keydown (Escape + Tab trap)

    User->>PublicLayout: Press Escape or click backdrop
    PublicLayout->>PublicLayout: setOpen(false)
    PublicLayout->>PublicLayout: cleanup restores overflow, removes listener
    PublicLayout->>PublicLayout: previouslyFocused.focus() restores menu button
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Address SEO manager review notes"](https://github.com/shimizu-technology/fd-alumni-hub/commit/ba3a08abf391186ba97176f8978996f8ba258c53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40330590)</sub>

<!-- /greptile_comment -->