### PR TITLE
Add safe historical import tooling

### DIFF
--- a/archive/legacy-next-app/scripts/export-rails-migration.ts
+++ b/archive/legacy-next-app/scripts/export-rails-migration.ts
@@ -40,8 +40,13 @@ function defaultOutPath() {
   return `tmp/fd-migration/next-prisma-export-${stamp}.json`
 }
 
+function outputPath() {
+  const requested = argValue('--out') || process.env.FD_EXPORT_PATH
+  return requested ? resolve(process.cwd(), requested) : resolve(repoRoot, defaultOutPath())
+}
+
 async function main() {
-  const outPath = resolve(repoRoot, argValue('--out') || process.env.FD_EXPORT_PATH || defaultOutPath())
+  const outPath = outputPath()
 
   const [
     tournaments,

--- a/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
+++ b/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
@@ -99,24 +99,35 @@ Before importing into production:
 
 1. Create a Neon backup/branch for the Rails production database.
 2. Confirm the filtered snapshot excludes 2026 and admin/user records unless intentionally included.
-3. Run the import once with the Rails production `DATABASE_URL`.
+3. Prefer running from the Render Shell, where `RAILS_ENV`, `DATABASE_URL`, and `SECRET_KEY_BASE` are already provided by the service environment. Do not paste `SECRET_KEY_BASE` or database credentials inline on a command line.
 
 ```bash
-cd api
-RAILS_ENV=production \
-DATABASE_URL=<rails-production-neon-url> \
-SECRET_KEY_BASE=<render-secret-key-base> \
-  bundle exec rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
+cd ~/project/src/api
+bundle exec rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
 ```
 
 Then validate and spot-check counts:
 
 ```bash
-RAILS_ENV=production DATABASE_URL=<rails-production-neon-url> SECRET_KEY_BASE=<render-secret-key-base> \
-  bundle exec rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
+bundle exec rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
+bundle exec rails runner 'puts "Tournaments=#{Tournament.count} Games=#{Game.count} Articles=#{ArticleLink.count} Media=#{MediaAsset.count}"'
+```
 
-RAILS_ENV=production DATABASE_URL=<rails-production-neon-url> SECRET_KEY_BASE=<render-secret-key-base> \
-  bundle exec rails runner 'puts "Tournaments=#{Tournament.count} Games=#{Game.count} Articles=#{ArticleLink.count} Media=#{MediaAsset.count}"'
+If an operator must run against production from a trusted workstation instead of Render Shell, put secrets in a private env file first and source it locally; keep that file out of git and remove it after use:
+
+```bash
+cat > tmp/fd-migration/rails-production-import.env <<'EOF'
+export RAILS_ENV=production
+export DATABASE_URL='<rails-production-neon-url>'
+export SECRET_KEY_BASE='<render-secret-key-base>'
+EOF
+chmod 600 tmp/fd-migration/rails-production-import.env
+
+set -a
+. tmp/fd-migration/rails-production-import.env
+set +a
+cd api
+bundle exec rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
 ```
 
 ## 7. Run Rails-backed frontend locally

--- a/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
+++ b/docs/RAILS-DATA-MIGRATION-RUNBOOK.md
@@ -34,7 +34,20 @@ The export includes:
 - admin whitelist rows
 - app users
 
-## 2. Prepare local Rails DB
+## 2. Create a history-only snapshot for production backfill
+
+For production after the Rails/Vite cutover, do **not** import the full legacy snapshot directly because the old database may contain stale 2026 schedule/admin rows. Filter to historical tournament years first:
+
+```bash
+node scripts/filter-next-prisma-snapshot.mjs \
+  --in tmp/fd-migration/next-prisma-export.json \
+  --out tmp/fd-migration/next-prisma-export-history-only.json \
+  --max-year 2025
+```
+
+The filtered snapshot keeps the historical tournaments, teams, games, standings, article links, media assets, sponsors, and ingest queue rows while excluding old admin whitelist/app-user records by default. Use `--include-admin` only for an intentional admin migration.
+
+## 3. Prepare local Rails DB
 
 Use an explicit local Rails database URL so Rails never points at the Prisma production DB by accident.
 
@@ -43,12 +56,12 @@ cd api
 DATABASE_URL=postgres:///fd_alumni_hub_api_development bin/rails db:create db:migrate
 ```
 
-## 3. Import into Rails
+## 4. Import into Rails
 
 ```bash
 cd api
 DATABASE_URL=postgres:///fd_alumni_hub_api_development \
-  bin/rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export.json]'
+  bin/rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
 ```
 
 The importer is idempotent. It upserts by `legacy_id` and preserves relationships by mapping Prisma CUIDs to Rails bigint IDs. Import output reports both snapshot `sourceCounts` and post-import `railsCounts`.
@@ -60,12 +73,12 @@ Migration normalizations:
 - Source ingest items marked `approved` without an imported article/media record are reset to `pending` with a migration note so Rails preserves the invariant that approved ingest items point at imported content.
 - Media ingest fallback inference only links to an imported media asset when the image URL is unique or when duplicate image URLs have exactly one title match; ambiguous cases are reset to pending for operator review.
 
-## 4. Validate the import
+## 5. Validate the import
 
 ```bash
 cd api
 DATABASE_URL=postgres:///fd_alumni_hub_api_development \
-  bin/rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export.json]'
+  bin/rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
 ```
 
 Reports are written to:
@@ -80,7 +93,33 @@ Validation checks:
 - score coverage
 - approved ingest imported-record references
 
-## 5. Run Rails-backed frontend locally
+## 6. Production import
+
+Before importing into production:
+
+1. Create a Neon backup/branch for the Rails production database.
+2. Confirm the filtered snapshot excludes 2026 and admin/user records unless intentionally included.
+3. Run the import once with the Rails production `DATABASE_URL`.
+
+```bash
+cd api
+RAILS_ENV=production \
+DATABASE_URL=<rails-production-neon-url> \
+SECRET_KEY_BASE=<render-secret-key-base> \
+  bundle exec rails 'fd:migration:import_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
+```
+
+Then validate and spot-check counts:
+
+```bash
+RAILS_ENV=production DATABASE_URL=<rails-production-neon-url> SECRET_KEY_BASE=<render-secret-key-base> \
+  bundle exec rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
+
+RAILS_ENV=production DATABASE_URL=<rails-production-neon-url> SECRET_KEY_BASE=<render-secret-key-base> \
+  bundle exec rails runner 'puts "Tournaments=#{Tournament.count} Games=#{Game.count} Articles=#{ArticleLink.count} Media=#{MediaAsset.count}"'
+```
+
+## 7. Run Rails-backed frontend locally
 
 ```bash
 # terminal 1
@@ -89,16 +128,16 @@ DATABASE_URL=postgres:///fd_alumni_hub_api_development bin/rails server -p 3001
 
 # terminal 2
 cp web/.env.example web/.env.local
-npm run web:dev
+npm run dev
 ```
 
-## 6. Staging path after local validation
+## 8. Staging path after local validation
 
 After local validation passes:
 
 1. Create a Rails-owned Neon branch/database.
 2. Deploy Rails API to Render with that Neon `DATABASE_URL`.
 3. Run Rails migrations against staging.
-4. Import the same snapshot into staging with the Rails import task.
+4. Import the filtered history-only snapshot into staging with the Rails import task.
 5. Deploy `/web` to Netlify staging with `VITE_API_BASE_URL` pointing to Render.
 6. Smoke test public and admin flows before any production cutover.

--- a/scripts/filter-next-prisma-snapshot.mjs
+++ b/scripts/filter-next-prisma-snapshot.mjs
@@ -3,10 +3,12 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, resolve } from 'node:path'
 
 function usage() {
-  console.error(`Usage: node scripts/filter-next-prisma-snapshot.mjs --in <snapshot.json> --out <filtered.json> [--max-year 2025] [--min-year 2000] [--years 2024,2025] [--include-admin]
+  console.error(`Usage: node scripts/filter-next-prisma-snapshot.mjs --in <snapshot.json> --out <filtered.json> [--max-year 2025] [--min-year 2000] [--years 2024,2025] [--include-admin] [--allow-missing-relations]
 
 Creates a relationship-safe Next/Prisma snapshot subset for Rails import.
-Defaults are intentionally production-safe for this repo: historical years only (--max-year 2025) and no old admin/user records.`)
+Defaults are intentionally production-safe for this repo: historical years only (--max-year 2025) and no old admin/user records.
+
+By default, the script exits if selected games or standings reference teams that are not in the filtered snapshot. Use --allow-missing-relations only when intentionally producing a partial snapshot.`)
 }
 
 function optionValue(name) {
@@ -31,6 +33,33 @@ function requiredOption(name) {
   return value
 }
 
+function parseIntegerOption(name, fallback = null) {
+  const raw = optionValue(name)
+  if (raw === undefined) return fallback
+
+  if (!/^\d+$/.test(raw.trim())) {
+    console.error(`${name} must be an integer`)
+    process.exit(1)
+  }
+
+  return Number(raw)
+}
+
+function parseYearList() {
+  const raw = optionValue('--years')
+  if (raw === undefined) return undefined
+
+  const values = raw.split(',').map((value) => value.trim())
+  const invalid = values.filter((value) => !/^\d{4}$/.test(value))
+
+  if (invalid.length > 0) {
+    console.error(`--years contains non-integer year values: ${invalid.join(', ')}`)
+    process.exit(1)
+  }
+
+  return values.map(Number)
+}
+
 function recordYear(record) {
   const year = Number(record?.year)
   return Number.isInteger(year) ? year : null
@@ -48,26 +77,39 @@ function sortCounts(records) {
   return Object.fromEntries(Object.entries(records).map(([key, value]) => [key, value.length]))
 }
 
-const inputPath = resolve(process.cwd(), requiredOption('--in'))
-const outputPath = resolve(process.cwd(), requiredOption('--out'))
-const maxYear = Number(optionValue('--max-year') || 2025)
-const minYearValue = optionValue('--min-year')
-const minYear = minYearValue ? Number(minYearValue) : null
-const explicitYears = optionValue('--years')
-  ?.split(',')
-  .map((value) => Number(value.trim()))
-  .filter((value) => Number.isInteger(value))
+function describeRecords(records, formatter) {
+  return records.slice(0, 10).map(formatter).join('\n')
+}
+
+function failOnMissingRelations({ missingTeamGames, missingStandingTeams }) {
+  const messages = []
+
+  if (missingTeamGames.length > 0) {
+    messages.push(`Selected games reference missing teams (${missingTeamGames.length}):`)
+    messages.push(describeRecords(missingTeamGames, (game) => `  - game ${game.id} homeTeamId=${game.homeTeamId} awayTeamId=${game.awayTeamId}`))
+  }
+
+  if (missingStandingTeams.length > 0) {
+    messages.push(`Selected standings reference missing teams (${missingStandingTeams.length}):`)
+    messages.push(describeRecords(missingStandingTeams, (standing) => `  - standing ${standing.id} teamId=${standing.teamId}`))
+  }
+
+  if (messages.length === 0) return
+
+  console.error(messages.join('\n'))
+  console.error('Refusing to silently drop related records. Re-export the source snapshot or pass --allow-missing-relations for an intentional partial snapshot.')
+  process.exit(1)
+}
+
+const inputArg = requiredOption('--in')
+const outputArg = requiredOption('--out')
+const inputPath = resolve(process.cwd(), inputArg)
+const outputPath = resolve(process.cwd(), outputArg)
+const maxYear = parseIntegerOption('--max-year', 2025)
+const minYear = parseIntegerOption('--min-year')
+const explicitYears = parseYearList()
 const includeAdmin = hasFlag('--include-admin')
-
-if (!explicitYears?.length && !Number.isInteger(maxYear)) {
-  console.error('--max-year must be an integer when --years is not provided')
-  process.exit(1)
-}
-
-if (minYear !== null && !Number.isInteger(minYear)) {
-  console.error('--min-year must be an integer')
-  process.exit(1)
-}
+const allowMissingRelations = hasFlag('--allow-missing-relations')
 
 const snapshot = JSON.parse(await readFile(inputPath, 'utf8'))
 if (snapshot.format !== 'fd-alumni-hub-next-prisma-export' || Number(snapshot.version) !== 1) {
@@ -87,10 +129,17 @@ const selectedTournaments = (sourceRecords.tournaments || []).filter((tournament
 const tournamentIds = byId(selectedTournaments)
 const selectedTeams = filterByTournament(sourceRecords.teams || [], tournamentIds)
 const teamIds = byId(selectedTeams)
-const selectedGames = filterByTournament(sourceRecords.games || [], tournamentIds)
-  .filter((game) => teamIds.has(game.homeTeamId) && teamIds.has(game.awayTeamId))
-const selectedStandings = filterByTournament(sourceRecords.standings || [], tournamentIds)
-  .filter((standing) => teamIds.has(standing.teamId))
+const candidateGames = filterByTournament(sourceRecords.games || [], tournamentIds)
+const missingTeamGames = candidateGames.filter((game) => !teamIds.has(game.homeTeamId) || !teamIds.has(game.awayTeamId))
+const selectedGames = candidateGames.filter((game) => teamIds.has(game.homeTeamId) && teamIds.has(game.awayTeamId))
+const candidateStandings = filterByTournament(sourceRecords.standings || [], tournamentIds)
+const missingStandingTeams = candidateStandings.filter((standing) => !teamIds.has(standing.teamId))
+const selectedStandings = candidateStandings.filter((standing) => teamIds.has(standing.teamId))
+
+if (!allowMissingRelations) {
+  failOnMissingRelations({ missingTeamGames, missingStandingTeams })
+}
+
 const selectedArticles = filterByTournament(sourceRecords.articleLinks || [], tournamentIds)
 const selectedMedia = filterByTournament(sourceRecords.mediaAssets || [], tournamentIds)
 const selectedSponsors = filterByTournament(sourceRecords.sponsors || [], tournamentIds)
@@ -118,7 +167,12 @@ const filtered = {
     minYear,
     years: explicitYears || null,
     includeAdmin,
-    sourcePath: inputPath,
+    allowMissingRelations,
+    sourceFile: inputArg,
+    droppedRelationships: {
+      gamesMissingTeams: missingTeamGames.length,
+      standingsMissingTeams: missingStandingTeams.length,
+    },
   },
   counts: sortCounts(records),
   records,
@@ -130,4 +184,7 @@ await writeFile(outputPath, `${JSON.stringify(filtered, null, 2)}\n`)
 const years = selectedTournaments.map((tournament) => tournament.year).sort((a, b) => a - b)
 console.log(`Filtered Next/Prisma snapshot written to ${outputPath}`)
 console.log(`Years: ${years.join(', ') || '(none)'}`)
+if (missingTeamGames.length > 0 || missingStandingTeams.length > 0) {
+  console.warn(`Dropped records with missing relationships: games=${missingTeamGames.length}, standings=${missingStandingTeams.length}`)
+}
 console.table(filtered.counts)

--- a/scripts/filter-next-prisma-snapshot.mjs
+++ b/scripts/filter-next-prisma-snapshot.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+function usage() {
+  console.error(`Usage: node scripts/filter-next-prisma-snapshot.mjs --in <snapshot.json> --out <filtered.json> [--max-year 2025] [--min-year 2000] [--years 2024,2025] [--include-admin]
+
+Creates a relationship-safe Next/Prisma snapshot subset for Rails import.
+Defaults are intentionally production-safe for this repo: historical years only (--max-year 2025) and no old admin/user records.`)
+}
+
+function optionValue(name) {
+  const prefix = `${name}=`
+  const inline = process.argv.find((arg) => arg.startsWith(prefix))
+  if (inline) return inline.slice(prefix.length)
+
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1] : undefined
+}
+
+function hasFlag(name) {
+  return process.argv.includes(name)
+}
+
+function requiredOption(name) {
+  const value = optionValue(name)
+  if (!value) {
+    usage()
+    process.exit(1)
+  }
+  return value
+}
+
+function recordYear(record) {
+  const year = Number(record?.year)
+  return Number.isInteger(year) ? year : null
+}
+
+function byId(records) {
+  return new Set(records.map((record) => record.id).filter(Boolean))
+}
+
+function filterByTournament(records, tournamentIds) {
+  return records.filter((record) => tournamentIds.has(record.tournamentId))
+}
+
+function sortCounts(records) {
+  return Object.fromEntries(Object.entries(records).map(([key, value]) => [key, value.length]))
+}
+
+const inputPath = resolve(process.cwd(), requiredOption('--in'))
+const outputPath = resolve(process.cwd(), requiredOption('--out'))
+const maxYear = Number(optionValue('--max-year') || 2025)
+const minYearValue = optionValue('--min-year')
+const minYear = minYearValue ? Number(minYearValue) : null
+const explicitYears = optionValue('--years')
+  ?.split(',')
+  .map((value) => Number(value.trim()))
+  .filter((value) => Number.isInteger(value))
+const includeAdmin = hasFlag('--include-admin')
+
+if (!explicitYears?.length && !Number.isInteger(maxYear)) {
+  console.error('--max-year must be an integer when --years is not provided')
+  process.exit(1)
+}
+
+if (minYear !== null && !Number.isInteger(minYear)) {
+  console.error('--min-year must be an integer')
+  process.exit(1)
+}
+
+const snapshot = JSON.parse(await readFile(inputPath, 'utf8'))
+if (snapshot.format !== 'fd-alumni-hub-next-prisma-export' || Number(snapshot.version) !== 1) {
+  console.error('Unsupported snapshot format/version')
+  process.exit(1)
+}
+
+const sourceRecords = snapshot.records || {}
+const selectedTournaments = (sourceRecords.tournaments || []).filter((tournament) => {
+  const year = recordYear(tournament)
+  if (year === null) return false
+  if (explicitYears?.length) return explicitYears.includes(year)
+  if (minYear !== null && year < minYear) return false
+  return year <= maxYear
+})
+
+const tournamentIds = byId(selectedTournaments)
+const selectedTeams = filterByTournament(sourceRecords.teams || [], tournamentIds)
+const teamIds = byId(selectedTeams)
+const selectedGames = filterByTournament(sourceRecords.games || [], tournamentIds)
+  .filter((game) => teamIds.has(game.homeTeamId) && teamIds.has(game.awayTeamId))
+const selectedStandings = filterByTournament(sourceRecords.standings || [], tournamentIds)
+  .filter((standing) => teamIds.has(standing.teamId))
+const selectedArticles = filterByTournament(sourceRecords.articleLinks || [], tournamentIds)
+const selectedMedia = filterByTournament(sourceRecords.mediaAssets || [], tournamentIds)
+const selectedSponsors = filterByTournament(sourceRecords.sponsors || [], tournamentIds)
+const selectedIngest = filterByTournament(sourceRecords.contentIngestItems || [], tournamentIds)
+
+const records = {
+  tournaments: selectedTournaments,
+  teams: selectedTeams,
+  games: selectedGames,
+  standings: selectedStandings,
+  articleLinks: selectedArticles,
+  mediaAssets: selectedMedia,
+  sponsors: selectedSponsors,
+  contentIngestItems: selectedIngest,
+  adminWhitelists: includeAdmin ? (sourceRecords.adminWhitelists || []) : [],
+  appUsers: includeAdmin ? (sourceRecords.appUsers || []) : [],
+}
+
+const filtered = {
+  ...snapshot,
+  exportedAt: snapshot.exportedAt,
+  filteredAt: new Date().toISOString(),
+  filter: {
+    maxYear: explicitYears?.length ? null : maxYear,
+    minYear,
+    years: explicitYears || null,
+    includeAdmin,
+    sourcePath: inputPath,
+  },
+  counts: sortCounts(records),
+  records,
+}
+
+await mkdir(dirname(outputPath), { recursive: true })
+await writeFile(outputPath, `${JSON.stringify(filtered, null, 2)}\n`)
+
+const years = selectedTournaments.map((tournament) => tournament.year).sort((a, b) => a - b)
+console.log(`Filtered Next/Prisma snapshot written to ${outputPath}`)
+console.log(`Years: ${years.join(', ') || '(none)'}`)
+console.table(filtered.counts)


### PR DESCRIPTION
## Summary
- Add a relationship-safe Next/Prisma snapshot filter for historical backfills
- Default the filter to years <= 2025 and exclude old admin/app-user rows so production imports do not touch the new Rails 2026 schedule or admin access
- Fix the archived export script so explicit --out paths resolve from the current working directory as documented
- Update the Rails data migration runbook with export, filter, validate, and production import steps

## Validation
- Exported the legacy Prisma DB snapshot using the root .env DATABASE_URL without printing the secret
- Generated tmp/fd-migration/next-prisma-export-history-only.json with years 2005-2025, no 2026, admins=0, users=0
- cd api && bin/rails 'fd:migration:validate_next_snapshot[../tmp/fd-migration/next-prisma-export-history-only.json]'
- ./scripts/gate.sh

## Notes
This PR does not import data into production. It makes the production import repeatable and safer; production DB mutation should happen only after a Neon backup/branch and explicit approval.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `filter-next-prisma-snapshot.mjs` script that produces a relationship-safe, year-bounded subset of the legacy Next/Prisma export for use in the Rails production backfill, fixes the `--out` path resolution bug in the legacy export script, and updates the migration runbook with explicit production import steps and improved secret handling guidance.

- **New filter script** (`scripts/filter-next-prisma-snapshot.mjs`): parses the legacy snapshot, keeps only tournaments within a configurable year range (default ≤ 2025), validates referential integrity for games and standings (failing hard by default), and emits a filtered JSON file with audit metadata.
- **Export script fix** (`archive/legacy-next-app/scripts/export-rails-migration.ts`): explicit `--out` and `FD_EXPORT_PATH` values are now resolved relative to `process.cwd()` rather than the repo root, matching the documented behaviour.
- **Runbook update** (`docs/RAILS-DATA-MIGRATION-RUNBOOK.md`): adds steps 2 and 6 (filter and production import), renumbers existing steps, prefers the Render Shell (where `SECRET_KEY_BASE` is already in env) over inline credentials, and documents an env-file fallback for workstation runs.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changed files are developer/operator tooling with no runtime path to production data.

All three changed files are developer/operator tooling with no runtime path to production data. The filter script's relationship-integrity checks are sound and fail-fast by default. The two noted edge cases are low-probability in a manually invoked ops script and do not reflect defects in the current happy-path behaviour.

scripts/filter-next-prisma-snapshot.mjs — worth a quick read-through of the --years + --max-year interaction before the next production import run.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/filter-next-prisma-snapshot.mjs | New filter script with solid relationship-integrity checks by default; the --years flag silently bypasses --max-year/--min-year, and there is no guard against --in and --out resolving to the same file. |
| archive/legacy-next-app/scripts/export-rails-migration.ts | Bug fix correctly moves explicit --out/FD_EXPORT_PATH resolution from repoRoot to process.cwd(); logic is sound. |
| docs/RAILS-DATA-MIGRATION-RUNBOOK.md | Runbook updated with filter step, production import guidance, and improved secret handling (Render Shell preferred, env-file fallback); clear and safe. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Legacy Prisma DB] -->|export-rails-migration.ts| B[full snapshot JSON\nnext-prisma-export.json]
    B -->|filter-next-prisma-snapshot.mjs\n--max-year 2025| C{Year filter}
    C -->|year > maxYear| D[Excluded]
    C -->|year <= maxYear| E[Selected tournaments]
    E --> F[Filter teams by tournamentId]
    F --> G{Referential integrity check\ngames & standings}
    G -->|missing team refs\ndefault: exit 1| H[Error - re-export or use --allow-missing-relations]
    G -->|relations OK| I[filtered snapshot JSON\nnext-prisma-export-history-only.json]
    I -->|Rails import task| J[Rails DB production / staging]
    J -->|validate task| K[Validation reports]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Legacy Prisma DB] -->|export-rails-migration.ts| B[full snapshot JSON\nnext-prisma-export.json]
    B -->|filter-next-prisma-snapshot.mjs\n--max-year 2025| C{Year filter}
    C -->|year > maxYear| D[Excluded]
    C -->|year <= maxYear| E[Selected tournaments]
    E --> F[Filter teams by tournamentId]
    F --> G{Referential integrity check\ngames & standings}
    G -->|missing team refs\ndefault: exit 1| H[Error - re-export or use --allow-missing-relations]
    G -->|relations OK| I[filtered snapshot JSON\nnext-prisma-export-history-only.json]
    I -->|Rails import task| J[Rails DB production / staging]
    J -->|validate task| K[Validation reports]
```

</a>

<sub>Reviews (2): Last reviewed commit: ["Harden historical snapshot filter"](https://github.com/shimizu-technology/fd-alumni-hub/commit/8720f860f4d781114c927c06054a79389496506d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40334645)</sub>

<!-- /greptile_comment -->