### PR TITLE
Add admin class coverage board

### DIFF
--- a/api/app/controllers/api/v1/admin/teams_controller.rb
+++ b/api/app/controllers/api/v1/admin/teams_controller.rb
@@ -14,12 +14,20 @@ module Api
           class_cohort_keys = attrs.delete(:class_cohort_keys)
           team = admin_tournament.teams.build(attrs.except(:tournament_id))
 
-          if team.save
+          Team.transaction do
+            unless team.save
+              render_errors(team)
+              raise ActiveRecord::Rollback
+            end
+
             sync_manual_memberships(team, class_cohort_keys) if class_cohort_keys.present?
-            render json: { team: team_for_response(team.id).api_json(include_roster: true) }, status: :created
-          else
-            render_errors(team)
           end
+          return if performed?
+
+          render json: { team: team_for_response(team.id).api_json(include_roster: true) }, status: :created
+        rescue ClassArchive::SyncManualTeamMemberships::ConflictError => error
+          team.errors.add(:base, error.message)
+          render_errors(team)
         end
 
         def update
@@ -29,12 +37,20 @@ module Api
           class_cohort_keys = attrs.delete(:class_cohort_keys)
           class_cohort_keys_changed = attrs.delete(:class_cohort_keys_changed)
 
-          if team.update(attrs.except(:tournament_id))
+          Team.transaction do
+            unless team.update(attrs.except(:tournament_id))
+              render_errors(team)
+              raise ActiveRecord::Rollback
+            end
+
             sync_manual_memberships(team, class_cohort_keys) if manual_class_cohort_update?(class_cohort_keys, class_cohort_keys_changed)
-            render json: { team: team_for_response(team.id).api_json(include_roster: true) }
-          else
-            render_errors(team)
           end
+          return if performed?
+
+          render json: { team: team_for_response(team.id).api_json(include_roster: true) }
+        rescue ClassArchive::SyncManualTeamMemberships::ConflictError => error
+          team.errors.add(:base, error.message)
+          render_errors(team)
         end
 
         def destroy

--- a/api/app/services/class_archive/sync_manual_team_memberships.rb
+++ b/api/app/services/class_archive/sync_manual_team_memberships.rb
@@ -2,6 +2,29 @@ module ClassArchive
   class SyncManualTeamMemberships
     MANUAL_SOURCE = "manual".freeze
 
+    class ConflictError < StandardError
+      attr_reader :conflicts
+
+      def initialize(conflicts)
+        @conflicts = conflicts
+        super(build_message(conflicts))
+      end
+
+      private
+
+      def build_message(conflicts)
+        return "Class is already assigned to another team in this tournament." if conflicts.empty?
+
+        grouped = conflicts.group_by(&:class_cohort)
+        details = grouped.map do |cohort, memberships|
+          team_names = memberships.map { |membership| membership.team.display_name }.uniq.to_sentence
+          "#{cohort.display_name} is already assigned to #{team_names}"
+        end
+
+        "#{details.to_sentence}. Remove the class from the existing team before assigning it here."
+      end
+    end
+
     def self.call(team, class_keys:)
       new(team, class_keys: class_keys).call
     end
@@ -16,6 +39,8 @@ module ClassArchive
 
       cohorts = resolved_cohorts
       cohort_ids = cohorts.map(&:id)
+      conflicts = conflicting_memberships(cohort_ids)
+      raise ConflictError.new(conflicts) if conflicts.any?
 
       TeamClassMembership.transaction do
         team.team_class_memberships.where.not(class_cohort_id: cohort_ids).delete_all
@@ -41,6 +66,16 @@ module ClassArchive
 
     def resolved_cohorts
       class_keys.flat_map { |value| ClassArchive::Resolver.resolve_cohorts(value) }.uniq(&:id)
+    end
+
+    def conflicting_memberships(cohort_ids)
+      return [] if cohort_ids.empty? || team.tournament_id.blank?
+
+      TeamClassMembership.includes(:team, :class_cohort)
+        .joins(:team)
+        .where(class_cohort_id: cohort_ids, teams: { tournament_id: team.tournament_id })
+        .where.not(team_id: team.id)
+        .to_a
     end
   end
 end

--- a/api/app/services/class_archive/sync_manual_team_memberships.rb
+++ b/api/app/services/class_archive/sync_manual_team_memberships.rb
@@ -13,8 +13,6 @@ module ClassArchive
       private
 
       def build_message(conflicts)
-        return "Class is already assigned to another team in this tournament." if conflicts.empty?
-
         grouped = conflicts.group_by(&:class_cohort)
         details = grouped.map do |cohort, memberships|
           team_names = memberships.map { |membership| membership.team.display_name }.uniq.to_sentence

--- a/api/test/controllers/admin_teams_controller_test.rb
+++ b/api/test/controllers/admin_teams_controller_test.rb
@@ -101,6 +101,54 @@ class AdminTeamsControllerTest < ActionDispatch::IntegrationTest
     assert_empty @team.reload.class_cohorts
   end
 
+  test "manual represented classes must be unique within a tournament" do
+    other_team = @tournament.teams.create!(class_year_label: "12 Pack", display_name: "12 Pack", division: "Maroon")
+    ClassArchive::SyncManualTeamMemberships.call(other_team, class_keys: %w[12 17])
+
+    patch "/api/v1/admin/teams/#{@team.id}",
+      params: { team: { classCohortKeys: %w[16 17], classCohortKeysChanged: true } },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "Class of 2017 is already assigned to 12 Pack"
+    assert_equal [ 2016 ], @team.reload.class_cohorts.map(&:graduation_year)
+  end
+
+  test "same represented class can be used in a different tournament" do
+    other_tournament = Tournament.create!(
+      name: "FD Alumni Basketball Tournament",
+      year: 2027,
+      start_date: Date.new(2027, 7, 3),
+      end_date: Date.new(2027, 7, 24),
+      status: "upcoming"
+    )
+    other_tournament.teams.create!(class_year_label: "12 Pack", display_name: "12 Pack", division: "Maroon")
+
+    patch "/api/v1/admin/teams/#{@team.id}",
+      params: { tournamentId: @tournament.id, team: { classCohortKeys: %w[16 17], classCohortKeysChanged: true } },
+      headers: auth_headers,
+      as: :json
+
+    assert_response :success
+    assert_equal [ 2016, 2017 ], @team.reload.class_cohorts.order(:graduation_year).map(&:graduation_year)
+  end
+
+  test "conflicting represented class create rolls back the team" do
+    other_team = @tournament.teams.create!(class_year_label: "12 Pack", display_name: "12 Pack", division: "Maroon")
+    ClassArchive::SyncManualTeamMemberships.call(other_team, class_keys: %w[12 17])
+
+    assert_no_difference -> { Team.count } do
+      post "/api/v1/admin/teams",
+        params: { tournamentId: @tournament.id, team: { classYearLabel: "2017", displayName: "Class of 2017", classCohortKeys: %w[17] } },
+        headers: auth_headers,
+        as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes JSON.parse(response.body)["errors"].join, "Class of 2017 is already assigned to 12 Pack"
+  end
+
   test "class cohort master list is available to admins" do
     ClassArchive::Resolver.resolve_cohorts("AD7")
 

--- a/api/test/controllers/admin_teams_controller_test.rb
+++ b/api/test/controllers/admin_teams_controller_test.rb
@@ -123,7 +123,9 @@ class AdminTeamsControllerTest < ActionDispatch::IntegrationTest
       end_date: Date.new(2027, 7, 24),
       status: "upcoming"
     )
-    other_tournament.teams.create!(class_year_label: "12 Pack", display_name: "12 Pack", division: "Maroon")
+    other_team = other_tournament.teams.create!(class_year_label: "12 Pack", display_name: "12 Pack", division: "Maroon")
+    ClassArchive::SyncManualTeamMemberships.call(other_team, class_keys: %w[12 17])
+    assert_equal [ 2012, 2017 ], other_team.reload.class_cohorts.order(:graduation_year).map(&:graduation_year)
 
     patch "/api/v1/admin/teams/#{@team.id}",
       params: { tournamentId: @tournament.id, team: { classCohortKeys: %w[16 17], classCohortKeysChanged: true } },

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -11,6 +11,14 @@ import { EmptyState, ErrorState, Field, FormGrid, LoadingState, PageHeader, Pane
 
 const legacyPrefix = 'legacy:'
 type TeamSortOption = 'display' | 'class' | 'division' | 'roster'
+type CoverageFilter = 'all' | 'assigned' | 'open' | 'conflict'
+type ClassAssignmentStatus = 'assigned' | 'open' | 'conflict'
+type ClassAssignment = {
+  option: ClassCohortOption
+  teams: Team[]
+  status: ClassAssignmentStatus
+}
+type ClassAssignmentIndex = Map<string, Team[]>
 
 export function AdminDivisionsPage() {
   const [tournamentId, setTournamentId] = useTournamentSelection()
@@ -41,6 +49,9 @@ export function AdminDivisionsPage() {
     const knownCohorts = mergeClassCohorts(classCohorts, teams.flatMap((team) => team.classCohorts || []))
     return classCohortOptions(knownCohorts, tournament?.year || new Date().getFullYear())
   }, [classCohorts, teams, tournament?.year])
+  const coverageOptions = useMemo(() => coverageClassOptions(classOptions, tournament?.year), [classOptions, tournament?.year])
+  const classAssignmentIndex = useMemo(() => buildClassAssignmentIndex(teams), [teams])
+  const classAssignments = useMemo(() => buildClassAssignments(coverageOptions, classAssignmentIndex), [coverageOptions, classAssignmentIndex])
   const divisionOptions = useMemo(() => availableDivisionOptions(teams, divisions), [teams, divisions])
   const visibleTeams = useMemo(() => filterAndSortTeams(teams, teamQuery, divisionFilter, teamSort), [teams, teamQuery, divisionFilter, teamSort])
 
@@ -57,7 +68,8 @@ export function AdminDivisionsPage() {
       />
       <TournamentFilter tournaments={tournaments} value={tournament?.id || ''} onChange={setTournamentId} />
       <DivisionSettingsPanel tournament={tournament} divisions={divisions} allDivisions={allDivisions} onSaved={reload} />
-      <CreateTeamPanel tournament={tournament} teamsCount={teams.length} divisions={divisions} classOptions={classOptions} onSaved={reload} />
+      <CreateTeamPanel tournament={tournament} teamsCount={teams.length} divisions={divisions} classOptions={classOptions} classAssignmentIndex={classAssignmentIndex} onSaved={reload} />
+      <ClassCoverageBoard tournament={tournament} assignments={classAssignments} />
       <Panel>
         <div className="section-heading">
           <div>
@@ -77,7 +89,7 @@ export function AdminDivisionsPage() {
         />
         {!teams.length ? <EmptyState title="No teams found" description="Add the teams that are playing in this tournament before building the schedule." /> : null}
         {teams.length > 0 && !visibleTeams.length ? <EmptyState title="No teams match those filters" description="Clear the search or division filter to see more teams." /> : null}
-        {visibleTeams.length > 0 && <div className="admin-list team-card-list">{visibleTeams.map((team) => <EditableTeam key={team.id} team={team} divisions={divisions} classOptions={classOptions} onSaved={reload} />)}</div>}
+        {visibleTeams.length > 0 && <div className="admin-list team-card-list">{visibleTeams.map((team) => <EditableTeam key={team.id} team={team} divisions={divisions} classOptions={classOptions} classAssignmentIndex={classAssignmentIndex} onSaved={reload} />)}</div>}
       </Panel>
     </div>
   )
@@ -194,7 +206,7 @@ function EditableDivision({ division, onSaved }: { division: Division; onSaved: 
   )
 }
 
-function CreateTeamPanel({ tournament, teamsCount, divisions, classOptions, onSaved }: { tournament: Tournament | null; teamsCount: number; divisions: Division[]; classOptions: ClassCohortOption[]; onSaved: () => Promise<void> }) {
+function CreateTeamPanel({ tournament, teamsCount, divisions, classOptions, classAssignmentIndex, onSaved }: { tournament: Tournament | null; teamsCount: number; divisions: Division[]; classOptions: ClassCohortOption[]; classAssignmentIndex: ClassAssignmentIndex; onSaved: () => Promise<void> }) {
   const [form, setForm] = useState<{ classYearLabel: string; displayName: string; divisionId: string; classCohortKeys: string[] }>({ classYearLabel: '', displayName: '', divisionId: '', classCohortKeys: [] })
   const [message, setMessage] = useState('')
   const [saving, setSaving] = useState(false)
@@ -261,6 +273,7 @@ function CreateTeamPanel({ tournament, teamsCount, divisions, classOptions, onSa
             <ClassCohortPicker
               selectedKeys={form.classCohortKeys}
               options={classOptions}
+              assignmentIndex={classAssignmentIndex}
               onChange={(classCohortKeys) => setForm({ ...form, classCohortKeys })}
               help="Optional on create. If left blank, the hub will infer represented classes from known aliases and numeric labels."
             />
@@ -269,6 +282,86 @@ function CreateTeamPanel({ tournament, teamsCount, divisions, classOptions, onSa
         </div>
       ))}
     </Panel>
+  )
+}
+
+function ClassCoverageBoard({ tournament, assignments }: { tournament: Tournament | null; assignments: ClassAssignment[] }) {
+  const [filter, setFilter] = useState<CoverageFilter>('all')
+  const [query, setQuery] = useState('')
+  const counts = useMemo(() => coverageCounts(assignments), [assignments])
+  const visibleAssignments = useMemo(() => filterClassAssignments(assignments, filter, query), [assignments, filter, query])
+
+  if (!tournament) return null
+
+  return (
+    <Panel className="class-coverage-panel">
+      <div className="section-heading class-coverage-heading">
+        <div>
+          <h2>Class coverage board</h2>
+          <p className="muted">Verify which tournament team each graduating class rolls up to for {tournament.year}. One class should map to one team entry per tournament.</p>
+        </div>
+        <span>{counts.assigned} of {counts.total} mapped</span>
+      </div>
+
+      <div className="class-coverage-metrics" aria-label="Class coverage summary">
+        <button type="button" className={filter === 'assigned' ? 'selected' : ''} onClick={() => setFilter('assigned')}>
+          <span>Mapped</span>
+          <strong>{counts.assigned}</strong>
+        </button>
+        <button type="button" className={filter === 'open' ? 'selected' : ''} onClick={() => setFilter('open')}>
+          <span>Open</span>
+          <strong>{counts.open}</strong>
+        </button>
+        <button type="button" className={filter === 'conflict' ? 'selected danger' : 'danger'} onClick={() => setFilter('conflict')}>
+          <span>Conflicts</span>
+          <strong>{counts.conflict}</strong>
+        </button>
+      </div>
+
+      <div className="class-coverage-toolbar toolbar-panel">
+        <label>
+          <span>Search classes</span>
+          <input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Class year or team name" />
+        </label>
+        <div className="coverage-filter-buttons" role="group" aria-label="Filter class coverage rows">
+          <button type="button" className={filter === 'all' ? 'selected' : ''} onClick={() => setFilter('all')}>All</button>
+          <button type="button" className={filter === 'assigned' ? 'selected' : ''} onClick={() => setFilter('assigned')}>Mapped</button>
+          <button type="button" className={filter === 'open' ? 'selected' : ''} onClick={() => setFilter('open')}>Open</button>
+          <button type="button" className={filter === 'conflict' ? 'selected' : ''} onClick={() => setFilter('conflict')}>Conflicts</button>
+        </div>
+      </div>
+
+      <p className="field-help class-coverage-guidance">If a class moves to a different team next year, keep this tournament's mapping as-is and update the new tournament only. To move a class inside this tournament, remove it from the current team first, then add it to the new team.</p>
+
+      {visibleAssignments.length ? (
+        <div className="class-coverage-list" role="list" aria-label={`${tournament.year} class coverage`}>
+          {visibleAssignments.map((assignment) => <ClassCoverageRow key={assignment.option.key} assignment={assignment} />)}
+        </div>
+      ) : <EmptyState title="No class coverage rows match" description="Clear the search or switch filters to review the full class map." />}
+    </Panel>
+  )
+}
+
+function ClassCoverageRow({ assignment }: { assignment: ClassAssignment }) {
+  const { option, teams, status } = assignment
+  const statusLabel = status === 'conflict' ? 'Conflict' : status === 'assigned' ? 'Mapped' : 'Open'
+
+  return (
+    <div className={`class-coverage-row ${status}`} role="listitem">
+      <div className="class-coverage-class">
+        <span>{option.shortLabel}</span>
+        <strong>{option.displayName}</strong>
+      </div>
+      <div className="class-coverage-team">
+        <span>{statusLabel}</span>
+        {teams.length ? (
+          <div className="class-coverage-team-links">
+            {teams.map((team) => <a key={team.id} href={`#team-${team.id}`}>{team.displayName}</a>)}
+          </div>
+        ) : <strong>Not mapped yet</strong>}
+      </div>
+      <small>{coverageRowHelp(assignment)}</small>
+    </div>
   )
 }
 
@@ -282,12 +375,14 @@ function TeamToolbar({ query, division, sort, divisions, onQueryChange, onDivisi
   )
 }
 
-function ClassCohortPicker({ selectedKeys, options, onChange, help }: { selectedKeys: string[]; options: ClassCohortOption[]; onChange: (keys: string[]) => void; help?: string }) {
+function ClassCohortPicker({ selectedKeys, options, assignmentIndex, currentTeamId, onChange, help }: { selectedKeys: string[]; options: ClassCohortOption[]; assignmentIndex: ClassAssignmentIndex; currentTeamId?: string; onChange: (keys: string[]) => void; help?: string }) {
   const selectedOptions = selectedKeys.map((key) => classOptionForKey(key, options)).sort((a, b) => a.graduationYear - b.graduationYear)
   const availableOptions = options.filter((option) => !selectedKeys.includes(option.key))
+  const selectedConflicts = selectedOptions.flatMap((option) => assignmentConflictsForKey(option.key, assignmentIndex, currentTeamId).map((team) => ({ option, team })))
 
   const addClass = (key: string) => {
     if (!key || selectedKeys.includes(key)) return
+    if (assignmentConflictsForKey(key, assignmentIndex, currentTeamId).length) return
     onChange([...selectedKeys, key].sort((a, b) => (graduationYearForSort(a) || 0) - (graduationYearForSort(b) || 0)))
   }
 
@@ -302,14 +397,21 @@ function ClassCohortPicker({ selectedKeys, options, onChange, help }: { selected
         </div>
         <select value="" onChange={(event) => addClass(event.target.value)} aria-label="Add represented class">
           <option value="">Add class year</option>
-          {availableOptions.map((option) => <option key={option.key} value={option.key}>{option.displayName}</option>)}
+          {availableOptions.map((option) => {
+            const conflicts = assignmentConflictsForKey(option.key, assignmentIndex, currentTeamId)
+            return <option key={option.key} value={option.key} disabled={conflicts.length > 0}>{classPickerOptionLabel(option, conflicts)}</option>
+          })}
         </select>
       </div>
       {selectedOptions.length > 0 ? (
         <div className="class-chip-row class-editor-chip-row" aria-label="Selected represented classes">
-          {selectedOptions.map((option) => <button key={option.key} type="button" onClick={() => removeClass(option.key)}>{option.displayName}<span>Remove</span></button>)}
+          {selectedOptions.map((option) => {
+            const conflicts = assignmentConflictsForKey(option.key, assignmentIndex, currentTeamId)
+            return <button key={option.key} className={conflicts.length ? 'conflict' : ''} type="button" onClick={() => removeClass(option.key)}>{option.displayName}<span>{conflicts.length ? 'Conflict' : 'Remove'}</span></button>
+          })}
         </div>
       ) : <p className="form-note">No explicit represented classes selected.</p>}
+      {selectedConflicts.length > 0 && <p className="form-error" role="alert">{classSelectionConflictMessage(selectedConflicts)}</p>}
       {help && <p className="field-help">{help}</p>}
     </div>
   )
@@ -326,7 +428,7 @@ function RepresentationSummary({ team }: { team: Team }) {
   )
 }
 
-function EditableTeam({ team, divisions, classOptions, onSaved }: { team: Team; divisions: Division[]; classOptions: ClassCohortOption[]; onSaved: () => Promise<void> }) {
+function EditableTeam({ team, divisions, classOptions, classAssignmentIndex, onSaved }: { team: Team; divisions: Division[]; classOptions: ClassCohortOption[]; classAssignmentIndex: ClassAssignmentIndex; onSaved: () => Promise<void> }) {
   const [form, setForm] = useState(teamFormState(team, divisions))
   const [editing, setEditing] = useState(false)
   const [saving, setSaving] = useState(false)
@@ -383,7 +485,7 @@ function EditableTeam({ team, divisions, classOptions, onSaved }: { team: Team; 
   }
 
   return (
-    <article className="admin-row-card team-admin-card team-summary-card">
+    <article className="admin-row-card team-admin-card team-summary-card" id={`team-${team.id}`}>
       <div className="team-card-header">
         <div>
           <span className="team-card-kicker">{team.division || 'No division'}</span>
@@ -406,6 +508,8 @@ function EditableTeam({ team, divisions, classOptions, onSaved }: { team: Team; 
           <ClassCohortPicker
             selectedKeys={form.classCohortKeys}
             options={classOptions}
+            assignmentIndex={classAssignmentIndex}
+            currentTeamId={team.id}
             onChange={(classCohortKeys) => setForm({ ...form, classCohortKeys })}
             help="These classes receive this team entry's games, record, and title credits for this tournament."
           />
@@ -758,6 +862,93 @@ function classOptionForKey(key: string, options: ClassCohortOption[]) {
 
 function graduationYearForSort(key: string) {
   return graduationYearForClassKey(key)
+}
+
+function coverageClassOptions(options: ClassCohortOption[], tournamentYear?: number | null) {
+  const lastYear = tournamentYear || new Date().getFullYear()
+  return options
+    .filter((option) => option.graduationYear >= 1974 && option.graduationYear <= lastYear)
+    .sort((a, b) => b.graduationYear - a.graduationYear)
+}
+
+function buildClassAssignmentIndex(teams: Team[]): ClassAssignmentIndex {
+  const index: ClassAssignmentIndex = new Map()
+  teams.forEach((team) => {
+    sortedClassCohorts(team.classCohorts || []).forEach((cohort) => {
+      const assignedTeams = index.get(cohort.key) || []
+      if (!assignedTeams.some((existing) => existing.id === team.id)) assignedTeams.push(team)
+      index.set(cohort.key, assignedTeams.sort((a, b) => a.displayName.localeCompare(b.displayName, undefined, { numeric: true })))
+    })
+  })
+  return index
+}
+
+function buildClassAssignments(options: ClassCohortOption[], assignmentIndex: ClassAssignmentIndex): ClassAssignment[] {
+  return options.map((option) => {
+    const teams = assignmentIndex.get(option.key) || []
+    return {
+      option,
+      teams,
+      status: classAssignmentStatus(teams),
+    }
+  })
+}
+
+function classAssignmentStatus(teams: Team[]): ClassAssignmentStatus {
+  if (teams.length > 1) return 'conflict'
+  if (teams.length === 1) return 'assigned'
+  return 'open'
+}
+
+function coverageCounts(assignments: ClassAssignment[]) {
+  return assignments.reduce((counts, assignment) => {
+    counts.total += 1
+    counts[assignment.status] += 1
+    return counts
+  }, { total: 0, assigned: 0, open: 0, conflict: 0 })
+}
+
+function filterClassAssignments(assignments: ClassAssignment[], filter: CoverageFilter, query: string) {
+  const normalizedQuery = query.trim().toLowerCase()
+  return assignments.filter((assignment) => {
+    const matchesFilter = filter === 'all' || assignment.status === filter
+    const searchable = [ assignment.option.displayName, assignment.option.shortLabel, ...assignment.teams.map((team) => team.displayName) ].join(' ').toLowerCase()
+    const matchesQuery = !normalizedQuery || searchable.includes(normalizedQuery)
+    return matchesFilter && matchesQuery
+  })
+}
+
+function coverageRowHelp(assignment: ClassAssignment) {
+  if (assignment.status === 'conflict') return 'Needs verification. Remove this class from all but one team entry for this tournament.'
+  if (assignment.status === 'assigned') return `Games and standings roll up to ${assignment.teams[0].displayName}.`
+  return 'No team entry currently represents this class in this tournament.'
+}
+
+function assignmentConflictsForKey(key: string, assignmentIndex: ClassAssignmentIndex, currentTeamId?: string) {
+  return (assignmentIndex.get(key) || []).filter((team) => team.id !== currentTeamId)
+}
+
+function classPickerOptionLabel(option: ClassCohortOption, conflicts: Team[]) {
+  if (!conflicts.length) return option.displayName
+  return `${option.displayName} — assigned to ${joinHumanList(conflicts.map((team) => team.displayName))}`
+}
+
+function classSelectionConflictMessage(conflicts: Array<{ option: ClassCohortOption; team: Team }>) {
+  const grouped = new Map<string, { option: ClassCohortOption; teams: Team[] }>()
+  conflicts.forEach(({ option, team }) => {
+    const entry = grouped.get(option.key) || { option, teams: [] }
+    if (!entry.teams.some((existing) => existing.id === team.id)) entry.teams.push(team)
+    grouped.set(option.key, entry)
+  })
+
+  const details = Array.from(grouped.values()).map(({ option, teams }) => `${option.displayName} is already assigned to ${joinHumanList(teams.map((team) => team.displayName))}`)
+  return `${joinHumanList(details)}. Remove the class from the existing team before assigning it here.`
+}
+
+function joinHumanList(values: string[]) {
+  if (values.length <= 1) return values[0] || ''
+  if (values.length === 2) return `${values[0]} and ${values[1]}`
+  return `${values.slice(0, -1).join(', ')}, and ${values[values.length - 1]}`
 }
 
 function availableDivisionOptions(teams: Team[], divisions: Division[]) {

--- a/web/src/pages/admin/AdminDivisionsPage.tsx
+++ b/web/src/pages/admin/AdminDivisionsPage.tsx
@@ -69,7 +69,7 @@ export function AdminDivisionsPage() {
       <TournamentFilter tournaments={tournaments} value={tournament?.id || ''} onChange={setTournamentId} />
       <DivisionSettingsPanel tournament={tournament} divisions={divisions} allDivisions={allDivisions} onSaved={reload} />
       <CreateTeamPanel tournament={tournament} teamsCount={teams.length} divisions={divisions} classOptions={classOptions} classAssignmentIndex={classAssignmentIndex} onSaved={reload} />
-      <ClassCoverageBoard tournament={tournament} assignments={classAssignments} />
+      <ClassCoverageBoard key={tournament?.id || 'no-tournament'} tournament={tournament} assignments={classAssignments} />
       <Panel>
         <div className="section-heading">
           <div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -435,6 +435,32 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .team-card-list, .game-admin-list { margin-top: 1rem; }
 .team-toolbar, .game-toolbar { margin-bottom: 1rem; padding: .8rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--surface-strong); }
 .team-toolbar label:first-child, .game-toolbar label:first-child { flex: 1 1 18rem; }
+.class-coverage-panel { overflow: hidden; background: linear-gradient(135deg, #fffdf9, #fff7e6); }
+.class-coverage-heading { align-items: flex-start; }
+.class-coverage-heading p { max-width: 55rem; margin: .25rem 0 0; line-height: 1.45; }
+.class-coverage-metrics { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .65rem; margin-bottom: .8rem; }
+.class-coverage-metrics button { display: grid; gap: .15rem; text-align: left; border: 1px solid rgba(111,29,53,.14); border-radius: 1rem; background: rgba(255,255,255,.74); color: var(--ink); padding: .85rem; cursor: pointer; transition: transform .16s ease, border-color .16s ease, background .16s ease; }
+.class-coverage-metrics button:hover, .class-coverage-metrics button.selected { transform: translateY(-1px); border-color: rgba(111,29,53,.36); background: #fff; }
+.class-coverage-metrics button.danger strong { color: var(--danger); }
+.class-coverage-metrics span, .class-coverage-row span, .class-coverage-team span { color: var(--fd-maroon); font-size: .72rem; font-weight: 950; letter-spacing: .09em; text-transform: uppercase; }
+.class-coverage-metrics strong { font-size: clamp(1.5rem, 3vw, 2.15rem); line-height: .95; letter-spacing: -.055em; }
+.class-coverage-toolbar { margin-bottom: .65rem; padding: .75rem; border: 1px solid rgba(111,29,53,.12); border-radius: 1rem; background: rgba(255,255,255,.72); }
+.class-coverage-toolbar label { flex: 1 1 18rem; }
+.coverage-filter-buttons { display: flex; flex-wrap: wrap; gap: .4rem; align-items: end; }
+.coverage-filter-buttons button { min-height: 2.35rem; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--fd-maroon); padding: .45rem .7rem; font-weight: 900; cursor: pointer; }
+.coverage-filter-buttons button.selected { background: var(--fd-maroon); border-color: var(--fd-maroon); color: #fff; }
+.class-coverage-guidance { margin: .15rem 0 .75rem; }
+.class-coverage-list { max-height: 26rem; overflow: auto; display: grid; gap: .5rem; padding-right: .15rem; }
+.class-coverage-row { display: grid; grid-template-columns: minmax(10rem, .85fr) minmax(12rem, 1fr) minmax(16rem, 1.25fr); gap: .75rem; align-items: center; padding: .8rem; border: 1px solid var(--line); border-radius: 1rem; background: rgba(255,255,255,.86); }
+.class-coverage-row.conflict { border-color: rgba(165,34,34,.32); background: #fff6f4; }
+.class-coverage-row.open { border-style: dashed; background: rgba(255,255,255,.56); }
+.class-coverage-class { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: .55rem; align-items: center; min-width: 0; }
+.class-coverage-class > span { display: grid; place-items: center; min-width: 2.8rem; min-height: 2.25rem; border-radius: .75rem; background: var(--fd-maroon-50); }
+.class-coverage-class strong, .class-coverage-team strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.class-coverage-team { min-width: 0; display: grid; gap: .25rem; }
+.class-coverage-team-links { display: flex; flex-wrap: wrap; gap: .35rem; }
+.class-coverage-team-links a { max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; border: 1px solid rgba(111,29,53,.18); border-radius: 999px; background: #fff; color: var(--fd-maroon); padding: .28rem .55rem; font-weight: 900; }
+.class-coverage-row small { color: var(--muted); font-weight: 750; line-height: 1.35; }
 .admin-create-panel .collapsible-heading { margin-bottom: 0; }
 .bulk-link-panel { background: linear-gradient(135deg, #fff, #fff8ea); }
 .bulk-ticket-actions { display: grid; grid-template-columns: minmax(16rem, 1fr) auto; gap: .8rem; align-items: end; }
@@ -492,6 +518,8 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .class-membership-head span { display: block; color: var(--muted); font-size: .72rem; font-weight: 950; letter-spacing: .08em; text-transform: uppercase; }
 .class-membership-head strong { display: block; margin-top: .15rem; line-height: 1.25; }
 .class-editor-chip-row button:hover { border-color: rgba(111,29,53,.35); background: var(--fd-maroon-50); }
+.class-editor-chip-row button.conflict { border-color: rgba(165,34,34,.35); background: #fff6f4; color: var(--danger); }
+.class-editor-chip-row button.conflict span { color: var(--danger); }
 .team-facts-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .7rem; }
 .team-facts-grid div { min-width: 0; padding: .85rem; border: 1px solid var(--line); border-radius: .95rem; background: var(--surface-strong); }
 .team-facts-grid span { display: block; color: var(--muted); font-size: .72rem; font-weight: 900; letter-spacing: .08em; text-transform: uppercase; }
@@ -715,6 +743,14 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .admin-row-head { align-items: flex-start; }
   .prediction-admin-controls { justify-content: flex-start; }
   .row-actions .btn, .game-actions .btn { width: 100%; }
+  .class-coverage-heading { display: grid; }
+  .class-coverage-metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .45rem; }
+  .class-coverage-metrics button { padding: .65rem; }
+  .class-coverage-toolbar { display: grid; }
+  .coverage-filter-buttons { width: 100%; }
+  .coverage-filter-buttons button { flex: 1 1 auto; }
+  .class-coverage-row { grid-template-columns: 1fr; align-items: start; gap: .45rem; }
+  .class-coverage-list { max-height: 32rem; }
   .class-membership-head, .game-detail-summary, .score-entry-panel .form-grid, .team-facts-grid, .tournament-media-preview { grid-template-columns: 1fr; }
   .compact-admin-row, .media-admin-row, .sponsor-admin-row { grid-template-columns: 1fr; }
   .compact-admin-row .form-grid, .media-admin-row .form-grid, .sponsor-admin-row .form-grid, .media-admin-row .row-actions, .sponsor-admin-row .row-actions, .media-admin-row .form-error, .sponsor-admin-row .form-error { grid-column: auto; }


### PR DESCRIPTION
## Summary
- Adds an admin Class coverage board above Teams to verify each graduating class and the tournament team entry it rolls up to
- Shows mapped/open/conflict counts, searchable/filterable class rows, and team anchors for quick cleanup
- Disables already-assigned class options in the represented-class picker and surfaces conflict messages when editing mappings
- Enforces manual represented-class uniqueness per tournament in the Rails admin team create/update flow, with rollback on conflicts

## Validation
- `./scripts/gate.sh`

## Notes
- The uniqueness guard is scoped to the selected tournament, so a class can be with one team in 2026 and a different team in 2027.
- Existing auto-imported duplicate mappings are shown as conflicts in the board instead of being silently removed, so admins can verify and resolve them deliberately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an admin class coverage board that surfaces which graduating class maps to which tournament team, with searchable/filterable rows, conflict highlighting, and anchor links to team cards. It also enforces uniqueness of represented classes per tournament by raising a `ConflictError` inside a `Team.transaction` so both the team record and any membership writes are atomically rolled back on conflict.

- **Backend:** `SyncManualTeamMemberships` gains a scoped `conflicting_memberships` query (filtered by `tournament_id`) and a `ConflictError` whose message is built from eagerly-loaded associations before the rollback; the controller catches it at method scope via a standard `rescue` clause, letting Rails roll back the outer transaction automatically.
- **Frontend:** `ClassCoverageBoard` computes assignment status (assigned / open / conflict) entirely client-side from the existing `teams` response, avoiding extra API calls; `ClassCohortPicker` disables already-assigned options in the dropdown and shows an inline conflict banner for legacy duplicates.
- **Tests:** Three new integration tests cover conflict-on-update, cross-tournament permissibility, and rollback-on-create; the cross-tournament test now explicitly syncs memberships for the other tournament's team, making the scope guard meaningful.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the rollback and conflict-detection logic is correct, and all three new test cases exercise the meaningful paths.

The ConflictError is a plain StandardError raised inside Team.transaction, which causes Rails to roll back the transaction and re-raise; the method-level rescue then catches it cleanly. Associations are eagerly loaded before the raise, so the error message is assembled from in-memory objects and is safe after rollback. The conflicting_memberships query correctly scopes to the same tournament_id and excludes the current team. The client-side ClassAssignmentIndex mirrors this scoping. No data-loss or double-render path was found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| api/app/controllers/api/v1/admin/teams_controller.rb | Wraps create/update in Team.transaction, catches ConflictError at method level to ensure rollback on class conflict — flow is correct and tests cover it. |
| api/app/services/class_archive/sync_manual_team_memberships.rb | Adds ConflictError and a pre-transaction scoped conflict query; associations are eagerly loaded so message building is safe after rollback. |
| api/test/controllers/admin_teams_controller_test.rb | Three new tests cover conflict-on-update, cross-tournament safety, and rollback-on-conflict-create; cross-tournament test now calls SyncManualTeamMemberships for the other_tournament team, making scoping meaningful. |
| web/src/pages/admin/AdminDivisionsPage.tsx | Adds ClassCoverageBoard, updates ClassCohortPicker with conflict-aware disabled options and inline error messaging, correctly handles create (no currentTeamId) vs edit (with currentTeamId) cases. |
| web/src/styles.css | Adds scoped styles for the coverage board panel, metric tiles, filter toolbar, and conflict chip row; includes responsive overrides for mobile layout. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `api/test/controllers/admin_teams_controller_test.rb`, line 136-135 ([link](https://github.com/shimizu-technology/fd-alumni-hub/blob/4772ab0e659b95a0b23be3277a79ae5791a96e8a/api/test/controllers/admin_teams_controller_test.rb#L136-L135)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Cross-tournament scoping test doesn't set up conflicting memberships**

   The test creates a team in `other_tournament` with `class_year_label: "12 Pack"` but never calls `SyncManualTeamMemberships.call` for that team. Without explicit memberships for class 2016 or 2017 on the other-tournament's team, the conflict check finds nothing regardless of tournament scoping, and the test passes trivially. To validate that the `tournament_id` scope in `conflicting_memberships` actually allows the same class across tournaments, the setup needs to assign class 17 to a team in `other_tournament` first.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: api/test/controllers/admin_teams_controller_test.rb
   Line: 136-135

   Comment:
   **Cross-tournament scoping test doesn't set up conflicting memberships**

   The test creates a team in `other_tournament` with `class_year_label: "12 Pack"` but never calls `SyncManualTeamMemberships.call` for that team. Without explicit memberships for class 2016 or 2017 on the other-tournament's team, the conflict check finds nothing regardless of tournament scoping, and the test passes trivially. To validate that the `tournament_id` scope in `conflicting_memberships` actually allows the same class across tournaments, the setup needs to assign class 17 to a team in `other_tournament` first.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["Reset class coverage state by tournament"](https://github.com/shimizu-technology/fd-alumni-hub/commit/fb7a782c915d8b64ba9f0b72a0012a3e2ee2b25c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40417475)</sub>

<!-- /greptile_comment -->