### PR TITLE
Preserve FD Alumni history in a static archive

### DIFF
--- a/api/Gemfile.lock
+++ b/api/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    json (2.19.8)
+    json (2.20.0)
     jwt (3.2.0)
       base64
     kamal (2.11.0)
@@ -347,7 +347,7 @@ GEM
     unicode-emoji (4.2.0)
     uri (1.1.1)
     useragent (0.16.11)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -437,7 +437,7 @@ CHECKSUMS
   image_processing (1.14.0) sha256=754cc169c9c262980889bec6bfd325ed1dafad34f85242b5a07b60af004742fb
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
-  json (2.19.8) sha256=6354310fd76ef69b87d5bd1f38b40d730613baf90b6803d2d0a48f618d32dfaa
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
@@ -524,7 +524,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
-  websocket-driver (0.8.1) sha256=5ab238238ce230e5d4b262d2be39624c867914eab99171dc4952b58b577c2d96
+  websocket-driver (0.8.2) sha256=97c556b019bf3410b4961002ac501621e9322d3f8a7bc02161a09301cc4c4146
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   zeitwerk (2.8.2) sha256=7212a61311083c604184b1ea2574b9aa05cd14f855a0841c06985cabe9181d12
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -3,8 +3,6 @@ VITE_SITE_URL=https://fd-alumni-tourney.netlify.app
 
 # Rails API base. Include /api/v1.
 VITE_API_BASE_URL=http://localhost:3001/api/v1
-# 'live' enables the full tournament hub; 'archive' serves the static history page.
-VITE_SERVICE_MODE=archive
 
 # Clerk auth for admin routes.
 VITE_CLERK_PUBLISHABLE_KEY=

--- a/web/.env.example
+++ b/web/.env.example
@@ -3,6 +3,7 @@ VITE_SITE_URL=https://fd-alumni-tourney.netlify.app
 
 # Rails API base. Include /api/v1.
 VITE_API_BASE_URL=http://localhost:3001/api/v1
+VITE_SERVICE_MODE=archive
 
 # Clerk auth for admin routes.
 VITE_CLERK_PUBLISHABLE_KEY=

--- a/web/.env.example
+++ b/web/.env.example
@@ -3,6 +3,7 @@ VITE_SITE_URL=https://fd-alumni-tourney.netlify.app
 
 # Rails API base. Include /api/v1.
 VITE_API_BASE_URL=http://localhost:3001/api/v1
+# 'live' enables the full tournament hub; 'archive' serves the static history page.
 VITE_SERVICE_MODE=archive
 
 # Clerk auth for admin routes.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,14 +30,22 @@ import { AdminMediaPage } from './pages/admin/AdminMediaPage'
 import { AdminSponsorsPage } from './pages/admin/AdminSponsorsPage'
 import { AdminIngestPage } from './pages/admin/AdminIngestPage'
 import { StaticArchivePage } from './pages/public/StaticArchivePage'
+import { useBackendAvailability } from './hooks/useBackendAvailability'
 
 const clerkKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined
 const clerkEnabled = Boolean(clerkKey && clerkKey.startsWith('pk_'))
-const serviceMode = import.meta.env.VITE_SERVICE_MODE || 'archive'
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001/api/v1'
+const HEALTH_URL = new URL('/health', API_BASE_URL).toString()
 
 export function App() {
-  if (serviceMode !== 'live') {
-    return <Routes><Route path="*" element={<StaticArchivePage />} /></Routes>
+  const { status, retry } = useBackendAvailability(HEALTH_URL)
+
+  if (status === 'checking') {
+    return <main className="service-check" role="status"><div className="service-check-spinner" /><p>Checking tournament services…</p></main>
+  }
+
+  if (status === 'unavailable') {
+    return <Routes><Route path="*" element={<StaticArchivePage onRetry={retry} />} /></Routes>
   }
 
   const content = (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,11 +29,17 @@ import { AdminNewsPage } from './pages/admin/AdminNewsPage'
 import { AdminMediaPage } from './pages/admin/AdminMediaPage'
 import { AdminSponsorsPage } from './pages/admin/AdminSponsorsPage'
 import { AdminIngestPage } from './pages/admin/AdminIngestPage'
+import { StaticArchivePage } from './pages/public/StaticArchivePage'
 
 const clerkKey = import.meta.env.VITE_CLERK_PUBLISHABLE_KEY as string | undefined
 const clerkEnabled = Boolean(clerkKey && clerkKey.startsWith('pk_'))
+const serviceMode = import.meta.env.VITE_SERVICE_MODE || 'archive'
 
 export function App() {
+  if (serviceMode !== 'live') {
+    return <Routes><Route path="*" element={<StaticArchivePage />} /></Routes>
+  }
+
   const content = (
     <AuthProvider isClerkEnabled={clerkEnabled}>
       <Routes>

--- a/web/src/hooks/useBackendAvailability.ts
+++ b/web/src/hooks/useBackendAvailability.ts
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+export type BackendAvailability = 'checking' | 'available' | 'unavailable'
+
+const PROBE_TIMEOUT_MS = 7_000
+const RETRY_INTERVAL_MS = 30_000
+
+export function useBackendAvailability(healthUrl: string) {
+  const [status, setStatus] = useState<BackendAvailability>('checking')
+  const requestId = useRef(0)
+
+  const check = useCallback(async (showChecking = true) => {
+    const currentRequest = ++requestId.current
+    if (showChecking) setStatus('checking')
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), PROBE_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(healthUrl, {
+        cache: 'no-store',
+        headers: { Accept: 'application/json, text/plain' },
+        signal: controller.signal,
+      })
+      if (requestId.current === currentRequest) setStatus(response.ok ? 'available' : 'unavailable')
+    } catch {
+      if (requestId.current === currentRequest) setStatus('unavailable')
+    } finally {
+      window.clearTimeout(timeout)
+    }
+  }, [healthUrl])
+
+  useEffect(() => {
+    void check()
+    return () => { requestId.current += 1 }
+  }, [check])
+
+  useEffect(() => {
+    if (status !== 'unavailable') return
+    const interval = window.setInterval(() => void check(false), RETRY_INTERVAL_MS)
+    return () => window.clearInterval(interval)
+  }, [check, status])
+
+  return { status, retry: () => check() }
+}

--- a/web/src/pages/public/StaticArchivePage.tsx
+++ b/web/src/pages/public/StaticArchivePage.tsx
@@ -28,6 +28,9 @@ const champions: ChampionRecord[] = [
   { year: 2025, champion: 'Class of 2002/04', runnerUp: 'Class of 2013', score: '50–44' },
 ]
 
+const archiveStartYear = Math.min(...champions.map(({ year }) => year))
+const archiveEndYear = Math.max(...champions.map(({ year }) => year))
+
 export function StaticArchivePage() {
   return (
     <div className="archive-shell">
@@ -46,7 +49,7 @@ export function StaticArchivePage() {
           <p>The live tournament hub is resting between events, but its core championship record remains available. Full schedules, live scores, admin tools, and media will return when the next tournament is activated.</p>
           <div className="archive-stats">
             <div><strong>{champions.length}</strong><span>tracked editions</span></div>
-            <div><strong>1985–2025</strong><span>archive coverage</span></div>
+            <div><strong>{archiveStartYear}–{archiveEndYear}</strong><span>archive coverage</span></div>
             <div><strong>1</strong><span>brotherhood</span></div>
           </div>
         </section>

--- a/web/src/pages/public/StaticArchivePage.tsx
+++ b/web/src/pages/public/StaticArchivePage.tsx
@@ -20,7 +20,7 @@ const champions: ChampionRecord[] = [
   { year: 2010, champion: 'Class of 2006' }, { year: 2011, champion: 'Class of 2006' }, { year: 2012, champion: 'Class of 2006' },
   { year: 2013, champion: 'Class of 2006' }, { year: 2014, champion: 'Class of 2004' }, { year: 2015, champion: 'Class of 2013', score: '60–48' },
   { year: 2016, champion: 'Class of 2006' }, { year: 2017, champion: 'Class of 2002/04' }, { year: 2018, champion: 'Class of 2002/04' },
-  { year: 2019, champion: 'Class of 2006' }, { year: 2020, champion: 'Tournament cancelled', cancelled: true },
+  { year: 2019, champion: 'Class of 2006' }, { year: 2020, champion: '—', cancelled: true },
   { year: 2021, champion: 'Class of 2006', runnerUp: 'Class of 2011', score: '58–38' },
   { year: 2022, champion: 'Class of 2002/04', runnerUp: 'Class of 2006', score: '62–52' },
   { year: 2023, champion: 'Class of 2013' },

--- a/web/src/pages/public/StaticArchivePage.tsx
+++ b/web/src/pages/public/StaticArchivePage.tsx
@@ -31,7 +31,7 @@ const champions: ChampionRecord[] = [
 const archiveStartYear = Math.min(...champions.map(({ year }) => year))
 const archiveEndYear = Math.max(...champions.map(({ year }) => year))
 
-export function StaticArchivePage() {
+export function StaticArchivePage({ onRetry }: { onRetry?: () => void }) {
   return (
     <div className="archive-shell">
       <header className="archive-header">
@@ -81,6 +81,7 @@ export function StaticArchivePage() {
           <div className="archive-links">
             <a href="https://fatherduenas.com/" target="_blank" rel="noreferrer">Visit Father Dueñas</a>
             <a href="https://guamsportsnetwork.com/" target="_blank" rel="noreferrer">Visit GSPN</a>
+            {onRetry ? <button type="button" className="btn secondary" onClick={onRetry}>Check services again</button> : null}
           </div>
         </section>
       </main>

--- a/web/src/pages/public/StaticArchivePage.tsx
+++ b/web/src/pages/public/StaticArchivePage.tsx
@@ -1,0 +1,88 @@
+type ChampionRecord = {
+  year: number
+  edition?: string
+  champion: string
+  runnerUp?: string
+  score?: string
+  cancelled?: boolean
+}
+
+const champions: ChampionRecord[] = [
+  { year: 1985, champion: 'Class of 1974' }, { year: 1986, champion: 'Class of 1974' },
+  { year: 1987, edition: 'Spring', champion: 'Class of 1980' }, { year: 1987, edition: 'Summer', champion: 'Class of 1982' }, { year: 1987, edition: 'Fall', champion: 'Class of 1979' },
+  { year: 1988, champion: 'Class of 1982' }, { year: 1989, champion: 'Class of 1980' }, { year: 1991, champion: 'Class of 1991' },
+  { year: 1992, champion: 'Class of 1982' }, { year: 1993, champion: 'Class of 1991' }, { year: 1994, champion: 'Class of 1982' },
+  { year: 1995, champion: 'Class of 1982' }, { year: 1996, champion: 'Class of 1982' }, { year: 1997, champion: 'Class of 1991' },
+  { year: 1998, champion: 'Class of 1982' }, { year: 1999, champion: 'Class of 1995/96' }, { year: 2000, champion: 'Class of 1996' },
+  { year: 2001, champion: 'Class of 1991' }, { year: 2002, champion: 'Class of 1996' }, { year: 2003, champion: 'Class of 1996' },
+  { year: 2004, champion: 'Class of 1995' }, { year: 2005, champion: 'Class of 1991' }, { year: 2006, champion: 'Class of 2002/03' },
+  { year: 2007, champion: 'Class of 2006' }, { year: 2008, champion: 'Class of 1995' }, { year: 2009, champion: 'Class of 2002' },
+  { year: 2010, champion: 'Class of 2006' }, { year: 2011, champion: 'Class of 2006' }, { year: 2012, champion: 'Class of 2006' },
+  { year: 2013, champion: 'Class of 2006' }, { year: 2014, champion: 'Class of 2004' }, { year: 2015, champion: 'Class of 2013', score: '60–48' },
+  { year: 2016, champion: 'Class of 2006' }, { year: 2017, champion: 'Class of 2002/04' }, { year: 2018, champion: 'Class of 2002/04' },
+  { year: 2019, champion: 'Class of 2006' }, { year: 2020, champion: 'Tournament cancelled', cancelled: true },
+  { year: 2021, champion: 'Class of 2006', runnerUp: 'Class of 2011', score: '58–38' },
+  { year: 2022, champion: 'Class of 2002/04', runnerUp: 'Class of 2006', score: '62–52' },
+  { year: 2023, champion: 'Class of 2013' },
+  { year: 2024, champion: 'Class of 2016/17', runnerUp: 'Class of 2002/04', score: '58–56' },
+  { year: 2025, champion: 'Class of 2002/04', runnerUp: 'Class of 2013', score: '50–44' },
+]
+
+export function StaticArchivePage() {
+  return (
+    <div className="archive-shell">
+      <header className="archive-header">
+        <div className="archive-brand">
+          <img src="/brand/fd-crest.png" alt="Father Dueñas Memorial School crest" />
+          <div><strong>FD Alumni Basketball Hub</strong><span>Historical tournament archive</span></div>
+        </div>
+        <span className="archive-status">Off-season archive</span>
+      </header>
+
+      <main>
+        <section className="archive-hero">
+          <p className="archive-eyebrow">Brotherhood. Competition. History.</p>
+          <h1>Decades of FD Alumni champions, preserved.</h1>
+          <p>The live tournament hub is resting between events, but its core championship record remains available. Full schedules, live scores, admin tools, and media will return when the next tournament is activated.</p>
+          <div className="archive-stats">
+            <div><strong>{champions.length}</strong><span>tracked editions</span></div>
+            <div><strong>1985–2025</strong><span>archive coverage</span></div>
+            <div><strong>1</strong><span>brotherhood</span></div>
+          </div>
+        </section>
+
+        <section className="archive-content" aria-labelledby="champions-heading">
+          <div className="archive-section-heading">
+            <div><p className="archive-eyebrow">Permanent public record</p><h2 id="champions-heading">Tournament champions</h2></div>
+            <p>Compiled from alumni records, GSPN coverage, GuamPDN coverage, and tournament confirmations.</p>
+          </div>
+          <div className="archive-grid">
+            {champions.slice().reverse().map((record) => (
+              <article key={`${record.year}-${record.edition || 'annual'}`} className={record.cancelled ? 'archive-record cancelled' : 'archive-record'}>
+                <div className="archive-record-year">{record.year}{record.edition ? <small>{record.edition}</small> : null}</div>
+                <div>
+                  <strong>{record.champion}</strong>
+                  {record.runnerUp ? <p>Runner-up: {record.runnerUp}</p> : null}
+                  {record.score ? <span>{record.score}</span> : null}
+                  {record.cancelled ? <p>Cancelled because of COVID-19</p> : null}
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section className="archive-return">
+          <p className="archive-eyebrow">The hub will return</p>
+          <h2>Live tournament coverage is paused—not gone.</h2>
+          <p>When the next event is confirmed, schedules, standings, streams, stories, gallery coverage, and team tools can be restored by reactivating the service.</p>
+          <div className="archive-links">
+            <a href="https://fatherduenas.com/" target="_blank" rel="noreferrer">Visit Father Dueñas</a>
+            <a href="https://guamsportsnetwork.com/" target="_blank" rel="noreferrer">Visit GSPN</a>
+          </div>
+        </section>
+      </main>
+
+      <footer className="archive-footer">Built by <a href="https://shimizu-technology.com">Shimizu Technology</a>.</footer>
+    </div>
+  )
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -796,6 +796,9 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
 .archive-links { display: flex; justify-content: center; flex-wrap: wrap; gap: .8rem; margin-top: 1.5rem; }
 .archive-links a { padding: .7rem 1rem; border: 1px solid #7b2029; border-radius: 999px; color: #7b2029; font-weight: 800; text-decoration: none; }
 .archive-links a:hover { background: #7b2029; color: white; }
+.service-check { min-height: 100vh; display: grid; place-content: center; justify-items: center; gap: 1rem; padding: 2rem; background: var(--paper); color: var(--fd-maroon); text-align: center; font-weight: 850; }
+.service-check-spinner { width: 2.6rem; height: 2.6rem; border: 4px solid #eadfca; border-top-color: var(--fd-maroon); border-radius: 50%; animation: service-check-spin .8s linear infinite; }
+@keyframes service-check-spin { to { transform: rotate(360deg); } }
 .archive-footer { padding: 1.5rem; border-top: 1px solid #dfd2c8; color: #75615e; text-align: center; font-size: .78rem; }
 .archive-footer a { color: #571a20; font-weight: 800; }
 @media (max-width: 900px) { .archive-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } .archive-section-heading { display: block; } .archive-section-heading > p { margin-top: 1rem; } }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -761,3 +761,42 @@ input:focus, select:focus, textarea:focus { outline: 3px solid rgba(200,155,60,.
   .menu-button span { display: none; }
   .brand strong { max-width: 11.5rem; }
 }
+
+/* Static off-season archive */
+.archive-shell { min-height: 100vh; background: #f7f1ea; color: #241817; }
+.archive-header { display: flex; align-items: center; justify-content: space-between; gap: 1rem; padding: 1rem clamp(1rem, 4vw, 3rem); border-bottom: 1px solid #dfd2c8; background: rgba(255,255,255,.88); }
+.archive-brand { display: flex; align-items: center; gap: .8rem; }
+.archive-brand img { width: 3rem; height: 3rem; object-fit: contain; }
+.archive-brand strong, .archive-brand span { display: block; }
+.archive-brand strong { color: #571a20; font-family: "Sora", "Source Sans 3", ui-sans-serif, system-ui, sans-serif; }
+.archive-brand span { margin-top: .15rem; color: #776462; font-size: .75rem; }
+.archive-status { padding: .45rem .75rem; border-radius: 999px; background: #f1e4c6; color: #6f5010; font-size: .72rem; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.archive-hero { padding: clamp(4rem, 9vw, 7rem) clamp(1rem, 6vw, 5rem); background: linear-gradient(135deg, #431218, #711e27 62%, #8e3b32); color: white; }
+.archive-hero h1 { max-width: 52rem; margin: .7rem 0 1.2rem; font-family: "Sora", "Source Sans 3", ui-sans-serif, system-ui, sans-serif; font-size: clamp(2.6rem, 7vw, 5rem); line-height: .98; }
+.archive-hero > p:not(.archive-eyebrow) { max-width: 46rem; color: rgba(255,255,255,.75); font-size: 1.06rem; line-height: 1.75; }
+.archive-eyebrow { margin: 0; color: #d8b96f; font-size: .75rem; font-weight: 900; letter-spacing: .17em; text-transform: uppercase; }
+.archive-stats { display: flex; flex-wrap: wrap; gap: 2rem; margin-top: 2.2rem; padding-top: 2rem; border-top: 1px solid rgba(255,255,255,.16); }
+.archive-stats strong, .archive-stats span { display: block; }
+.archive-stats strong { font-family: "Sora", "Source Sans 3", ui-sans-serif, system-ui, sans-serif; font-size: 1.9rem; }
+.archive-stats span { margin-top: .2rem; color: rgba(255,255,255,.55); font-size: .78rem; text-transform: uppercase; letter-spacing: .08em; }
+.archive-content { max-width: 76rem; margin: 0 auto; padding: 4rem clamp(1rem, 4vw, 3rem); }
+.archive-section-heading { display: flex; align-items: end; justify-content: space-between; gap: 2rem; margin-bottom: 2rem; }
+.archive-section-heading h2, .archive-return h2 { margin: .45rem 0 0; color: #42151a; font-family: "Sora", "Source Sans 3", ui-sans-serif, system-ui, sans-serif; font-size: clamp(2rem, 4vw, 3rem); }
+.archive-section-heading > p { max-width: 30rem; margin: 0; color: #75615e; line-height: 1.6; }
+.archive-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: .8rem; }
+.archive-record { display: grid; grid-template-columns: 4.7rem 1fr; gap: .8rem; min-height: 7rem; padding: 1rem; border: 1px solid #e3d7ce; border-radius: 1rem; background: white; box-shadow: 0 5px 18px rgba(53,24,21,.04); }
+.archive-record.cancelled { background: #eee8e3; }
+.archive-record-year { color: #7b2029; font-family: "Sora", "Source Sans 3", ui-sans-serif, system-ui, sans-serif; font-size: 1.35rem; font-weight: 900; }
+.archive-record-year small { display: block; margin-top: .2rem; color: #987a55; font-family: inherit; font-size: .65rem; text-transform: uppercase; }
+.archive-record strong { color: #321a18; line-height: 1.25; }
+.archive-record p { margin: .4rem 0 0; color: #796562; font-size: .78rem; line-height: 1.35; }
+.archive-record span { display: inline-block; margin-top: .55rem; padding: .2rem .45rem; border-radius: .4rem; background: #f2e7c9; color: #6f5010; font-size: .72rem; font-weight: 800; }
+.archive-return { margin: 0 auto 4rem; max-width: 70rem; padding: 2.5rem; border-radius: 1.4rem; background: #fff; text-align: center; box-shadow: 0 10px 35px rgba(53,24,21,.08); }
+.archive-return > p:not(.archive-eyebrow) { max-width: 45rem; margin: 1rem auto 0; color: #75615e; line-height: 1.7; }
+.archive-links { display: flex; justify-content: center; flex-wrap: wrap; gap: .8rem; margin-top: 1.5rem; }
+.archive-links a { padding: .7rem 1rem; border: 1px solid #7b2029; border-radius: 999px; color: #7b2029; font-weight: 800; text-decoration: none; }
+.archive-links a:hover { background: #7b2029; color: white; }
+.archive-footer { padding: 1.5rem; border-top: 1px solid #dfd2c8; color: #75615e; text-align: center; font-size: .78rem; }
+.archive-footer a { color: #571a20; font-weight: 800; }
+@media (max-width: 900px) { .archive-grid { grid-template-columns: repeat(2, minmax(0,1fr)); } .archive-section-heading { display: block; } .archive-section-heading > p { margin-top: 1rem; } }
+@media (max-width: 600px) { .archive-header { align-items: flex-start; } .archive-brand span { display: none; } .archive-status { font-size: .6rem; } .archive-grid { grid-template-columns: 1fr; } .archive-hero { padding-top: 4.5rem; } .archive-return { margin-inline: 1rem; padding: 1.5rem; } }


### PR DESCRIPTION
## What changed
- preserve 42 Jungle championship editions in an API-independent static archive
- derive archive coverage from the embedded records
- probe the public API health route before mounting the live tournament hub
- select the archive automatically when the backend is unavailable
- retry in the background every 30 seconds and provide a manual check
- update two Rails dependencies required by the security audit

## Operations
No service-mode environment variable or frontend redeploy is required. Suspending the API selects the archive; resuming it restores the live hub on refresh or retry.

## Validation
- React/Vite production build
- Rails CI, Bundler Audit, and Brakeman
- unavailable, retry-recovery, and mobile browser QA

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a static championship archive page that displays automatically when the backend API is unreachable, ensuring historical tournament data remains publicly accessible during off-season periods when the backend is suspended.

- **`useBackendAvailability` hook** probes the `/health` endpoint on mount, shows a spinner during the 7-second probe, and falls back to the archive on failure; it auto-retries every 30 seconds while unavailable so the live app resumes transparently if the backend comes back.
- **`StaticArchivePage`** embeds 42 hardcoded championship records (1985–2025) with responsive CSS grid styling; no API calls are made from this page.
- **`App.tsx`** gates the entire app tree behind the availability check, rendering `<StaticArchivePage>` for all routes when the backend is down.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is purely additive, the live app path is unchanged, and the fallback archive is fully self-contained with no API calls.

The availability hook is straightforward with proper cleanup and race-condition guards. The archive page is entirely static data. No existing routes or auth flows are modified; the only change to App.tsx is a two-branch early-return before the existing content tree.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| web/src/hooks/useBackendAvailability.ts | New hook that probes a health URL, tracks availability state, and retries every 30 s when unavailable; race conditions are handled via a requestId ref. Clean implementation. |
| web/src/App.tsx | Integrates the availability hook; HEALTH_URL is derived from VITE_API_BASE_URL using new URL('/health', base) which correctly resolves to the server origin's /health path. |
| web/src/pages/public/StaticArchivePage.tsx | New static archive page with 42 embedded championship records; 2020 entry uses '—' for champion and cancelled:true, avoiding the double-cancelled-message issue. |
| web/src/styles.css | Adds archive and service-check CSS rules with responsive breakpoints at 900px and 600px; uses CSS custom properties for colors where available. |
| api/Gemfile.lock | Routine dependency bumps: json 2.19.8 → 2.20.0 and websocket-driver 0.8.1 → 0.8.2; no logic changes. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([App mounts]) --> B[useBackendAvailability\nprobes HEALTH_URL]
    B --> C{status}
    C -- checking --> D[🔄 Spinner\nservice-check screen]
    D --> C
    C -- available --> E[Live App\nAuthProvider + Routes]
    C -- unavailable --> F[StaticArchivePage\narchive of 42 editions]
    F --> G{Auto-retry\nevery 30 s}
    G -- still down --> F
    G -- backend up --> E
    F --> H([User clicks\n'Check services again'])
    H --> B
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([App mounts]) --> B[useBackendAvailability\nprobes HEALTH_URL]
    B --> C{status}
    C -- checking --> D[🔄 Spinner\nservice-check screen]
    D --> C
    C -- available --> E[Live App\nAuthProvider + Routes]
    C -- unavailable --> F[StaticArchivePage\narchive of 42 editions]
    F --> G{Auto-retry\nevery 30 s}
    G -- still down --> F
    G -- backend up --> E
    F --> H([User clicks\n'Check services again'])
    H --> B
```

</a>

<sub>Reviews (5): Last reviewed commit: ["Detect alumni API availability automatic..."](https://github.com/shimizu-technology/fd-alumni-hub/commit/aa28713ec090c1573f1197accea6d43a869b14c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43519198)</sub>

<!-- /greptile_comment -->